### PR TITLE
Single-source the app version string and enforce it in CI

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+# Node build tooling — linted by neither the app's React Native ESLint config nor its parser
+# (these are standalone ESM scripts run with `node`, not app source).
+scripts/

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,0 +1,19 @@
+name: Version sync
+
+# Enforces that the app version string stays single-sourced in package.json.
+# See scripts/check-versions.mjs for what it verifies.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  version-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - run: node scripts/check-versions.mjs

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -64,3 +64,35 @@ engine out-of-process. Google Play does not have the equivalent conflict.
 OpenRung provides the corresponding source for at least **three (3) years**
 after distribution. Keep the tagged commit + the matching `SINGBOX_VERSION`
 reachable for that long.
+
+## 6. Bumping the app version
+
+The version **string** lives in exactly one place — `version` in
+[`package.json`](package.json). Everything else derives from it, so never edit
+the version in the other files by hand:
+
+- **Android** `versionName` — read from `package.json` by
+  [`android/app/build.gradle`](android/app/build.gradle) at build time.
+- **iOS** `MARKETING_VERSION` — injected as `${APP_VERSION}` when
+  [`ios/scripts/generate-project.sh`](ios/scripts/generate-project.sh)
+  regenerates the Xcode project.
+- **In-app** `APP_VERSION` — imported from `package.json` in
+  [`src/config.ts`](src/config.ts).
+
+To cut a new version:
+
+```sh
+npm version <new-version> --no-git-tag-version   # or edit package.json's "version"
+./ios/scripts/generate-project.sh                # re-bake iOS MARKETING_VERSION
+npm run version:check                            # verify everything is in sync
+```
+
+`npm run version:check` ([`scripts/check-versions.mjs`](scripts/check-versions.mjs))
+is also run in CI ([`.github/workflows/version-check.yml`](.github/workflows/version-check.yml))
+and fails the build if any source drifts from `package.json` — in practice the
+only thing that can drift is a stale committed `project.pbxproj` (fix by
+re-running `generate-project.sh`).
+
+The Android `versionCode` and iOS `CURRENT_PROJECT_VERSION` are **build
+numbers**, a separate monotonic integer from the version string; bump those by
+hand per store upload.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -73,6 +73,11 @@ def enableProguardInReleaseBuilds = false
  */
 def jscFlavor = 'io.github.react-native-community:jsc-android:2026004.+'
 
