### PR TITLE
CI: install both NDKs + pin libbox to NDK 29 (fix relocation link error)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,8 +79,11 @@ jobs:
           go-version: stable
 
       - uses: android-actions/setup-android@v3
-      - name: Install NDK 29.0.14206865
-        run: sdkmanager "ndk;29.0.14206865"
+      # Two NDKs are needed: 29.0.14206865 to LINK the prebuilt libcronet.a inside libbox
+      # (older lld rejects its relocations), and 27.1.12297006 for the Gradle APK build
+      # (android/build.gradle pins ndkVersion). The runner's default NDK is neither.
+      - name: Install NDKs
+        run: sdkmanager "ndk;29.0.14206865" "ndk;27.1.12297006"
 
       # libbox.aar is the GPL corresponding-source pinned in SINGBOX_VERSION and built
       # out of tree (Go + gomobile + NDK). Cache it so it only rebuilds when sing-box
@@ -99,9 +102,15 @@ jobs:
         run: |
           go install github.com/sagernet/gomobile/cmd/gomobile@v0.1.12
           go install github.com/sagernet/gomobile/cmd/gobind@v0.1.12
+      # Force NDK 29 for the libbox link. The runner pre-sets ANDROID_NDK_HOME to an older
+      # NDK, which the script's ${VAR:-default} would otherwise keep — and that older lld
+      # fails on libcronet.a with "unknown relocation".
       - name: Build libbox.aar
         if: steps.libbox.outputs.cache-hit != 'true'
-        run: bash android/build-libbox-release.sh
+        run: |
+          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/29.0.14206865"
+          export ANDROID_NDK_ROOT="$ANDROID_HOME/ndk/29.0.14206865"
+          bash android/build-libbox-release.sh
 
       - name: Decode upload keystore
         env:


### PR DESCRIPTION
## Progress
The gomobile fix (#22) worked — the run got past "missing gomobile installation" and deep into **Build libbox.aar**, then failed at the link step:
```
ld.lld: error: libcronet.a(...): unknown relocation (315) against symbol typeinfo for std::bad_cast
```

## Two NDK problems
1. **libbox linked with the wrong NDK.** The path in the error is NDK `27.3.13750724` — the runner's *pre-set* `ANDROID_NDK_HOME` — not the `29.0.14206865` the step installed. `build-libbox-release.sh` only defaults the NDK when it's unset, so the runner's older one won. NDK 27's `lld` can't link the prebuilt `libcronet.a` (newer relocations). This is why the **local** build works — it defaults to NDK 29.
2. **Gradle needs a *different* NDK.** `android/build.gradle` pins `ndkVersion = "27.1.12297006"`, which the workflow never installed — the APK build would have failed next.

## Fix
- Install **both** NDKs: `29.0.14206865` (libbox link) and `27.1.12297006` (Gradle APK).
- Export `ANDROID_NDK_HOME`/`ANDROID_NDK_ROOT = …/ndk/29.0.14206865` for the libbox step, overriding the runner default — matching the known-good local build.

## After merge
Same as before: merge won't auto-release; trigger the workflow manually (`workflow_dispatch`) to finish v0.2.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)