### PR TITLE
CI: attach a stable openrung-android.apk to each release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,8 +138,14 @@ jobs:
           echo "$certs" | grep -i "certificate DN"
           echo "$certs" | grep -qi "CN=OpenRung" || { echo "::error::APK is not signed with the OpenRung upload key"; exit 1; }
 
-      - name: Stage APK asset
-        run: cp android/app/build/outputs/apk/release/app-release.apk "$ASSET"
+      # Two names: a versioned asset for history, and a STABLE openrung-android.apk so that
+      # https://github.com/openrung/openrung-mobile-app/releases/latest/download/openrung-android.apk
+      # is a permanent link that always serves the newest release (used by the openrung.org
+      # download button, which lives in the separate openrung/openrung repo).
+      - name: Stage APK assets
+        run: |
+          cp android/app/build/outputs/apk/release/app-release.apk "$ASSET"
+          cp android/app/build/outputs/apk/release/app-release.apk openrung-android.apk
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -148,7 +154,9 @@ jobs:
           name: v${{ env.VERSION }} (build ${{ env.VERSION_CODE }})
           generate_release_notes: true
           fail_on_unmatched_files: true
-          files: ${{ env.ASSET }}
+          files: |
+            ${{ env.ASSET }}
+            openrung-android.apk
 
       # Optional: mirror to Cloudflare R2, but only if the token secret is configured.
       # No-op (not a failure) when CLOUDFLARE_API_TOKEN is absent.
@@ -164,5 +172,10 @@ jobs:
           npx --yes wrangler@4 r2 object put \
             "openrung-downloads/android/$ASSET" \
             --file "$ASSET" \
+            --content-type application/vnd.android.package-archive \
+            --remote
+          npx --yes wrangler@4 r2 object put \
+            "openrung-downloads/android/openrung-android.apk" \
+            --file openrung-android.apk \
             --content-type application/vnd.android.package-archive \
             --remote


### PR DESCRIPTION
Attaches a fixed-name copy of the APK — `openrung-android.apk` — to every release, alongside the versioned `openrung-mobile-<v>-<code>-release.apk`.

## Why
It makes this a **permanent download URL** that always serves the newest release:
```
https://github.com/openrung/openrung-mobile-app/releases/latest/download/openrung-android.apk
```
The `docs/index.html` download button (in the separate `openrung/openrung` repo) points at that once and never needs touching again — GitHub resolves "latest" server-side. No CI write-back to the site repo, no rebuild loops.

## Changes
- Stage step copies the APK to both the versioned name and `openrung-android.apk`
- The release attaches both files
- The (optional, currently-off) R2 mirror also writes a stable `android/openrung-android.apk` key, so R2 has a permanent path too if that mirror is ever enabled

Storage cost is negligible — GitHub release assets are free/unmetered for public repos, and it's ~170 MB × 2 per release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)