### PR TITLE
Ignore .wrangler/ (Cloudflare Wrangler local state)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,9 @@ yarn-error.log
 android/app/libs/libbox.aar
 ios/ThirdParty/Libbox.xcframework/
 
+# Cloudflare Wrangler (local miniflare state / R2 dev bucket; can hold large release artifacts)
+.wrangler/
+
 # Env files
 .env
 .env.*


### PR DESCRIPTION
## What & why

`.wrangler/` — Cloudflare Wrangler's local miniflare dev directory — was untracked but **not** gitignored. It holds local KV/R2 simulation state, currently including a ~176 MB release APK (`android/openrung-mobile-0.2.1-3-release.apk`) in the simulated `openrung-downloads` R2 bucket. Without an ignore rule, a stray `git add -A` would commit a large binary blob into history.

This adds `.wrangler/` to `.gitignore` under a dedicated Cloudflare Wrangler section.

## Notes

- Verified with `git check-ignore .wrangler` → now ignored.
- No functional change; `.gitignore`-only.
- Follow-up to the hygiene item flagged during the security review (separate from the transport fixes in #11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)