+// Single source of truth for the app version string: package.json at the repo root.
+// versionName derives from it so it can't drift (scripts/check-versions.mjs enforces this).
+// versionCode stays a manually-bumped build number — it's a separate, monotonic integer.
+def appVersionName = new groovy.json.JsonSlurper().parse(file("$rootDir/../package.json")).version
+
 android {
     ndkVersion rootProject.ext.ndkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion
@@ -86,7 +91,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 3
-        versionName "0.2.1"
+        versionName appVersionName
     }
     signingConfigs {
         debug {

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -11,7 +11,9 @@ options:
 
 settings:
   base:
-    MARKETING_VERSION: "0.2.1"
+    # Injected from package.json by scripts/generate-project.sh (the app version string is
+    # single-sourced there; check-versions.mjs enforces the baked pbxproj value matches).
+    MARKETING_VERSION: "${APP_VERSION}"
     CURRENT_PROJECT_VERSION: "3"
     DEVELOPMENT_TEAM: 9VLV9A7KS9
     CODE_SIGN_STYLE: Automatic

--- a/ios/scripts/generate-project.sh
+++ b/ios/scripts/generate-project.sh
@@ -9,5 +9,10 @@ export LANG="${LANG:-en_US.UTF-8}"
 
 cd "$(dirname "$0")/.."
 
+# The app version string is single-sourced in package.json; inject it so xcodegen bakes the
+# matching MARKETING_VERSION into the project (see ../scripts/check-versions.mjs).
+APP_VERSION="$(node -p "require('$(pwd)/../package.json').version")"
+export APP_VERSION
+
 xcodegen generate
 pod install

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "ios": "react-native run-ios",
     "lint": "eslint .",
     "start": "react-native start",
-    "test": "jest"
+    "test": "jest",
+    "version:check": "node scripts/check-versions.mjs"
   },
   "dependencies": {
     "@maplibre/maplibre-react-native": "^11.3.6",

--- a/scripts/check-versions.mjs
+++ b/scripts/check-versions.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+// Enforces that the app version string stays single-sourced in package.json.
+//
+// Three surfaces derive their version from package.json at build time and therefore cannot
+// drift: src/config.ts (imports it), android/app/build.gradle (JsonSlurper), and
+// ios/project.yml (${APP_VERSION} expanded by scripts/generate-project.sh). The one place a
+// stale copy can be committed is the *generated* iOS pbxproj, so we check that against the
+// canonical value — and we assert the derived surfaces still derive (no re-hardcoding).
+//
+// Run: node scripts/check-versions.mjs   (also wired into .github/workflows/version-check.yml)
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const read = (p) => readFileSync(join(root, p), 'utf8');
+
+const canonical = JSON.parse(read('package.json')).version;
+const errors = [];
+
+// iOS: the generated pbxproj bakes MARKETING_VERSION; every entry must match package.json.
+const pbxproj = read('ios/OpenRung.xcodeproj/project.pbxproj');
+const marketing = [...pbxproj.matchAll(/MARKETING_VERSION = ([^;]+);/g)].map((m) => m[1].trim());
+if (marketing.length === 0) {
+  errors.push('ios pbxproj: no MARKETING_VERSION found (did the project fail to generate?)');
+}
+for (const v of new Set(marketing)) {
+  if (v !== canonical) {
+    errors.push(
+      `ios MARKETING_VERSION "${v}" != package.json "${canonical}" — run ios/scripts/generate-project.sh and commit the regenerated project`,
+    );
+  }
+}
+
+// Android: versionName must derive from package.json, never be a hardcoded literal.
+const gradle = read('android/app/build.gradle');
+const gradleLiteral = gradle.match(/versionName\s+["']([^"']+)["']/);
+if (gradleLiteral) {
+  errors.push(
+    `android/app/build.gradle hardcodes versionName "${gradleLiteral[1]}" — it must derive from package.json (def appVersionName)`,
+  );
+}
+
+// JS: APP_VERSION must derive from package.json, never be a hardcoded literal.
+const config = read('src/config.ts');
+const configLiteral = config.match(/APP_VERSION\s*=\s*['"]([^'"]+)['"]/);
+if (configLiteral) {
+  errors.push(
+    `src/config.ts hardcodes APP_VERSION "${configLiteral[1]}" — it must import { version } from '../package.json'`,
+  );
+}
+
+if (errors.length) {
+  console.error(`✖ Version sources out of sync with package.json (${canonical}):`);
+  for (const e of errors) console.error(`  - ${e}`);
+  process.exit(1);
+}
+console.log(`✓ All version sources single-sourced from package.json (${canonical}).`);

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,8 @@
 import { candidates } from './net/brokerClient';
+// The app version string lives in exactly ONE place — package.json — and every other
+// surface (Android versionName, iOS MARKETING_VERSION, this constant) derives from it so
+// they cannot drift. scripts/check-versions.mjs enforces this in CI.
+import { version } from '../package.json';
 
 /**
  * App configuration, ported 1:1 from the production `config/AppConfig.kt`
@@ -69,4 +73,4 @@ export const AppConfig = {
 } as const;
 
 /** App version reported in X-OpenRung-App-Version (production uses BuildConfig.VERSION_NAME). */
-export const APP_VERSION = '0.2.1';
+export const APP_VERSION = version;


### PR DESCRIPTION
Stacked on #5 (targets `chore/bump-version-0.2.1`; GitHub will retarget to `main` when #5 merges). Closes the "no automation currently enforces this" gap called out in #5.

## Problem
The version string was duplicated across four files and synced by hand — and it drifted: the in-app `APP_VERSION` was missed in a prior bump and lagged the actual build (0.2.0 shown in-app while the build was 0.2.1).

## Fix — package.json is the single source of truth; the rest derive from it
| Surface | Before | After |
|---|---|---|
| `src/config.ts` `APP_VERSION` | hardcoded literal | `import { version } from '../package.json'` |
| Android `versionName` | hardcoded literal | read from package.json via Groovy `JsonSlurper` |
| iOS `MARKETING_VERSION` | hardcoded in project.yml | `${APP_VERSION}`, injected from package.json by `generate-project.sh` |

Three of the four can no longer drift (they read package.json at build time). The only copy that can still go stale is the **generated, committed** `project.pbxproj`.

## Enforcement (backstop)
- `scripts/check-versions.mjs` — verifies the baked pbxproj `MARKETING_VERSION` matches package.json and that gradle/config.ts weren't re-hardcoded. Available as `npm run version:check`.
- `.github/workflows/version-check.yml` — runs it on every PR/push (repo had no CI before).
- `.eslintignore` — excludes standalone Node build scripts from the app's RN eslint config.
- `RELEASE.md` §6 documents the one-command bump procedure.

## Test plan
- [x] xcodegen expands `${APP_VERSION}` → baked `MARKETING_VERSION = 0.2.1`; leaves `$(inherited)` untouched
- [x] Android release APK rebuilt → `versionName='0.2.1'` via JsonSlurper
- [x] `check-versions.mjs`: negative test (package.json=9.9.9 → exit 1) and positive test (exit 0)
- [x] `tsc --noEmit` clean, `npm run lint` 0 errors, 39/39 jest tests pass
- [x] Reverted incidental pbxproj reordering churn from regeneration (version value unchanged) to keep the diff minimal

## Not in scope
Android `versionCode` / iOS `CURRENT_PROJECT_VERSION` are build *numbers* (separate monotonic integer), still bumped by hand per store upload — documented in RELEASE.md §6.