### PR TITLE
iOS tunnel: add sleep/wake + lock down the libbox command port

### DIFF
--- a/ios/PacketTunnel/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider.swift
@@ -45,6 +45,18 @@ final class PacketTunnelProvider: NEPacketTunnelProvider {
         }
     }
 
+    override func sleep(completionHandler: @escaping () -> Void) {
+        // Pause the engine while the device sleeps so iOS doesn't terminate the extension for CPU
+        // wakeups; libbox schedules its own auto-wake. Without this the extension can be silently
+        // killed while SharedConnectionState still reports .connected.
+        engine?.pause()
+        completionHandler()
+    }
+
+    override func wake() {
+        engine?.wake()
+    }
+
     // MARK: - Connection flow
 
     private func connect(completionHandler: @escaping (Error?) -> Void) async {

--- a/ios/PacketTunnel/PacketTunnelProxyEngine.swift
+++ b/ios/PacketTunnel/PacketTunnelProxyEngine.swift
@@ -6,6 +6,10 @@ import OSLog
 protocol PacketTunnelProxyEngine: AnyObject {
     func start(relay: RelayDescriptor, tunnelProvider: NEPacketTunnelProvider) async throws
     func stop()
+    /// Pause the engine when the device sleeps and resume it on wake, so iOS doesn't terminate the
+    /// extension for CPU/wakeups while the tunnel sits idle. Safe no-op before the engine starts.
+    func pause()
+    func wake()
 }
 
 #if canImport(Libbox)
@@ -34,7 +38,16 @@ final class EmbeddedProxyEngine: PacketTunnelProxyEngine {
         setupOptions.crashReportSource = AppConfig.engineDirectoryName
         setupOptions.oomKillerEnabled = false
         setupOptions.oomKillerDisabled = true
+        // The libbox command server listens on loopback TCP. iOS has no per-app loopback isolation,
+        // and the unix-socket alternative (commandServerListenPort = 0) puts the socket at
+        // basePath/command.sock, whose path overflows Darwin's 104-byte sun_path limit inside an
+        // app-extension container. So gate the listener with a random per-launch secret: libbox's
+        // gRPC auth interceptor rejects any client that doesn't present it, which blocks a
+        // co-installed app from issuing commands (close/reload the service, subscribe to logs,
+        // trigger a crash). The app's own control calls (startOrReloadService, closeService, pause,
+        // wake) are direct in-process method calls and bypass the interceptor.
         setupOptions.commandServerListenPort = try availableCommandServerPort()
+        setupOptions.commandServerSecret = Self.makeCommandServerSecret()
 
         TunnelDiagnostics.recordEvent("Setting up libbox")
         logger.info("Setting up libbox")
@@ -76,6 +89,19 @@ final class EmbeddedProxyEngine: PacketTunnelProxyEngine {
         activeRelay = nil
     }
 
+    func pause() {
+        commandServer?.pause()
+    }
+
+    func wake() {
+        commandServer?.wake()
+    }
+
+    /// Per-launch random secret for the command server's gRPC auth interceptor (see `start`).
+    private static func makeCommandServerSecret() -> String {
+        (0..<32).map { _ in String(format: "%02x", UInt8.random(in: .min ... .max)) }.joined()
+    }
+
     private func availableCommandServerPort() throws -> Int32 {
         var port: Int32 = 0
         var error: NSError?
@@ -103,6 +129,9 @@ final class EmbeddedProxyEngine: PacketTunnelProxyEngine {
     func stop() {
         activeRelay = nil
     }
+
+    func pause() {}
+    func wake() {}
 }
 
 #endif


### PR DESCRIPTION
Two PacketTunnel-extension fixes from the security review.

## 1. Missing `sleep()` / `wake()`

`PacketTunnelProvider` overrode only `startTunnel`/`stopTunnel`. Without `sleep(completionHandler:)`, libbox is never paused when the device sleeps — the Go engine keeps timers/connections alive, iOS terminates the extension for CPU/wakeups, and the user wakes to a **silently dead VPN while `SharedConnectionState` still reports `.connected`** (only corrected when the app next foregrounds).

**Fix:** `sleep()` pauses the engine and `wake()` resumes it, via new `pause()`/`wake()` on the `PacketTunnelProxyEngine` protocol that forward to `LibboxCommandServer.pause()`/`wake()`. Confirmed against the pinned sing-box source: `Pause()` calls `PauseManager().DevicePause()` and (on iOS) schedules its own 1-minute auto-wake — this is exactly sing-box's own iOS sleep/wake mechanism. Both are safe no-ops before the engine starts (`instance == nil` guard in Go; optional-chaining in Swift). The `#else` stub engine gets no-op implementations.

## 2. Unauthenticated libbox command server reachable by co-installed apps

The command server listens on loopback TCP (`127.0.0.1:<port>`), which **any co-installed app can reach** — iOS has no per-app loopback isolation. `commandServerSecret` was empty, and per the pinned sing-box source the gRPC auth interceptor treats an empty secret as "no auth required", so any local app could close/reload the service, subscribe to logs (connection metadata), or trigger a native crash.

**Fix:** set a random per-launch `commandServerSecret`. The interceptor now rejects every client that doesn't present it. The app's own control calls (`startOrReloadService`/`closeService`/`pause`/`wake`) are direct in-process method calls that bypass the interceptor, so they're unaffected — and the app uses no libbox command *client* at all.

### Why not a unix socket?

A unix-domain socket (`commandServerListenPort = 0`) would remove the listener from the network entirely (what the review suggested). But libbox derives the socket path from `basePath` (`basePath/command.sock`), and the extension's `.applicationSupportDirectory/OpenRungPacketTunnel` base overflows Darwin's 104-byte `sun_path` limit, so the bind would fail and the tunnel wouldn't start. Since I can't validate on-device from here and that's a hard failure mode, the authenticated loopback listener is the robust choice. (If `basePath` is later shortened to fit, switching to the unix socket becomes a clean follow-up.)

## Verification

`xcodebuild -workspace OpenRung.xcworkspace -scheme PacketTunnel -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' build` → **BUILD SUCCEEDED**, compiling and linking both changed files against the real `Libbox.xcframework` and the NetworkExtension SDK. (`Podfile.lock` churn from a local `pod install` was reverted — it only reflected this sandbox missing the `react-native-bottom-tabs` npm package.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)