### PR TITLE
Fix three JS-layer bugs (speed-test double-run, seed race, blank relay id)

### DIFF
--- a/__tests__/core/exitNodeDirectory.test.ts
+++ b/__tests__/core/exitNodeDirectory.test.ts
@@ -148,4 +148,11 @@ describe('loadExitNodeDirectory', () => {
     ]);
     expect(regions).toEqual([]);
   });
+
+  it('excludes a broker-located relay with a blank id (no list key / connect target)', async () => {
+    const regions = await load([relay({ id: '', ...TOKYO }), relay({ id: 'ok', ...TOKYO })]);
+    expect(regions).toHaveLength(1);
+    expect(regions[0].nodeCount).toBe(1);
+    expect(regions[0].relays).toEqual([{ id: 'ok', label: null }]);
+  });
 });

--- a/src/net/exitNodeDirectory.ts
+++ b/src/net/exitNodeDirectory.ts
@@ -42,7 +42,9 @@ export async function loadExitNodeDirectory(
 
   const regionsByKey = new Map<string, ExitNodeRegion>();
   for (const relay of usable) {
-    if (!isLocated(relay)) {
+    // A relay with a blank id can't be keyed in the list or targeted by tap-to-connect (it would
+    // hand an empty targetRelayId to the native VPN layer), so it never enters the directory.
+    if (relay.id.trim().length === 0 || !isLocated(relay)) {
       continue;
     }
     const code = relay.country_code.trim().toUpperCase();

--- a/src/net/speedTestClient.ts
+++ b/src/net/speedTestClient.ts
@@ -46,13 +46,27 @@ export function calculateMbps(bytes: number, durationMs: number): number {
   return (bytes * 8) / durationMs / 1_000;
 }
 
-async function download(endpoint: string, bytes: number): Promise<SpeedTestResult> {
+async function download(
+  endpoint: string,
+  bytes: number,
+  signal?: AbortSignal,
+): Promise<SpeedTestResult> {
   const separator = endpoint.includes('?') ? '&' : '?';
   const cacheBust = `${Date.now()}${Math.floor(Math.random() * 1_000_000)}`;
   const url = `${endpoint}${separator}bytes=${bytes}&cacheBust=${cacheBust}`;
 
+  // Bounded by a timeout; an optional caller signal (e.g. the screen unmounting) also aborts the
+  // request so a navigated-away speed test stops downloading instead of running to completion.
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  const onCallerAbort = () => controller.abort();
+  if (signal) {
+    if (signal.aborted) {
+      controller.abort();
+    } else {
+      signal.addEventListener('abort', onCallerAbort);
+    }
+  }
   try {
     const startedMs = Date.now();
     const response = await fetch(url, {
@@ -81,19 +95,22 @@ async function download(endpoint: string, bytes: number): Promise<SpeedTestResul
     };
   } finally {
     clearTimeout(timer);
+    signal?.removeEventListener('abort', onCallerAbort);
   }
 }
 
 /**
  * Runs the production two-phase test against `{broker}/api/v1/speed-test`: a 1 MB warmup download
- * followed by the measured 10 MB download; the second download's result is returned.
+ * followed by the measured 10 MB download; the second download's result is returned. An optional
+ * `signal` aborts an in-flight run (e.g. when the Settings screen unmounts).
  */
 export async function runSpeedTest(
   brokerUrl: string,
   warmupBytes: number = DEFAULT_WARMUP_BYTES,
   measurementBytes: number = DEFAULT_MEASUREMENT_BYTES,
+  signal?: AbortSignal,
 ): Promise<SpeedTestResult> {
   const endpoint = speedTestUrl(brokerUrl);
-  await download(endpoint, warmupBytes);
-  return download(endpoint, measurementBytes);
+  await download(endpoint, warmupBytes, signal);
+  return download(endpoint, measurementBytes, signal);
 }

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -6,7 +6,7 @@
  * list; the speed test RUN button is enabled only while connected and not
  * already running.
  */
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Modal, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -36,6 +36,19 @@ export function SettingsScreen({ onOpenDebug }: SettingsScreenProps): React.JSX.
   const [speedTestResult, setSpeedTestResult] = useState<SpeedTestResult | null>(null);
   const [speedTestError, setSpeedTestError] = useState<string | null>(null);
 
+  const mountedRef = useRef(true);
+  const runControllerRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    return () => {
+      // Android unmounts inactive tabs. Abort an in-flight speed test on unmount so it stops
+      // downloading instead of finishing in the background — and so a fresh RUN after returning
+      // to the tab can't kick off a second concurrent download.
+      mountedRef.current = false;
+      runControllerRef.current?.abort();
+    };
+  }, []);
+
   // Same precedence as production: running > error > result > requires-connection > ready.
   const speedTestSubtitle = speedTestRunning
     ? s.speedTestRunning
@@ -50,12 +63,22 @@ export function SettingsScreen({ onOpenDebug }: SettingsScreenProps): React.JSX.
   const runEnabled = isConnected && !speedTestRunning;
 
   const onRunSpeedTest = useCallback(() => {
+    const controller = new AbortController();
+    runControllerRef.current = controller;
     setSpeedTestRunning(true);
     setSpeedTestResult(null);
     setSpeedTestError(null);
     (async () => {
       try {
-        const result = await runSpeedTest(AppConfig.TELEMETRY_BROKER_URL);
+        const result = await runSpeedTest(
+          AppConfig.TELEMETRY_BROKER_URL,
+          undefined,
+          undefined,
+          controller.signal,
+        );
+        if (!mountedRef.current) {
+          return;
+        }
         setSpeedTestResult(result);
         try {
           const identity = await OpenRungVpn.getIdentity();
@@ -69,6 +92,12 @@ export function SettingsScreen({ onOpenDebug }: SettingsScreenProps): React.JSX.
           // Telemetry is best-effort; never surfaces in the UI.
         }
       } catch (error) {
+        // A run cancelled by unmount/navigation is not a real failure: don't surface it or report
+        // a bogus speed_test_failed event. (A timeout aborts the internal controller, not this
+        // one, so it still falls through to the failure path below.)
+        if (controller.signal.aborted || !mountedRef.current) {
+          return;
+        }
         // Mirrors production: message ?: exception simple name for the subtitle,
         // the error type name for the telemetry attribute.
         const errorType = error instanceof Error ? error.constructor.name || error.name : 'Error';
@@ -85,7 +114,9 @@ export function SettingsScreen({ onOpenDebug }: SettingsScreenProps): React.JSX.
           // Best-effort.
         }
       } finally {
-        setSpeedTestRunning(false);
+        if (mountedRef.current) {
+          setSpeedTestRunning(false);
+        }
       }
     })();
   }, []);

--- a/src/state/useVpnState.ts
+++ b/src/state/useVpnState.ts
@@ -34,16 +34,23 @@ export function useVpnState(): VpnStateHook {
 
   useEffect(() => {
     let mounted = true;
+    let receivedEvent = false;
+    // Subscribe FIRST so no event is missed, and track whether one has arrived: a slow getState()
+    // seed must not clobber a fresher event that landed while it was in flight (e.g. mounting during
+    // a connecting -> connected transition).
+    const unsubscribe = subscribeVpnState(nativeState => {
+      receivedEvent = true;
+      applyNativeState(nativeState);
+    });
     OpenRungVpn.getState()
       .then(nativeState => {
-        if (mounted) {
+        if (mounted && !receivedEvent) {
           applyNativeState(nativeState);
         }
       })
       .catch(() => {
         // Native state stays at the store default until the first event arrives.
       });
-    const unsubscribe = subscribeVpnState(applyNativeState);
     return () => {
       mounted = false;
       unsubscribe();


### PR DESCRIPTION
Batches the three remaining lower-severity JS-layer findings from the security review.

## 1. Speed test could double-run and waste volunteer bandwidth

`SettingsScreen`'s speed test was an untracked async IIFE with no cancellation. On Android (which unmounts inactive tabs), switching away mid-run let the 11 MB download run to completion in the background, and returning reset the component state so **RUN re-enabled and started a second concurrent download** against the bandwidth-donated relay.

- `runSpeedTest`/`download` now accept an optional `AbortSignal` (chained to the internal timeout controller).
- The screen creates a per-run `AbortController`, **aborts it on unmount**, and treats a cancelled run as a non-failure — no error shown, no bogus `speed_test_failed` telemetry.
- A real 60 s timeout aborts the *internal* controller (not the caller's), so it still surfaces as a genuine failure. The guard distinguishes the two.

## 2. `useVpnState` seed/subscribe race

`getState()` was fired *before* subscribing and applied whenever it resolved, guarded only by `mounted`. A slow seed could overwrite a fresher event that arrived while it was in flight — e.g. mounting during a `connecting → connected` transition left the UI stuck on CONNECTING until the next event. Now it **subscribes first** and drops the seed if any event has already been applied. Recurs on every screen mount, so this affects Main/Settings/Debug.

## 3. Blank relay `id` → duplicate keys, empty labels, empty connect target

A relay with a blank `id` can't be keyed in the list or targeted by tap-to-connect (it would hand an **empty `targetRelayId`** to the native VPN layer), yet `isUsable` — a documented 1:1 port of the production predicate — doesn't check `id`. Rather than diverge the ported predicate, I filter blank-`id` relays at the **directory-build choke point** (`exitNodeDirectory`), which fixes the duplicate React keys, empty row labels, and empty-`targetRelayId` connect in one place. Added a directory test.

## Verification

- `tsc --noEmit` clean (no errors in the changed files).
- `jest` green — 68/68, including the new `exitNodeDirectory` blank-`id` test.
- (The pre-existing `App.test.tsx` suite fails to load in this sandbox because `react-native-bottom-tabs` isn't installed — unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)