### PR TITLE
Native iOS tab bar: Liquid Glass on iOS 26

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,18 +1,24 @@
 /**
  * OpenRung mobile app root. Three bottom tabs (Home / Settings / About us)
- * over a plain state machine — no nav library, screens swap instantly. The
- * home screen (full-screen map) stays mounted underneath the other tabs so
- * the MapLibre view keeps its camera/tiles across tab switches; Settings and
- * About render as opaque overlays above it. Deep screens (debug console,
- * licenses, license full text) push over everything including the tab bar,
- * with hardware back mapped exactly like their in-header back arrows:
- * LICENSE_TEXT -> LICENSES -> ABOUT, DEBUG -> SETTINGS, any tab -> HOME,
- * HOME -> system default (exit).
+ * over a plain state machine — no nav library, screens swap instantly.
+ *
+ * iOS renders the tabs through the system TabView (NativeTabs), so the bar is
+ * the real native one — Liquid Glass on iOS 26+ — and the native tab
+ * controller keeps the home map mounted across switches. Android keeps the
+ * custom JS TabBar: the home screen (full-screen map) stays mounted
+ * underneath the other tabs so the MapLibre view keeps its camera/tiles, and
+ * Settings/About render as opaque overlays above it.
+ *
+ * On both platforms, deep screens (debug console, licenses, license full
+ * text) push over everything including the tab bar, with hardware back mapped
+ * exactly like their in-header back arrows: LICENSE_TEXT -> LICENSES ->
+ * ABOUT, DEBUG -> SETTINGS, any tab -> HOME, HOME -> system default (exit).
  */
 import React, { useCallback, useEffect, useState } from 'react';
-import { BackHandler, StatusBar, StyleSheet, View } from 'react-native';
+import { BackHandler, Platform, StatusBar, StyleSheet, View } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
+import { NativeTabs } from './src/components/NativeTabs';
 import { TabBar, type AppTab } from './src/components/TabBar';
 import { LanguageProvider } from './src/i18n';
 import { AboutScreen } from './src/screens/AboutScreen';
@@ -87,21 +93,42 @@ function AppRoutes(): React.JSX.Element {
       break;
   }
 
+  const renderScene = useCallback(
+    (scene: AppTab): React.JSX.Element => (
+      <View style={styles.scene}>
+        {scene === 'home' ? (
+          <MainScreen />
+        ) : scene === 'settings' ? (
+          <SettingsScreen onOpenDebug={() => setSubRoute('DEBUG')} />
+        ) : (
+          <AboutScreen onOpenLicenses={() => setSubRoute('LICENSES')} />
+        )}
+      </View>
+    ),
+    [],
+  );
+
   return (
     <View style={styles.root}>
-      {/* Home stays mounted so the map keeps its camera and loaded tiles. */}
-      <MainScreen />
-      {tab === 'settings' ? (
-        <View style={styles.tabOverlay}>
-          <SettingsScreen onOpenDebug={() => setSubRoute('DEBUG')} />
-        </View>
-      ) : null}
-      {tab === 'about' ? (
-        <View style={styles.tabOverlay}>
-          <AboutScreen onOpenLicenses={() => setSubRoute('LICENSES')} />
-        </View>
-      ) : null}
-      <TabBar active={tab} onSelect={onSelectTab} />
+      {Platform.OS === 'ios' ? (
+        <NativeTabs active={tab} onSelect={onSelectTab} renderScene={renderScene} />
+      ) : (
+        <>
+          {/* Home stays mounted so the map keeps its camera and loaded tiles. */}
+          <MainScreen />
+          {tab === 'settings' ? (
+            <View style={styles.tabOverlay}>
+              <SettingsScreen onOpenDebug={() => setSubRoute('DEBUG')} />
+            </View>
+          ) : null}
+          {tab === 'about' ? (
+            <View style={styles.tabOverlay}>
+              <AboutScreen onOpenLicenses={() => setSubRoute('LICENSES')} />
+            </View>
+          ) : null}
+          <TabBar active={tab} onSelect={onSelectTab} />
+        </>
+      )}
       {subScreen != null ? <View style={styles.subOverlay}>{subScreen}</View> : null}
     </View>
   );
