### PR TITLE
docs: clarify availability-first design (not "fail-closed")

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ The app is a thin, well-designed TypeScript shell over a native VPN engine. The
 shell handles everything the user sees — the map, relay directory, and connect
 UI — while the native module carries the actual traffic.
 
+OpenRung is **availability-first**: it optimizes for keeping you reachable rather
+than guaranteeing zero leakage. If no relay can be reached the app reports the
+failure and leaves your normal connection in place instead of blocking it — there
+is no OS-level kill switch.
+
 ```mermaid
 flowchart LR
     ui["📱 React Native shell<br/>(map · directory · connect UI)"]
@@ -73,8 +78,8 @@ side-by-side with them.
   + GeoIP grouping, speed test, and language selection.
 - **Android native (`android/`)** — the production `VpnService` connect path
   (package `com.openrung.*`): broker relay fetch, relay selection + TCP
-  reachability, sing-box/libbox engine, TUN + DNS, internet probe, fail-closed
-  behavior, heartbeat telemetry, plus the `OpenRungVpn` React Native module that
+  reachability, sing-box/libbox engine, TUN + DNS, internet probe, connection-failure
+  handling, heartbeat telemetry, plus the `OpenRungVpn` React Native module that
   bridges it.
 - **iOS native (`ios/`)** — the production `NEPacketTunnelProvider` extension,
   shared Swift sources compiled into both targets, and an `OpenRungVpnModule`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -16,7 +16,7 @@ TypeScript through one small bridge module, `OpenRungVpn`.
 **Native owns the connect path** (exactly as in the production apps):
 broker relay fetch for connecting, relay selection, TCP reachability,
 sing-box (libbox) engine lifecycle, TUN + DNS configuration, internet probe,
-fail-closed behavior, heartbeat telemetry, VPN permission and background
+connection-failure handling, heartbeat telemetry, VPN permission and background
 lifecycle, recents recording, and status/log persistence. If the RN process
 dies, the tunnel keeps running.
 
@@ -28,6 +28,13 @@ speed test, language selection, and the licenses screens.
 Note that the broker is queried from *both* sides, matching production: the
 native service fetches relays to connect, and the TS shell independently
 fetches relays to draw the map directory.
+
+**Availability over "never leak."** OpenRung is availability-first. The only leak
+protection is sing-box `strict_route` while the tunnel is up; there is deliberately
+no OS-level kill switch, so when the tunnel is down (no relay reachable, a crash, or
+between sessions) traffic falls back to the normal network instead of being blocked.
+"Report failure if no relay works" below means the connect attempt reports failure
+without leaving a leaky tunnel — not that traffic is blocked. See CONTRACT.md §1.
 
 ## Data flow
 
@@ -69,7 +76,7 @@ fetches relays to draw the map directory.
   |  broker fetch -> relay selection -> TCP reachability                |
   |     -> sing-box config -> libbox engine + TUN + DNS                 |
   |     -> internet probe -> geo label -> heartbeat telemetry           |
-  |     -> fail closed if no relay works                                |
+  |     -> report failure if no relay works                             |
   +-----|---------------------------------------------------------------+
         v
      libbox (sing-box, statically linked)
@@ -177,7 +184,7 @@ The production connect-path packages are ported with only the package rename
 are not ported (TS owns them). Key pieces:
 
 - `vpn/OpenRungVpnService.kt` + `vpn/ProxyEngine.kt` — the whole connect
-  flow, fail-closed, notification id 2001 on channel `openrung_vpn`,
+  flow, connection-failure handling, notification id 2001 on channel `openrung_vpn`,
   heartbeat every 50–70 s.
 - `net/`, `model/`, `telemetry/`, `config/AppConfig.kt` — verbatim.
 - `state/OpenRungStatusStore.kt` — trimmed to status/relay/error/logs/recents

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -13,14 +13,25 @@ functionality 1:1 unless noted.
 **Native (Kotlin service / Swift NEPacketTunnelProvider extension)** owns the whole
 connect path, exactly as in the production apps:
 broker relay fetch (connect path), relay selection, TCP reachability, sing-box
-(libbox) engine lifecycle, TUN + DNS config, internet probe, fail-closed behavior,
-heartbeat telemetry, VPN permission + background lifecycle, recents recording,
-status/log persistence.
+(libbox) engine lifecycle, TUN + DNS config, internet probe, connection-failure
+handling, heartbeat telemetry, VPN permission + background lifecycle, recents
+recording, status/log persistence.
 
 **TypeScript (RN shell)** owns everything the production *app processes* own:
 all UI, navigation, exit-node map directory (broker fetch, grouped by the
 broker-served relay locations — relay IPs are never geolocated client-side),
 speed test, language selection, licenses screens.
+
+**Availability over "never leak."** OpenRung is availability-first: keeping the
+user reachable matters more than guaranteeing no traffic ever leaves the tunnel.
+The only leak protection is sing-box `strict_route` *while the tunnel is up*
+(`SingBoxConfiguration`). There is deliberately **no OS-level kill switch** (no
+`includeAllNetworks` / on-demand enforcement), so when the tunnel is down — no
+relay reachable, a service/extension crash, or between sessions — traffic falls
+back to the normal network rather than being blocked. "Connection-failure
+handling" above and "report failure if no relay works" elsewhere therefore mean
+the connect attempt *reports failure without leaving a half-open or leaky tunnel* —
+NOT that the OS blocks traffic while the VPN is down.
 
 ## 2. Identifiers
 
@@ -186,7 +197,8 @@ Ported from the production app with packages renamed
 ported (that lives in TS now). Files:
 
 - `vpn/OpenRungVpnService.kt`, `vpn/ProxyEngine.kt` — verbatim port (connect flow,
-  fail-closed, notification id 2001 channel `openrung_vpn`, heartbeat 50–70s).
+  connection-failure handling, notification id 2001 channel `openrung_vpn`,
+  heartbeat 50–70s).
 - `net/` BrokerClient, GeoIpClient, InternetProbe, RelayReachability,
   SingBoxConfiguration; `model/` RelayDescriptor, RelaySelector, CountryGeo,
   RecentNode; `telemetry/` all four files; `config/AppConfig.kt`.


### PR DESCRIPTION
## What & why

The docs (CONTRACT.md, ARCHITECTURE.md, README) described the native layer as **"fail-closed."** That term of art means "block traffic on failure," which overstates what the app actually does — and it's exactly what led a security review to flag a *missing iOS kill switch* as an urgent gap.

Per the maintainer, OpenRung is **availability-first by design**: keeping the user reachable matters more than guaranteeing zero leakage. The only leak protection is sing-box `strict_route` *while the tunnel is up*. There is deliberately **no OS-level kill switch** — when the tunnel is down (no relay reachable, a crash, or between sessions), traffic falls back to the normal network rather than being blocked. That's the intended tradeoff for a censorship-circumvention tool, not a bug.

This PR makes the docs say that, so the wording matches the design and future reviews don't re-flag it.

## Changes (docs only — no code/behavior change)

- Replaced the misleading **"fail-closed"** wording with accurate language — "connection-failure handling" and "report failure if no relay works" — in all three files (including the ASCII flow diagram in ARCHITECTURE.md).
- Added an explicit **"Availability over 'never leak'"** note to `CONTRACT.md` §1 (the binding spec) and a concise version to `ARCHITECTURE.md`, spelling out what the connect-failure behavior really is: *reports failure without leaving a leaky half-tunnel; does not block OS traffic while disconnected.*
- Added an availability-first sentence to the README "How it works" section.

Resolves the iOS-review "no kill switch / fail-closed" finding (URGENT-4) as **by-design**. A strict kill switch remains possible later as an opt-in Settings toggle (default off) if ever wanted, but is intentionally not the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)