### PR TITLE
Make recents pills tappable to reconnect

### DIFF
--- a/src/components/RecentsSection.tsx
+++ b/src/components/RecentsSection.tsx
@@ -4,11 +4,11 @@
  * over the map. Hidden entirely while there is no history, so a fresh install
  * keeps the map uncluttered.
  *
- * Pills are deliberately NOT tappable: recents are recorded from past
- * connections (the broker picks the relay), not a connect affordance.
+ * Tapping a pill reconnects to that country, same flow as tapping a region
+ * on the map (broker still picks the specific relay within it).
  */
 import React from 'react';
-import { FlatList, StyleSheet, Text, View } from 'react-native';
+import { FlatList, Pressable, StyleSheet, Text, View } from 'react-native';
 
 import { useStrings } from '../i18n';
 import type { RecentNode } from '../native/types';
@@ -16,6 +16,7 @@ import { monoFont, palette, tokens } from '../theme';
 
 export interface RecentsSectionProps {
   recents: RecentNode[];
+  onPress: (countryCode: string) => void;
 }
 
 /** ISO 3166-1 alpha-2 -> flag emoji via regional indicators; neutral flag if invalid. */
@@ -29,7 +30,7 @@ function countryFlag(code: string): string {
   return String.fromCodePoint(first) + String.fromCodePoint(second);
 }
 
-export function RecentsSection({ recents }: RecentsSectionProps): React.JSX.Element | null {
+export function RecentsSection({ recents, onPress }: RecentsSectionProps): React.JSX.Element | null {
   const s = useStrings();
 
   if (recents.length === 0) {
@@ -44,12 +45,15 @@ export function RecentsSection({ recents }: RecentsSectionProps): React.JSX.Elem
         data={recents}
         keyExtractor={item => item.countryCode}
         renderItem={({ item }) => (
-          <View style={styles.pill}>
+          <Pressable
+            style={({ pressed }) => [styles.pill, pressed && styles.pillPressed]}
+            onPress={() => onPress(item.countryCode)}
+          >
             <Text style={styles.flag}>{countryFlag(item.countryCode)}</Text>
             <Text style={styles.pillLabel} numberOfLines={1}>
               {item.label}
             </Text>
-          </View>
+          </Pressable>
         )}
         ItemSeparatorComponent={PillGap}
         showsHorizontalScrollIndicator={false}
@@ -84,6 +88,9 @@ const styles = StyleSheet.create({
     borderColor: tokens.glassBorder,
     paddingHorizontal: 12,
     paddingVertical: 8,
+  },
+  pillPressed: {
+    opacity: 0.6,
   },
   pillLabel: {
     flexShrink: 1,

--- a/src/screens/MainScreen.tsx
+++ b/src/screens/MainScreen.tsx
@@ -123,7 +123,7 @@ export function MainScreen(): React.JSX.Element {
         <View style={styles.spacer} pointerEvents="none" />
 
         <View style={styles.bottomStack} pointerEvents="box-none">
-          <RecentsSection recents={native.recents} />
+          <RecentsSection recents={native.recents} onPress={onConnectRegion} />
           <ConnectCard
             status={native.status}
             relayLabel={native.relayLabel}


### PR DESCRIPTION
## Summary
- The recents strip on the home map was purely informational — tapping a pill did nothing, even though the comment said this was deliberate.
- Wired each pill into the existing `prepareAndConnect` flow (same handler already used for map region taps), so tapping a recent reconnects to that country. The broker still picks the specific relay within it.
- Added a pressed-state opacity dip for tap feedback.

## Test plan
- [x] `tsc --noEmit` passes
- [ ] Manually tap a recents pill on device/simulator and confirm it triggers a reconnect to that country

🤖 Generated with [Claude Code](https://claude.com/claude-code)