@@ -109,6 +136,10 @@ function AppRoutes(): React.JSX.Element {
 
 const styles = StyleSheet.create({
   root: {
+    flex: 1,
+    backgroundColor: palette.screen,
+  },
+  scene: {
     flex: 1,
     backgroundColor: palette.screen,
   },

--- a/Gemfile
+++ b/Gemfile
@@ -4,9 +4,11 @@ source 'https://rubygems.org'
 ruby ">= 2.6.10"
 
 # Exclude problematic versions of cocoapods and activesupport that causes build failures.
-gem 'cocoapods', '>= 1.13', '!= 1.15.0', '!= 1.15.1'
+# cocoapods >= 1.16.2 / xcodeproj >= 1.27 are required to parse the Xcode 26
+# project format (objectVersion 77).
+gem 'cocoapods', '>= 1.16.2'
 gem 'activesupport', '>= 6.1.7.5', '!= 7.1.0'
-gem 'xcodeproj', '< 1.26.0'
+gem 'xcodeproj', '>= 1.27.0'
 gem 'concurrent-ruby', '< 1.3.4'
 
 # Ruby 3.4.0 has removed some libraries from the standard library.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,10 +24,10 @@ GEM
     benchmark (0.5.0)
     bigdecimal (4.1.2)
     claide (1.1.0)
-    cocoapods (1.15.2)
+    cocoapods (1.16.2)
       addressable (~> 2.8)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.15.2)
+      cocoapods-core (= 1.16.2)
       cocoapods-deintegrate (>= 1.0.3, < 2.0)
       cocoapods-downloader (>= 2.1, < 3.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
@@ -41,8 +41,8 @@ GEM
       molinillo (~> 0.8.0)
       nap (~> 1.0)
       ruby-macho (>= 2.3.0, < 3.0)
-      xcodeproj (>= 1.23.0, < 2.0)
-    cocoapods-core (1.15.2)
+      xcodeproj (>= 1.27.0, < 2.0)
+    cocoapods-core (1.16.2)
       activesupport (>= 5.0, < 8)
       addressable (~> 2.8)
       algoliasearch (~> 1.0)
@@ -92,7 +92,7 @@ GEM
     minitest (5.27.0)
     molinillo (0.8.0)
     mutex_m (0.3.0)
-    nanaimo (0.3.0)
+    nanaimo (0.4.0)
     nap (1.1.0)
     netrc (0.11.0)
     nkf (0.3.0)
@@ -104,12 +104,12 @@ GEM
       ethon (>= 0.18.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    xcodeproj (1.25.1)
+    xcodeproj (1.27.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
       colored2 (~> 3.1)
-      nanaimo (~> 0.3.0)
+      nanaimo (~> 0.4.0)
       rexml (>= 3.3.6, < 4.0)
 
 PLATFORMS
@@ -129,12 +129,12 @@ DEPENDENCIES
   activesupport (>= 6.1.7.5, != 7.1.0)
   benchmark
   bigdecimal
-  cocoapods (>= 1.13, != 1.15.1, != 1.15.0)
+  cocoapods (>= 1.16.2)
   concurrent-ruby (< 1.3.4)
   logger
   mutex_m
   nkf
-  xcodeproj (< 1.26.0)
+  xcodeproj (>= 1.27.0)
 
 CHECKSUMS
   CFPropertyList (3.0.8) sha256=2c99d0d980536d3d7ab252f7bd59ac8be50fbdd1ff487c98c949bb66bb114261
@@ -146,8 +146,8 @@ CHECKSUMS
   benchmark (0.5.0) sha256=465df122341aedcb81a2a24b4d3bd19b6c67c1530713fd533f3ff034e419236c
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   claide (1.1.0) sha256=6d3c5c089dde904d96aa30e73306d0d4bd444b1accb9b3125ce14a3c0183f82e
-  cocoapods (1.15.2) sha256=f0f5153de8d028d133b96f423e04f37fb97a1da0d11dda581a9f46c0cba4090a
-  cocoapods-core (1.15.2) sha256=322650d97fe1ad4c0831a09669764b888bd91c6d79d0f6bb07281a17667a2136
+  cocoapods (1.16.2) sha256=0ff1c860f32df3db8b16df09b58da1a6bb2a12fe55f6d5e8be994a74fadd1e5e
+  cocoapods-core (1.16.2) sha256=4bb1b5c420691e60cf36fa227dec6bc48c096c34c97bb7aa512ea7f3246fc12b
   cocoapods-deintegrate (1.0.5) sha256=517c2a448ef563afe99b6e7668704c27f5de9e02715a88ee9de6974dc1b3f6a2
   cocoapods-downloader (2.1) sha256=bb6ebe1b3966dc4055de54f7a28b773485ac724fdf575d9bee2212d235e7b6d1
   cocoapods-plugins (1.0.0) sha256=725d17ce90b52f862e73476623fd91441b4430b742d8a071000831efb440ca9a
@@ -181,7 +181,7 @@ CHECKSUMS
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
   molinillo (0.8.0) sha256=efbff2716324e2a30bccd3eba1ff3a735f4d5d53ffddbc6a2f32c0ca9433045d
   mutex_m (0.3.0) sha256=cfcb04ac16b69c4813777022fdceda24e9f798e48092a2b817eb4c0a782b0751
-  nanaimo (0.3.0) sha256=aaaedc60497070b864a7e220f7c4b4cad3a0daddda2c30055ba8dae306342376
+  nanaimo (0.4.0) sha256=faf069551bab17f15169c1f74a1c73c220657e71b6e900919897a10d991d0723
   nap (1.1.0) sha256=949691660f9d041d75be611bb2a8d2fd559c467537deac241f4097d9b5eea576
   netrc (0.11.0) sha256=de1ce33da8c99ab1d97871726cba75151113f117146becbe45aa85cb3dabee3f
   nkf (0.3.0) sha256=357a8dbeba38b727b75930f665146546076a394a1c243faf634ff176e3588895
@@ -191,7 +191,7 @@ CHECKSUMS
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   typhoeus (1.6.0) sha256=bacc41c23e379547e29801dc235cd1699b70b955a1ba3d32b2b877aa844c331d
   tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
-  xcodeproj (1.25.1) sha256=9a2310dccf6d717076e86f602b17c640046b6f1dfe64480044596f6f2f13dc84
+  xcodeproj (1.27.0) sha256=8cc7a73b4505c227deab044dce118ede787041c702bc47636856a2e566f854d3
 
 RUBY VERSION
   ruby 4.0.5

--- a/__tests__/App.test.tsx
+++ b/__tests__/App.test.tsx
@@ -114,6 +114,26 @@ jest.mock('react-native-safe-area-context', () => {
   };
 });
 
+// Stand-in for the native TabView: renders the active route's scene like the
+// real tab controller would (Jest runs as Platform.OS === 'ios').
+jest.mock('react-native-bottom-tabs', () => {
+  const ReactActual = require('react');
+  const { View } = require('react-native');
+  const TabView = ({
+    navigationState,
+    renderScene,
+  }: {
+    navigationState: { index: number; routes: { key: string }[] };
+    renderScene: (props: { route: { key: string }; jumpTo: (key: string) => void }) => React.ReactNode;
+  }) =>
+    ReactActual.createElement(
+      View,
+      null,
+      renderScene({ route: navigationState.routes[navigationState.index], jumpTo: () => {} }),
+    );
+  return { __esModule: true, default: TabView };
+});
+
 import App from '../App';
 
 // Keep the directory refresh (broker fetch) off the real network: reject fast so

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1470,6 +1470,53 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
+  - react-native-bottom-tabs (1.3.1):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - react-native-bottom-tabs/common (= 1.3.1)
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+    - SwiftUIIntrospect (~> 1.0)
+    - Yoga
+  - react-native-bottom-tabs/common (1.3.1):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+    - SwiftUIIntrospect (~> 1.0)
+    - Yoga
   - react-native-safe-area-context (5.8.0):
     - hermes-engine
     - RCTRequired
@@ -1981,6 +2028,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
+  - SwiftUIIntrospect (1.3.0)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -2026,6 +2074,7 @@ DEPENDENCIES:
   - React-Mapbuffer (from `../node_modules/react-native/ReactCommon`)
   - React-microtasksnativemodule (from `../node_modules/react-native/ReactCommon/react/nativemodule/microtasks`)
   - React-mutationobservernativemodule (from `../node_modules/react-native/ReactCommon/react/nativemodule/mutationobserver`)
+  - react-native-bottom-tabs (from `../node_modules/react-native-bottom-tabs`)
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - React-NativeModulesApple (from `../node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios`)
   - React-networking (from `../node_modules/react-native/ReactCommon/react/networking`)
@@ -2064,6 +2113,10 @@ DEPENDENCIES:
   - ReactNativeDependencies (from `../node_modules/react-native/third-party-podspecs/ReactNativeDependencies.podspec`)
   - RNSVG (from `../node_modules/react-native-svg`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
+
+SPEC REPOS:
+  trunk:
+    - SwiftUIIntrospect
 
 EXTERNAL SOURCES:
   AsyncStorage:
@@ -2149,6 +2202,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/react/nativemodule/microtasks"
   React-mutationobservernativemodule:
     :path: "../node_modules/react-native/ReactCommon/react/nativemodule/mutationobserver"
+  react-native-bottom-tabs:
+    :path: "../node_modules/react-native-bottom-tabs"
   react-native-safe-area-context:
     :path: "../node_modules/react-native-safe-area-context"
   React-NativeModulesApple:
@@ -2229,7 +2284,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   AsyncStorage: 163ab23f6aa37a58b7f2379d0b4ee7ac84d6655c
   FBLazyVector: b3e7ad108f0d882e30445c5527d774e3fd432f3d
-  hermes-engine: 7908f9ff818c2be84140cf114deb465b0ff4e7cb
+  hermes-engine: 88086ef42538e5e368d066661ef02e80da5feaca
   MapLibreReactNative: 9f1f16d5f5f522309ad1f2afc483a34cfc56fe6e
   RCTDeprecation: 2a74a2c57675e64419bd89078efde81f7c1de90b
   RCTRequired: 30451112e6fef4e6f31b4e7eee0845156e35e4b0
@@ -2268,6 +2323,7 @@ SPEC CHECKSUMS:
   React-Mapbuffer: ce449ccdf3b80384415b925606be8a4bdcfc65d3
   React-microtasksnativemodule: 2eb3f49d0d8e77b5343455eccd057010b8d38b6b
   React-mutationobservernativemodule: f0a0d5ae9b51caf7becbeabf836d716cfedb6bf2
+  react-native-bottom-tabs: e93dc04b1d64eb0932a099ca0d05a96f3f95fe61
   react-native-safe-area-context: fb5c8ee9f6dd62ef710611b3d370c501f42a4ac0
   React-NativeModulesApple: a092d89b58f635ebfab88048b0eda9fb516819fd
   React-networking: 968bbbe73590149feb1e72b2af4f6a68e4796ece
@@ -2305,6 +2361,7 @@ SPEC CHECKSUMS:
   ReactCommon: d5c1bb4427bf51c443de5926aac332c89ddd9363
   ReactNativeDependencies: fa0a54b3f5319ae0e3b9aff32bfee7a424b88e66
   RNSVG: 6cae8d4082913be2eb43eaec2a456222c42195ed
+  SwiftUIIntrospect: fee9aa07293ee280373a591e1824e8ddc869ba5d
   Yoga: fe50ab299e578f397fef753cf309c6703a4db29b
 
 PODFILE CHECKSUM: 81844dfd1d01f0c5e562678222cea0ed236212d1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "openrung-mobile-app",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openrung-mobile-app",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@maplibre/maplibre-react-native": "^11.3.6",
         "@react-native-async-storage/async-storage": "^3.1.1",
         "@react-native/new-app-screen": "0.86.0",
         "react": "19.2.3",
         "react-native": "0.86.0",
+        "react-native-bottom-tabs": "^1.3.1",
         "react-native-safe-area-context": "^5.5.2",
         "react-native-svg": "^15.12.1"
       },
@@ -10476,6 +10477,18 @@
         }
       }
     },
+    "node_modules/react-freeze": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/react-freeze/-/react-freeze-1.0.4.tgz",
+      "integrity": "sha512-r4F0Sec0BLxWicc7HEyo2x3/2icUTrRmDjaaRyzzn+7aDyFZliszMDOgLVwSnQnYENOlL1o569Ze2HZefk8clA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -10539,6 +10552,21 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-native-bottom-tabs": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/react-native-bottom-tabs/-/react-native-bottom-tabs-1.3.1.tgz",
+      "integrity": "sha512-RMAVToSAGVgHga5Y33+Zf8otr6WgB1xYcWI0C4HJofPyw+Tj3uEaFLzTo7oeXdVsddB3qba/4nf0bhS3YiVhfA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-freeze": "^1.0.0",
+        "sf-symbols-typescript": "^2.0.0",
+        "use-latest-callback": "^0.2.1"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/react-native-safe-area-context": {
@@ -11168,6 +11196,15 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/sf-symbols-typescript": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/sf-symbols-typescript/-/sf-symbols-typescript-2.2.0.tgz",
+      "integrity": "sha512-TPbeg0b7ylrswdGCji8FRGFAKuqbpQlLbL8SOle3j1iHSs5Ob5mhvMAxWN2UItOjgALAB5Zp3fmMfj8mbWvXKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -12141,6 +12178,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-latest-callback": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/use-latest-callback/-/use-latest-callback-0.2.6.tgz",
+      "integrity": "sha512-FvRG9i1HSo0wagmX63Vrm8SnlUU3LMM3WyZkQ76RnslpBrX694AdG4A0zQBx2B3ZifFA0yv/BaEHGBnEax5rZg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@react-native/new-app-screen": "0.86.0",
     "react": "19.2.3",
     "react-native": "0.86.0",
+    "react-native-bottom-tabs": "^1.3.1",
     "react-native-safe-area-context": "^5.5.2",
     "react-native-svg": "^15.12.1"
   },

