### PR TITLE
Cancel serviceScope on VPN service destroy (fix coroutine scope leak)

### DIFF
--- a/android/app/src/main/java/com/openrung/vpn/OpenRungVpnService.kt
+++ b/android/app/src/main/java/com/openrung/vpn/OpenRungVpnService.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
@@ -77,7 +78,12 @@ class OpenRungVpnService : VpnService() {
 
     override fun onDestroy() {
         disconnect()
-        connectJob?.cancel()
+        // Cancel the scope so its Job, its Main.immediate dispatcher, and any in-flight
+        // coroutines (connect, heartbeat, the disconnect() telemetry flush) don't outlive this
+        // service instance. Mirrors OpenRungVpnModule.invalidate(). This supersedes the explicit
+        // connectJob cancel (scope cancellation cancels all children). The on-destroy telemetry
+        // flush is best-effort — the outbox retries anything dropped here on the next session.
+        serviceScope.cancel()
         super.onDestroy()
     }
 


### PR DESCRIPTION
## What & why

`OpenRungVpnService.onDestroy()` cancelled only `connectJob`, never `serviceScope`:

```kotlin
override fun onDestroy() {
    disconnect()
    connectJob?.cancel()   // ← individual job only
    super.onDestroy()
}
```

`serviceScope` is a `CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)` created per service instance. Because the scope's `Job` was never cancelled, it — its dispatcher, and every coroutine launched on it (`connect`, the `startHeartbeatLoop()` loop, and the fire-and-forget telemetry flush in `disconnect()`) — outlived each destroyed service instance.

**Failure scenario:** repeated connect/disconnect (or system-triggered service recreation) leaks a live scope every cycle, and the heartbeat/flush coroutines can keep running after the service is gone.

## Fix

Cancel the scope in `onDestroy()`, mirroring the existing `OpenRungVpnModule.invalidate()` which already does `moduleScope.cancel()`:

```kotlin
override fun onDestroy() {
    disconnect()
    serviceScope.cancel()   // cancels the Job, dispatcher, and all child coroutines
    super.onDestroy()
}
```

- Scope cancellation cancels all children, so the now-redundant `connectJob?.cancel()` is dropped.
- Uses `import kotlinx.coroutines.cancel` — the same import/pattern the bridge module already uses.
- The on-destroy telemetry flush becomes best-effort; the telemetry outbox retries anything dropped here on the next session. (Normal disconnects are unaffected — the scope is only cancelled on service destroy, not on `ACTION_DISCONNECT`.)

## Verification

- `:app:compileDebugKotlin` → **BUILD SUCCESSFUL** (compiled against the real libbox AAR; only pre-existing `allNetworks` deprecation warnings in `ProxyEngine.kt`, unrelated).
- No Kotlin tests reference this service, so none needed updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)