### PR TITLE
Sign release builds with the Play Store upload key

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -95,15 +95,26 @@ android {
             keyAlias 'androiddebugkey'
             keyPassword 'android'
         }
+        // Play upload key. The keystore is git-ignored; credentials live in
+        // ~/.gradle/gradle.properties (OPENRUNG_UPLOAD_*). Checkouts without
+        // them fall back to the debug key so local release builds still work.
+        if (project.hasProperty('OPENRUNG_UPLOAD_STORE_FILE')) {
+            release {
+                storeFile file(OPENRUNG_UPLOAD_STORE_FILE)
+                storePassword OPENRUNG_UPLOAD_STORE_PASSWORD
+                keyAlias OPENRUNG_UPLOAD_KEY_ALIAS
+                keyPassword OPENRUNG_UPLOAD_KEY_PASSWORD
+            }
+        }
     }
     buildTypes {
         debug {
             signingConfig signingConfigs.debug
         }
         release {
-            // Caution! In production, you need to generate your own keystore file.
-            // see https://reactnative.dev/docs/signed-apk-android.
-            signingConfig signingConfigs.debug
+            signingConfig project.hasProperty('OPENRUNG_UPLOAD_STORE_FILE')
+                    ? signingConfigs.release
+                    : signingConfigs.debug
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }


### PR DESCRIPTION
## Summary
- Adds an optional `release` signingConfig sourced from `OPENRUNG_UPLOAD_*` gradle properties (upload keystore path + passwords)
- Release APK/AAB builds use this upload key when the properties are present, falling back to the debug keystore otherwise so unconfigured checkouts and CI are unaffected

## Why
Release builds were previously signed with the debug keystore (`signingConfig signingConfigs.debug`), which cannot be used to publish to Google Play. This wires in a real upload key without hardcoding secrets into the repo — the keystore file is git-ignored and credentials live only in the local `~/.gradle/gradle.properties`.

## Test plan
- [x] `./gradlew assembleRelease bundleRelease` succeeds with `OPENRUNG_UPLOAD_*` properties set
- [x] Verified signature on the resulting APK (`apksigner verify --print-certs`) and AAB (`jarsigner -verify`) match the upload key cert (`CN=OpenRung, O=OpenRung, C=US`)
- [ ] Reviewer confirms: without `OPENRUNG_UPLOAD_*` set, `assembleRelease` still falls back to debug signing (unchanged behavior)

Note: this branch also carries an earlier, unrelated commit (`96e5ffa`, relay geolocation display) that was already pushed before this PR.