--- a/src/components/NativeTabs.tsx
+++ b/src/components/NativeTabs.tsx
@@ -1,0 +1,52 @@
+/**
+ * iOS-only bottom tabs backed by the system TabView (react-native-bottom-tabs)
+ * so the bar is the real native one: Liquid Glass with the press-follow
+ * indicator on iOS 26+, classic translucent UITabBar on older iOS. Scenes are
+ * kept alive by the native tab controller, so the home map keeps its camera
+ * and tiles across tab switches. Android keeps the custom JS TabBar.
+ */
+import React, { useMemo } from 'react';
+import TabView, { type AppleIcon } from 'react-native-bottom-tabs';
+
+import { useStrings } from '../i18n';
+import { monoFont, palette } from '../theme';
+import type { AppTab } from './TabBar';
+
+const TAB_ORDER: AppTab[] = ['home', 'settings', 'about'];
+
+const ICONS: Record<AppTab, AppleIcon> = {
+  home: { sfSymbol: 'house' },
+  settings: { sfSymbol: 'slider.horizontal.3' },
+  about: { sfSymbol: 'info.circle' },
+};
+
+export interface NativeTabsProps {
+  active: AppTab;
+  onSelect: (tab: AppTab) => void;
+  renderScene: (tab: AppTab) => React.ReactNode;
+}
+
+export function NativeTabs({ active, onSelect, renderScene }: NativeTabsProps): React.JSX.Element {
+  const s = useStrings();
+
+  const routes = useMemo(() => {
+    const titles: Record<AppTab, string> = {
+      home: s.tabHome,
+      settings: s.tabSettings,
+      about: s.tabAbout,
+    };
+    return TAB_ORDER.map(tab => ({ key: tab, title: titles[tab], focusedIcon: ICONS[tab] }));
+  }, [s]);
+
+  return (
+    <TabView
+      navigationState={{ index: TAB_ORDER.indexOf(active), routes }}
+      onIndexChange={index => onSelect(TAB_ORDER[index])}
+      renderScene={({ route }) => renderScene(route.key as AppTab)}
+      tabBarActiveTintColor={palette.terminalGreen}
+      tabBarInactiveTintColor={palette.dimText}
+      tabLabelStyle={{ fontFamily: monoFont }}
+      hapticFeedbackEnabled
+    />
+  );
+}


