### PR TITLE
Fix start/stop tunnel race (stopped tunnel could show "connected")

### DIFF
--- a/android/app/src/main/java/com/openrung/vpn/OpenRungVpnService.kt
+++ b/android/app/src/main/java/com/openrung/vpn/OpenRungVpnService.kt
@@ -34,8 +34,10 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlin.coroutines.coroutineContext
 import kotlin.random.Random
 
 class OpenRungVpnService : VpnService() {
@@ -167,6 +169,10 @@ class OpenRungVpnService : VpnService() {
 
             failureStage = "relay_connect"
             val connectedRelay = connectFirstAvailable(targetedCandidates)
+            // If a disconnect raced in while we were connecting, don't publish CONNECTED for a
+            // tunnel that's being torn down. Stopping the engine is owned by disconnect()/a new
+            // connect (both call cleanupActiveTunnel); we just must not commit CONNECTED here.
+            coroutineContext.ensureActive()
             val relay = connectedRelay.relay
             activeRelayId = relay.id
             TelemetryManager.markConnected(relay.id)
@@ -189,6 +195,9 @@ class OpenRungVpnService : VpnService() {
                 ),
             )
             runCatching { TelemetryManager.flush(AppConfig.TELEMETRY_BROKER_URL) }
+            // The flush above swallows cancellation (runCatching), so re-check: a disconnect that
+            // raced in during it must not leave a heartbeat loop running after teardown.
+            coroutineContext.ensureActive()
             startHeartbeatLoop()
         } catch (error: CancellationException) {
             throw error
@@ -219,6 +228,11 @@ class OpenRungVpnService : VpnService() {
                 OpenRungStatusStore.appendLog(getString(R.string.log_checking_relay_reachability))
                 val tcpLatencyMs = try {
                     RelayReachability.checkTcp(relay)
+                } catch (error: CancellationException) {
+                    // A racing disconnect cancels this coroutine; let cancellation propagate instead
+                    // of masking it as an "unreachable" failure, which would keep trying relays and
+                    // could bring a tunnel up after teardown.
+                    throw error
                 } catch (error: Throwable) {
                     throw IllegalStateException(
                         getString(R.string.error_relay_unreachable, relay.publicHost, relay.publicPort),

--- a/ios/PacketTunnel/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider.swift
@@ -10,6 +10,7 @@ final class PacketTunnelProvider: NEPacketTunnelProvider {
     private let selector = RelaySelector()
     private var engine: PacketTunnelProxyEngine?
     private var heartbeatTask: Task<Void, Never>?
+    private var connectTask: Task<Void, Never>?
     private var activeRelayID: String?
     private var brokerURL = AppConfig.defaultBrokerURL
 
@@ -17,7 +18,7 @@ final class PacketTunnelProvider: NEPacketTunnelProvider {
         options: [String: NSObject]?,
         completionHandler: @escaping (Error?) -> Void
     ) {
-        Task { await connect(completionHandler: completionHandler) }
+        connectTask = Task { await connect(completionHandler: completionHandler) }
     }
 
     override func stopTunnel(
@@ -26,20 +27,29 @@ final class PacketTunnelProvider: NEPacketTunnelProvider {
     ) {
         heartbeatTask?.cancel()
         heartbeatTask = nil
+        // Cancel any in-flight connect and wait for it to unwind BEFORE tearing down, so it can't
+        // assign a new engine or publish .connected for a tunnel we're stopping. connect() checks
+        // for cancellation before it commits; a libbox engine it already started (start() is not
+        // cancellable) is stopped below, after the await.
+        let pendingConnect = connectTask
+        connectTask = nil
+        pendingConnect?.cancel()
         SharedConnectionState.setStatus(.disconnecting)
-
-        if let relayID = activeRelayID {
-            TelemetryManager.record("tunnel_stopped", relayId: relayID)
-        }
-        activeRelayID = nil
-        TelemetryManager.endSession(reason: "disconnect")
-
-        engine?.stop()
-        engine = nil
-        SharedConnectionState.setStatus(.disconnected, clearRelayLabel: true, clearError: true)
 
         let telemetryURLString = AppConfig.telemetryBrokerURL.absoluteString
         Task {
+            await pendingConnect?.value
+
+            if let relayID = activeRelayID {
+                TelemetryManager.record("tunnel_stopped", relayId: relayID)
+            }
+            activeRelayID = nil
+            TelemetryManager.endSession(reason: "disconnect")
+
+            engine?.stop()
+            engine = nil
+            SharedConnectionState.setStatus(.disconnected, clearRelayLabel: true, clearError: true)
+
             try? await TelemetryManager.flush(brokerURL: telemetryURLString)
             completionHandler()
         }
@@ -138,6 +148,12 @@ final class PacketTunnelProvider: NEPacketTunnelProvider {
 
             failureStage = "relay_connect"
             let connected = try await connectFirstAvailableRelay(targetedCandidates)
+
+            // A stop may have arrived while we were connecting. Don't publish .connected or start
+            // the heartbeat for a tunnel that's being torn down; stopTunnel awaited this task and
+            // stops the engine connectFirstAvailableRelay assigned.
+            try Task.checkCancellation()
+
             let relay = connected.relay
             activeRelayID = relay.id
             TelemetryManager.markConnected(relayId: relay.id)
@@ -159,6 +175,11 @@ final class PacketTunnelProvider: NEPacketTunnelProvider {
 
             logger.info("Connected through relay \(relay.id, privacy: .public)")
             completionHandler(nil)
+        } catch is CancellationError {
+            // Stopped mid-connect. Leave engine teardown and the .disconnected status to stopTunnel
+            // (which awaited this task); don't record a failure or publish an error for a
+            // user-initiated stop.
+            completionHandler(CancellationError())
         } catch {
             engine?.stop()
             engine = nil
@@ -180,6 +201,7 @@ final class PacketTunnelProvider: NEPacketTunnelProvider {
         var lastError: Error?
 
         for (index, relay) in candidates.enumerated() {
+            try Task.checkCancellation()
             do {
                 SharedConnectionState.appendLog("trying relay \(relay.id) at \(relay.publicHost):\(relay.publicPort)")
                 SharedConnectionState.appendLog("checking relay TCP reachability")
@@ -208,6 +230,12 @@ final class PacketTunnelProvider: NEPacketTunnelProvider {
                     internetProbeMs: probe.durationMs,
                     attempts: index + 1
                 )
+            } catch is CancellationError {
+                // A racing stop cancelled us; stop the engine this attempt may have started and
+                // propagate cancellation instead of trying the next relay.
+                engine?.stop()
+                engine = nil
+                throw CancellationError()
             } catch {
                 lastError = error
                 TelemetryManager.record(


### PR DESCRIPTION
On both platforms, a disconnect arriving **mid-connect** could race the connect flow: the connect path kept running after teardown and could publish `.connected` (and start the heartbeat) for a tunnel that was being stopped, and/or leave a libbox engine running with nothing left to stop it.

## iOS (`PacketTunnelProvider`)

`startTunnel` did `Task { await connect(...) }` and **discarded the Task handle**, so `stopTunnel` could only cancel the heartbeat. If the user disconnected while `connect` was in flight, `stopTunnel` wrote `.disconnected` while the connect task continued — assigning a new engine, publishing `.connected`, and starting the heartbeat (also a data race on the non-actor `engine`).

- The connect `Task` is now retained (`connectTask`).
- `stopTunnel` cancels it and **`await`s it before tearing down**, so teardown is strictly ordered after connect unwinds — and it stops whatever engine connect started (libbox `start()` isn't cancellable, so an engine can exist even after cancellation).
- `connect()` calls `try Task.checkCancellation()` before committing `.connected`/starting the heartbeat; `connectFirstAvailableRelay()` checks cancellation at the top of each relay attempt and rethrows `CancellationError` cleanly instead of recording a spurious `relay_attempt_failed`.

## Android (`OpenRungVpnService`)

The subtler root cause: `RelayReachability.checkTcp` was wrapped in a `catch (Throwable)` that **swallowed `CancellationException`**, masking a racing disconnect as an "unreachable" failure — so the connect coroutine kept trying the next relay (and could bring a tunnel up) *after* `disconnect()` had already torn down.

- Cancellation now propagates from `checkTcp` (a `catch (CancellationException) { throw }` before the `Throwable` catch).
- The `CONNECTED` commit and the heartbeat start are guarded with `coroutineContext.ensureActive()`, so a superseded connect can't publish `CONNECTED` or leak a heartbeat.
- Engine teardown intentionally stays owned by the canceller (`disconnect()` / a new connect both already call `cleanupActiveTunnel()`). I deliberately did **not** make the cancelled connect stop the engine itself, because on the single-threaded main dispatcher that could stop a *newer* connect's engine during a rapid relay-switch (cross-contamination). `checkTcp` cancellation-cooperation guarantees a cancelled connect never assigns a new engine after the canceller cleaned up.

## Verification

- Android: `./gradlew :app:compileDebugKotlin` → **BUILD SUCCESSFUL** (compiled against the real libbox AAR).
- iOS: `xcodebuild -workspace OpenRung.xcworkspace -scheme PacketTunnel -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' build` → **BUILD SUCCEEDED** (compiled/linked against the real `Libbox.xcframework`).
- (`Podfile.lock` churn from a local `pod install` was reverted — it only reflects this sandbox missing the `react-native-bottom-tabs` npm package.)

Note: PR #15 already narrowed the iOS window slightly (engine stop on the `sleep` path); this closes the core `stopTunnel`-can't-cancel-`startTunnel` race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)