### PR TITLE
Enforce HTTPS-only transport (drop cleartext relay discovery + telemetry)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
       android:roundIcon="@mipmap/ic_launcher_round"
       android:allowBackup="false"
       android:theme="@style/AppTheme"
-      android:usesCleartextTraffic="true"
+      android:networkSecurityConfig="@xml/network_security_config"
       android:supportsRtl="true">
       <activity
         android:name=".MainActivity"

--- a/android/app/src/main/java/com/openrung/config/AppConfig.kt
+++ b/android/app/src/main/java/com/openrung/config/AppConfig.kt
@@ -2,28 +2,33 @@ package com.openrung.config
 
 object AppConfig {
     /**
-     * Discovery broker (relay-list bootstrap) default. Prefer the HTTPS, Cloudflare-fronted endpoint:
-     * discovery is the censorship-critical path — it runs BEFORE the VPN tunnel is up — and TLS + CDN
-     * edge IPs make it costly to block. Falls back to the raw origin IP; see [DEFAULT_BROKER_URLS].
+     * Discovery broker (relay-list bootstrap) default, and — since discovery is HTTPS-only — the sole
+     * built-in discovery candidate. Discovery is the censorship-critical path: it runs BEFORE the VPN
+     * tunnel is up, and the relay list it returns defines which server the client trusts as its exit.
+     * The relay list is NOT signed, so it must only be fetched over a TLS-authenticated channel; the
+     * Cloudflare-fronted HTTPS endpoint (TLS + CDN edge IPs) is both hard to block and unforgeable.
      */
     const val DEFAULT_BROKER_URL = "https://broker.openrung.org/"
 
     /**
-     * Telemetry / heartbeat / speed-test target: the raw origin IP, NOT the Cloudflare-fronted
-     * hostname. Heartbeats fire ~once/minute per connected user; routing them through the Cloudflare
-     * Worker would burn the Workers free-tier quota (100k requests/day). They ride the established VPN
-     * tunnel so they don't need the CDN front (and it's the same broker either way). Discovery stays
-     * fronted (low volume, pre-tunnel, needs the resilience); telemetry goes direct (high volume).
+     * Telemetry / heartbeat / speed-test target. Uses the same Cloudflare-fronted HTTPS broker as
+     * discovery, so this traffic is TLS-protected — the app never sends anything in cleartext. Kept as
+     * a separate constant from [DEFAULT_BROKER_URL] because telemetry is high-volume (heartbeats fire
+     * ~once/minute per connected user), so it consumes the Cloudflare Worker free-tier request quota
+     * (100k/day). If that quota becomes a constraint, the planned fix is to send telemetry
+     * direct-to-origin over TLS via a dedicated unproxied hostname — "Option A" in
+     * docs/ARCHITECTURE.md § "Network transport". Never revert to a raw-IP HTTP endpoint: that leaked
+     * the user's real pre-VPN IP, geo and stable client ID in cleartext.
      */
-    const val TELEMETRY_BROKER_URL = "http://54.238.185.205:8080/"
+    const val TELEMETRY_BROKER_URL = "https://broker.openrung.org/"
 
     /**
      * Ordered discovery candidates, tried in order until one returns relays (see
-     * [com.openrung.net.BrokerClient.firstReachable]): the Cloudflare-fronted endpoint first,
-     * then the raw IP as a fallback so a blocked edge never takes discovery offline. The raw cleartext
-     * IP is why `usesCleartextTraffic` is still enabled in the manifest.
+     * [com.openrung.net.BrokerClient.firstReachable]). HTTPS-only: the unsigned relay list must never
+     * be fetched over a forgeable cleartext channel, so there is deliberately NO raw-IP fallback here.
+     * A blocked edge fails discovery CLOSED (offline) rather than open to an attacker-injected relay.
      */
-    val DEFAULT_BROKER_URLS: List<String> = listOf(DEFAULT_BROKER_URL, TELEMETRY_BROKER_URL)
+    val DEFAULT_BROKER_URLS: List<String> = listOf(DEFAULT_BROKER_URL)
 
     /**
      * Ordered discovery candidates for a connection attempt: the caller-selected [primary] (a user

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Cleartext HTTP is denied for every host. All app traffic — relay discovery, telemetry / heartbeat /
+  speed-test, geo lookup, connectivity probes — goes over HTTPS. Discovery in particular must never
+  fall back to cleartext, because the relay list is unsigned and a forged one would redirect the whole
+  tunnel. If telemetry is ever moved to a direct-to-origin endpoint ("Option A" in docs/ARCHITECTURE.md
+  § "Network transport"), it should still be HTTPS; only add a scoped domain-config here if that origin
+  genuinely cannot present a publicly-trusted certificate.
+-->
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false" />
+</network-security-config>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -81,6 +81,55 @@ change; TS mirrors it into the store and never mutates it. Commands flow the
 other way as the five bridge methods (`prepare`, `connect`, `disconnect`,
 `getState`, `getIdentity`).
 
+## Network transport
+
+Every endpoint the app talks to is HTTPS. Both platforms enforce this at the OS
+layer: iOS runs default App Transport Security (no exceptions), and the Android
+`network_security_config.xml` denies cleartext for all hosts. There is no `http://`
+endpoint anywhere in the app.
+
+- **Relay discovery** — `https://broker.openrung.org/` only. This is the
+  censorship-critical, pre-tunnel path, and the relay list it returns is *unsigned*,
+  so it must only ever be fetched over a TLS-authenticated channel: a forged list
+  would repoint the whole tunnel at an attacker's exit. There is deliberately **no**
+  raw-IP fallback — a blocked edge fails discovery closed (offline), never open to an
+  injected relay.
+- **Telemetry / heartbeat / speed-test** — currently also `https://broker.openrung.org/`
+  (the same Cloudflare-fronted broker); see the trade-off below.
+- **Geo lookup** (`https://ipwho.is/`) and **connectivity probes**
+  (`https://www.gstatic.com/generate_204`, `https://cp.cloudflare.com/generate_204`)
+  are HTTPS.
+
+### Telemetry transport: current (Option B) vs. future (Option A)
+
+Telemetry is higher-volume than discovery — heartbeats fire ~once/minute per
+connected user, plus per-app connection records — so its transport is a
+cost/security trade-off:
+
+- **Option B — current.** Send telemetry to the Cloudflare-fronted
+  `https://broker.openrung.org/`, the same endpoint as discovery. TLS end-to-end with
+  zero extra infrastructure. Cost: every heartbeat runs through the Cloudflare Worker
+  and counts against its request quota (free tier: 100k/day). Fine at low user counts.
+- **Option A — future, if the Worker quota becomes the bottleneck.** Give the origin
+  box a dedicated *unproxied* (DNS-only / "grey-cloud") hostname — e.g.
+  `origin.openrung.org` → the origin IP directly — with a publicly-trusted TLS
+  certificate (e.g. Let's Encrypt) terminated on the origin, then point
+  `TELEMETRY_BROKER_URL` at `https://origin.openrung.org/`. This keeps telemetry
+  TLS-protected *and* bypasses the Cloudflare Worker (so it no longer consumes the
+  quota), while remaining a real hostname both platforms' cleartext policies accept.
+  The app-side change is one line of `TELEMETRY_BROKER_URL` in each of the three
+  `AppConfig` files (`src/config.ts`, `android/.../config/AppConfig.kt`,
+  `ios/Shared/AppConfig.swift`); the rest is server-side (DNS record + origin cert).
+  Because the new endpoint is HTTPS, no cleartext exception is needed on either
+  platform — unless the origin cannot present a publicly-trusted cert, in which case
+  add a scoped `domain-config` in `network_security_config.xml` (Android) and the
+  equivalent `NSExceptionDomains` entry (iOS) for that one hostname.
+
+  Do **not** revert to the old raw-IP-over-HTTP telemetry endpoint. That transmitted
+  the user's real pre-VPN IP, city, ISP and stable client ID in cleartext — readable
+  by the volunteer relay operator, and (on connection-failure flush paths) by the
+  user's own censored network.
+
 ## The bridge contract (§3 of the contract)
 
 One classic NativeModule named `OpenRungVpn` on both platforms, identical

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -200,7 +200,9 @@ ported (that lives in TS now). Files:
 - Manifest: INTERNET, ACCESS_NETWORK_STATE, FOREGROUND_SERVICE,
   FOREGROUND_SERVICE_SPECIAL_USE, POST_NOTIFICATIONS; service
   `.vpn.OpenRungVpnService` with BIND_VPN_SERVICE + specialUse;
-  `usesCleartextTraffic=true` (raw-IP telemetry broker).
+  `networkSecurityConfig=@xml/network_security_config` — cleartext HTTP denied for
+  all hosts (discovery, telemetry, geo and probes are all HTTPS; see ARCHITECTURE.md
+  § "Network transport").
 - Gradle: serialization plugin (Kotlin 2.1.20), kotlinx-serialization-json 1.7.3,
   kotlinx-coroutines-android 1.9.0, conditional `implementation(files("libs/libbox.aar"))`
   (file is copied locally, git-ignored). Status strings the service logs live in
@@ -232,8 +234,9 @@ phases, ENABLE_USER_SCRIPT_SANDBOXING=NO, current pbxproj settings), plus the
   (RCT_EXTERN_MODULE) — implements §3 over NETunnelProviderManager +
   SharedConnectionState (Darwin observer + NEVPNStatusDidChange), including the
   production relay-switch dance (stop → 350 ms → reconfigure → start).
-- Both targets: packet-tunnel-provider entitlement + app group;
-  `NSAllowsArbitraryLoads=true`. PacketTunnel links `ThirdParty/Libbox.xcframework`
+- Both targets: packet-tunnel-provider entitlement + app group; no ATS exceptions —
+  default App Transport Security is enforced because every endpoint is HTTPS (see
+  ARCHITECTURE.md § "Network transport"). PacketTunnel links `ThirdParty/Libbox.xcframework`
   (embed:false) + libresolv.tbd, `APPLICATION_EXTENSION_API_ONLY=YES`; compiles
   without the xcframework via the existing `#if canImport(Libbox)` stub.
 

--- a/ios/OpenRung/Info.plist
+++ b/ios/OpenRung/Info.plist
@@ -26,11 +26,6 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
-	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string></string>
 	<key>RCTNewArchEnabled</key>

--- a/ios/PacketTunnel/Info.plist
+++ b/ios/PacketTunnel/Info.plist
@@ -20,11 +20,6 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
-	</dict>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/ios/Shared/AppConfig.swift
+++ b/ios/Shared/AppConfig.swift
@@ -8,23 +8,28 @@ enum AppConfig {
     static let providerTargetCountryKey = "target_country"
     static let providerTargetRelayIDKey = "target_relay_id"
 
-    /// Discovery broker (relay-list bootstrap) default. Prefer the HTTPS, Cloudflare-fronted endpoint:
-    /// discovery is the censorship-critical path — it runs BEFORE the VPN tunnel is up — and TLS + CDN
-    /// edge IPs make it costly to block. Falls back to the raw origin IP; see `defaultBrokerURLs`.
+    /// Discovery broker (relay-list bootstrap) default, and — since discovery is HTTPS-only — the sole
+    /// built-in discovery candidate. Discovery is the censorship-critical path: it runs BEFORE the VPN
+    /// tunnel is up, and the relay list it returns defines which server the client trusts as its exit.
+    /// The relay list is NOT signed, so it must only be fetched over a TLS-authenticated channel; the
+    /// Cloudflare-fronted HTTPS endpoint (TLS + CDN edge IPs) is both hard to block and unforgeable.
     static let defaultBrokerURL = URL(string: "https://broker.openrung.org/")!
 
-    /// Telemetry / heartbeat / speed-test target: the raw origin IP, NOT the Cloudflare-fronted
-    /// hostname. Heartbeats fire ~once/minute per connected user; routing them through the Cloudflare
-    /// Worker would burn the Workers free-tier quota (100k requests/day). They ride the established VPN
-    /// tunnel so they don't need the CDN front (and it's the same broker either way). Discovery stays
-    /// fronted (low volume, pre-tunnel, needs the resilience); telemetry goes direct (high volume).
-    static let telemetryBrokerURL = URL(string: "http://54.238.185.205:8080/")!
+    /// Telemetry / heartbeat / speed-test target. Uses the same Cloudflare-fronted HTTPS broker as
+    /// discovery, so this traffic is TLS-protected — the app never sends anything in cleartext. Kept
+    /// as a separate constant from `defaultBrokerURL` because telemetry is high-volume (heartbeats
+    /// fire ~once/minute per connected user), so it consumes the Cloudflare Worker free-tier request
+    /// quota (100k/day). If that quota becomes a constraint, the planned fix is to send telemetry
+    /// direct-to-origin over TLS via a dedicated unproxied hostname — "Option A" in
+    /// docs/ARCHITECTURE.md § "Network transport". Never revert to a raw-IP HTTP endpoint: that leaked
+    /// the user's real pre-VPN IP, geo and stable client ID in cleartext.
+    static let telemetryBrokerURL = URL(string: "https://broker.openrung.org/")!
 
     /// Ordered discovery candidates, tried in order until one returns relays (see
-    /// `BrokerClient.firstReachable`): the Cloudflare-fronted endpoint first, then the raw IP as a
-    /// fallback so a blocked edge never takes discovery offline. The raw cleartext IP is why
-    /// `NSAllowsArbitraryLoads` is still set.
-    static let defaultBrokerURLs: [URL] = [defaultBrokerURL, telemetryBrokerURL]
+    /// `BrokerClient.firstReachable`). HTTPS-only: the unsigned relay list must never be fetched over
+    /// a forgeable cleartext channel, so there is deliberately NO raw-IP fallback here. A blocked edge
+    /// fails discovery CLOSED (offline) rather than open to an attacker-injected relay.
+    static let defaultBrokerURLs: [URL] = [defaultBrokerURL]
 
     /// Ordered broker candidates for a connection attempt: the caller-selected `primary` (the provider
     /// configuration's broker, today the default) first, then the built-in `defaultBrokerURLs`,

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,28 +10,33 @@ import { version } from '../package.json';
  */
 export const AppConfig = {
   /**
-   * Discovery broker (relay-list bootstrap) default. Prefer the HTTPS, Cloudflare-fronted endpoint:
-   * discovery is the censorship-critical path — it runs BEFORE the VPN tunnel is up — and TLS + CDN
-   * edge IPs make it costly to block. Falls back to the raw origin IP; see DEFAULT_BROKER_URLS.
+   * Discovery broker (relay-list bootstrap) default, and — since discovery is HTTPS-only — the sole
+   * built-in discovery candidate. Discovery is the censorship-critical path: it runs BEFORE the VPN
+   * tunnel is up, and the relay list it returns defines which server the client trusts as its exit.
+   * The relay list is NOT signed, so it must only be fetched over a TLS-authenticated channel; the
+   * Cloudflare-fronted HTTPS endpoint (TLS + CDN edge IPs) is both hard to block and unforgeable.
    */
   DEFAULT_BROKER_URL: 'https://broker.openrung.org/',
 
   /**
-   * Telemetry / heartbeat / speed-test target: the raw origin IP, NOT the Cloudflare-fronted
-   * hostname. Heartbeats fire ~once/minute per connected user; routing them through the Cloudflare
-   * Worker would burn the Workers free-tier quota (100k requests/day). They ride the established VPN
-   * tunnel so they don't need the CDN front (and it's the same broker either way). Discovery stays
-   * fronted (low volume, pre-tunnel, needs the resilience); telemetry goes direct (high volume).
+   * Telemetry / heartbeat / speed-test target. Uses the same Cloudflare-fronted HTTPS broker as
+   * discovery, so this traffic is TLS-protected — the app never sends anything in cleartext. Kept as
+   * a separate constant from DEFAULT_BROKER_URL because telemetry is high-volume (heartbeats fire
+   * ~once/minute per connected user), so it consumes the Cloudflare Worker free-tier request quota
+   * (100k/day). If that quota becomes a constraint, the planned fix is to send telemetry
+   * direct-to-origin over TLS via a dedicated unproxied hostname — "Option A" in
+   * docs/ARCHITECTURE.md § "Network transport". Never revert to a raw-IP HTTP endpoint: that leaked
+   * the user's real pre-VPN IP, geo and stable client ID in cleartext.
    */
-  TELEMETRY_BROKER_URL: 'http://54.238.185.205:8080/',
+  TELEMETRY_BROKER_URL: 'https://broker.openrung.org/',
 
   /**
-   * Ordered discovery candidates, tried in order until one returns relays (see
-   * `firstReachable` in `net/brokerClient.ts`): the Cloudflare-fronted endpoint first, then the
-   * raw IP as a fallback so a blocked edge never takes discovery offline. The raw cleartext IP is
-   * why cleartext HTTP stays allowed in both native app configs.
+   * Ordered discovery candidates, tried in order until one returns relays (see `firstReachable` in
+   * `net/brokerClient.ts`). HTTPS-only: the unsigned relay list must never be fetched over a
+   * forgeable cleartext channel, so there is deliberately NO raw-IP fallback here. A blocked edge
+   * fails discovery CLOSED (offline) rather than open to an attacker-injected relay.
    */
-  DEFAULT_BROKER_URLS: ['https://broker.openrung.org/', 'http://54.238.185.205:8080/'],
+  DEFAULT_BROKER_URLS: ['https://broker.openrung.org/'],
 
   /**
    * Ordered discovery candidates for a connection attempt: the caller-selected `primary` (a user


### PR DESCRIPTION
## What & why

A security review found that this censorship-circumvention VPN could be turned against its own users over cleartext HTTP. This PR closes the three most urgent findings.

**The core problem:** relay discovery tried the HTTPS broker first, then silently fell back to a cleartext `http://54.238.185.205:8080/` endpoint, and the relay list it returns is **unsigned**. An on-path attacker who blocks the HTTPS edge — exactly the adversary this app is built to defeat — could force the fallback, MITM the plaintext response, and serve a forged relay descriptor pointing at *their own* server. The client validated only field-presence, so it would route **all device traffic** through the attacker's exit. The same cleartext IP also received telemetry containing the user's real pre-VPN IP, city, ISP, stable client ID, and per-app connection records.

## Changes

- **Discovery is HTTPS-only.** Removed the raw-IP fallback from `DEFAULT_BROKER_URLS` in all three layers (`src/config.ts`, `AppConfig.kt`, `AppConfig.swift`). A blocked edge now fails discovery **closed** (offline), never open to an injected relay.
- **Telemetry over TLS (Option B).** `TELEMETRY_BROKER_URL` now points at the HTTPS broker, so nothing leaves the device in cleartext. Kept as a distinct constant so a future direct-to-origin TLS endpoint (**Option A**) is a one-line change.
- **Android:** replaced app-wide `usesCleartextTraffic="true"` with a `network_security_config.xml` that denies cleartext for **all** hosts.
- **iOS:** removed the `NSAllowsArbitraryLoads` ATS exception from both the app and the PacketTunnel extension — default App Transport Security is now enforced (possible because every endpoint is HTTPS).
- **Docs:** new `ARCHITECTURE.md` § "Network transport" documenting the current Option B and the future Option A (unproxied origin hostname + Let's Encrypt cert to bypass the Cloudflare Worker quota while keeping TLS); `CONTRACT.md` updated to match.

Closes tunnel-hijack (**URGENT-1**), broad-cleartext (**URGENT-3**), and cleartext-telemetry (**URGENT-2**).

## Reviewer notes

- ⚠️ **Backend dependency:** this assumes the Cloudflare-fronted `broker.openrung.org` forwards the telemetry paths (`/api/v1/telemetry/events`, heartbeat, speed-test), not just `/api/v1/relays`. If the Worker only routes discovery, telemetry POSTs will 404 until those paths are forwarded. Please confirm before release.
- **Cost note:** telemetry now rides the Cloudflare Worker (heartbeats ~1/min/user), which counts against the free-tier request quota. Option A in `ARCHITECTURE.md` is the documented escape hatch if that becomes a bottleneck.
- **Verification:** all 48 unit tests pass; both `Info.plist` files pass `plutil -lint`; the Android XML is well-formed; `grep` confirms zero `http://` endpoints remain in source. (The pre-existing `App.test.tsx` suite fails to load in CI-less envs because `react-native-bottom-tabs` isn't installed — unrelated to this change.)
- **Not included:** the untracked 176 MB `.wrangler/` APK is deliberately left out of this commit; it should be gitignored separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)