### PR DESCRIPTION
## What changed

- **iOS now renders the bottom tabs through the system `TabView`** via [react-native-bottom-tabs](https://github.com/callstack/react-native-bottom-tabs) (new `src/components/NativeTabs.tsx`). On iOS 26+ this is the genuine Liquid Glass bar — floating capsule, press-follow selection pill, scroll-to-minimize — and on iOS 16–18 it falls back to the classic translucent `UITabBar` automatically. SF Symbol icons (`house`, `slider.horizontal.3`, `info.circle`), terminal-green active tint, Menlo labels, haptics on press, i18n titles (RTL handled natively).
- **Android is behaviorally unchanged**: `App.tsx` branches on `Platform.OS`, so Android keeps the custom JS `TabBar` and the existing overlay-stack layout. (The library does get compiled into the Android build via autolinking, but nothing renders it.)
- **Scene lifecycle**: the native tab controller keeps scenes mounted after first visit, so the home map keeps its MapLibre camera/tiles across tab switches — same guarantee the old always-mounted layout provided. Sub-screens (Debug, Licenses, License text) still push over everything including the native bar.
- **Gemfile**: CocoaPods bumped to ≥ 1.16.2 / xcodeproj ≥ 1.27.0 — the old template pins (`xcodeproj < 1.26`) cannot parse the Xcode 26 project format (objectVersion 77), which broke `pod install` outright.
- **Tests**: `App.test.tsx` gains a mock for the native TabView that renders the active scene (Jest runs as `Platform.OS === 'ios'`), following the existing MapLibre/safe-area mock pattern.

## Why

The previous tab bar was a custom JS component; approximating Liquid Glass in JS (tried with `@callstack/liquid-glass` wrapping the custom bar) doesn't reproduce the native material's refraction/lensing. Wrapping the real `UITabBarController` is the only way to get the authentic iOS 26 appearance and behaviors.

## Reviewer notes

- **Inactive tab tint on iOS 26 is system-controlled** — inactive items render white/gray instead of `dimText` green. `tabBarInactiveTintColor` is honored on iOS ≤ 18 and Android only. There is an `experimental_bakedTintColors` workaround upstream, deliberately not used (icon-sizing/accessibility drawbacks).
- Verified on an iPhone 17 Pro simulator (iOS 26.5): glass bar renders, tab selection syncs with app state, sub-screens cover the bar, map survives tab switches. TypeScript, ESLint, and all 39 Jest tests pass.
- Screens still pad bottom content with `tokens.tabBarHeight + insets.bottom`, which clears the floating native bar; could later be refined with the library's `useBottomTabBarHeight`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)