### PR TITLE
Report per-session data usage in telemetry (bytes_sent/bytes_received)

### DIFF
--- a/android/app/src/main/java/com/openrung/net/SingBoxConfiguration.kt
+++ b/android/app/src/main/java/com/openrung/net/SingBoxConfiguration.kt
@@ -107,6 +107,13 @@ data class SingBoxConfiguration(
                 })
                 put("final", "proxy")
             })
+            put("experimental", buildJsonObject {
+                // No external_controller is set, so nothing listens; an empty clash_api
+                // block just turns on sing-box's traffic accounting, which feeds the
+                // cumulative bytes_sent/bytes_received counters reported with session
+                // telemetry (see TelemetryManager.updateTrafficCounters).
+                put("clash_api", buildJsonObject { })
+            })
         }
     }
 

--- a/android/app/src/main/java/com/openrung/telemetry/TelemetryManager.kt
+++ b/android/app/src/main/java/com/openrung/telemetry/TelemetryManager.kt
@@ -25,6 +25,7 @@ object TelemetryManager {
     private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
     private var context: Context? = null
     private var activeSession: Session? = null
+    private var sessionTraffic: TrafficCounters? = null
 
     data class Session(
         val id: String,
@@ -35,6 +36,15 @@ object TelemetryManager {
         val connectedElapsedMs: Long? = null,
         val geoAttributes: Map<String, String> = emptyMap(),
     )
+
+    /** Cumulative tunneled-traffic counters for the active session, as last reported by the engine. */
+    data class TrafficCounters(val bytesSent: Long, val bytesReceived: Long) {
+        /** Broker contract (openrung docs/api.md): cumulative per session, zero values omitted. */
+        fun measurements(): Map<String, Long> = buildMap {
+            if (bytesSent > 0) put("bytes_sent", bytesSent)
+            if (bytesReceived > 0) put("bytes_received", bytesReceived)
+        }
+    }
 
     fun initialize(context: Context) {
         synchronized(lock) {
@@ -51,10 +61,33 @@ object TelemetryManager {
             clientId = clientId(context),
             brokerUrl = brokerUrl,
             startedElapsedMs = SystemClock.elapsedRealtime(),
-        ).also { synchronized(lock) { activeSession = it } }
+        ).also {
+            synchronized(lock) {
+                activeSession = it
+                sessionTraffic = null
+            }
+        }
     }
 
     fun activeSession(): Session? = synchronized(lock) { activeSession }
+
+    /**
+     * Records the tunnel's traffic counters for the active session. Reported values must be
+     * cumulative since the engine started; the high-water mark is kept so a counter reset
+     * (engine restart) never regresses what the session already reported.
+     */
+    fun updateTrafficCounters(bytesSent: Long, bytesReceived: Long) {
+        synchronized(lock) {
+            if (activeSession == null) return
+            val current = sessionTraffic
+            sessionTraffic = TrafficCounters(
+                bytesSent = maxOf(bytesSent, current?.bytesSent ?: 0L),
+                bytesReceived = maxOf(bytesReceived, current?.bytesReceived ?: 0L),
+            )
+        }
+    }
+
+    private fun trafficCounters(): TrafficCounters? = synchronized(lock) { sessionTraffic }
 
     fun markConnected(relayId: String) {
         synchronized(lock) {
@@ -146,13 +179,19 @@ object TelemetryManager {
         val now = SystemClock.elapsedRealtime()
         val measurements = mutableMapOf("session_duration_ms" to (now - session.startedElapsedMs))
         session.connectedElapsedMs?.let { measurements["connection_duration_ms"] = now - it }
+        trafficCounters()?.let { measurements.putAll(it.measurements()) }
         record(
             event = "connection_ended",
             relayId = session.relayId,
             attributes = mapOf("reason" to reason),
             measurements = measurements,
         )
-        synchronized(lock) { if (activeSession?.id == session.id) activeSession = null }
+        synchronized(lock) {
+            if (activeSession?.id == session.id) {
+                activeSession = null
+                sessionTraffic = null
+            }
+        }
     }
 
     // NOTE(prototype): recordSpeedTest(SpeedTestResult) is not ported — the speed test
@@ -166,6 +205,7 @@ object TelemetryManager {
             occurredAt = Instant.now(),
             elapsedRealtimeMs = SystemClock.elapsedRealtime(),
             attributes = deviceAttributes(appContext) + session.geoAttributes,
+            trafficCounters = trafficCounters(),
         ) ?: return
         val queued = synchronized(lock) { readOutbox(appContext).take(UPLOAD_BATCH_SIZE - 1) }
         TelemetryClient(session.brokerUrl).send(queued + event)
@@ -246,6 +286,7 @@ internal fun buildSessionHeartbeat(
     occurredAt: Instant,
     elapsedRealtimeMs: Long,
     attributes: Map<String, String>,
+    trafficCounters: TelemetryManager.TrafficCounters? = null,
 ): TelemetryEvent? {
     val relayId = session.relayId ?: return null
     val connectedElapsedMs = session.connectedElapsedMs ?: return null
@@ -260,6 +301,6 @@ internal fun buildSessionHeartbeat(
         measurements = mapOf(
             "session_duration_ms" to (elapsedRealtimeMs - session.startedElapsedMs).coerceAtLeast(0),
             "connected_duration_ms" to (elapsedRealtimeMs - connectedElapsedMs).coerceAtLeast(0),
-        ),
+        ) + (trafficCounters?.measurements() ?: emptyMap()),
     )
 }

--- a/android/app/src/main/java/com/openrung/vpn/ProxyEngine.kt
+++ b/android/app/src/main/java/com/openrung/vpn/ProxyEngine.kt
@@ -12,15 +12,22 @@ import android.util.Log
 import com.openrung.model.RelayDescriptor
 import com.openrung.state.OpenRungStatusStore
 import com.openrung.telemetry.TelemetryManager
+import io.nekohasekai.libbox.CommandClient
+import io.nekohasekai.libbox.CommandClientHandler
+import io.nekohasekai.libbox.CommandClientOptions
 import io.nekohasekai.libbox.CommandServer
 import io.nekohasekai.libbox.CommandServerHandler
+import io.nekohasekai.libbox.ConnectionEvents
 import io.nekohasekai.libbox.ConnectionOwner
 import io.nekohasekai.libbox.InterfaceUpdateListener
 import io.nekohasekai.libbox.Libbox
 import io.nekohasekai.libbox.LocalDNSTransport
+import io.nekohasekai.libbox.LogIterator
 import io.nekohasekai.libbox.NeighborUpdateListener
 import io.nekohasekai.libbox.NetworkInterfaceIterator
 import io.nekohasekai.libbox.Notification
+import io.nekohasekai.libbox.OutboundGroupItemIterator
+import io.nekohasekai.libbox.OutboundGroupIterator
 import io.nekohasekai.libbox.OverrideOptions
 import io.nekohasekai.libbox.PlatformInterface
 import io.nekohasekai.libbox.PlatformUser
@@ -28,6 +35,7 @@ import io.nekohasekai.libbox.RoutePrefix
 import io.nekohasekai.libbox.RoutePrefixIterator
 import io.nekohasekai.libbox.SetupOptions
 import io.nekohasekai.libbox.ShellSession
+import io.nekohasekai.libbox.StatusMessage
 import io.nekohasekai.libbox.StringIterator
 import io.nekohasekai.libbox.SystemProxyStatus
 import io.nekohasekai.libbox.TunOptions
@@ -79,6 +87,7 @@ class StubProxyEngine : ProxyEngine {
 
 class LibboxProxyEngine : ProxyEngine {
     private var commandServer: CommandServer? = null
+    private var statusClient: CommandClient? = null
     private var tunFd: ParcelFileDescriptor? = null
 
     override suspend fun start(
@@ -109,14 +118,72 @@ class LibboxProxyEngine : ProxyEngine {
         server.start()
         server.startOrReloadService(configJson, OverrideOptions())
         commandServer = server
+        statusClient = connectStatusClient()
+    }
+
+    /**
+     * Subscribes to the in-process libbox status stream, whose messages carry the tunnel's
+     * cumulative uplink/downlink byte counters (enabled by the clash_api traffic accounting in
+     * the sing-box config). Best-effort: if the subscription fails, sessions simply omit the
+     * bytes_sent/bytes_received telemetry measurements.
+     */
+    private fun connectStatusClient(): CommandClient? {
+        val options = CommandClientOptions().apply {
+            addCommand(Libbox.CommandStatus)
+            statusInterval = STATUS_INTERVAL_NS
+        }
+        val client = CommandClient(TrafficStatusHandler(), options)
+        return runCatching { client.connect() }
+            .map { client }
+            .onFailure { Log.w(LOG_TAG, "libbox status client connect failed", it) }
+            .getOrNull()
     }
 
     override fun stop() {
+        runCatching { statusClient?.disconnect() }
+        statusClient = null
         runCatching { commandServer?.closeService() }
         runCatching { commandServer?.close() }
         commandServer = null
         runCatching { tunFd?.close() }
         tunFd = null
+    }
+
+    companion object {
+        /** Status push interval, a Go time.Duration in nanoseconds. */
+        private const val STATUS_INTERVAL_NS = 3_000_000_000L
+    }
+}
+
+/** Receives libbox status pushes and forwards the tunnel's traffic counters to telemetry. */
+private class TrafficStatusHandler : CommandClientHandler {
+    override fun connected() = Unit
+
+    override fun disconnected(message: String?) = Unit
+
+    override fun clearLogs() = Unit
+
+    override fun initializeClashMode(modeList: StringIterator?, currentMode: String?) = Unit
+
+    override fun setDefaultLogLevel(level: Int) = Unit
+
+    override fun updateClashMode(newMode: String?) = Unit
+
+    override fun writeConnectionEvents(events: ConnectionEvents?) = Unit
+
+    override fun writeGroups(groups: OutboundGroupIterator?) = Unit
+
+    override fun writeLogs(messages: LogIterator?) = Unit
+
+    override fun writeOutbounds(outbounds: OutboundGroupItemIterator?) = Unit
+
+    override fun writeStatus(message: StatusMessage?) {
+        val status = message ?: return
+        if (!status.trafficAvailable) return
+        TelemetryManager.updateTrafficCounters(
+            bytesSent = status.uplinkTotal,
+            bytesReceived = status.downlinkTotal,
+        )
     }
 }
 

--- a/ios/PacketTunnel/PacketTunnelProxyEngine.swift
+++ b/ios/PacketTunnel/PacketTunnelProxyEngine.swift
@@ -18,8 +18,12 @@ import Libbox
 final class EmbeddedProxyEngine: PacketTunnelProxyEngine {
     private let logger = Logger(subsystem: AppConfig.loggingSubsystem, category: "EmbeddedProxyEngine")
     private var commandServer: LibboxCommandServer?
+    private var statusClient: LibboxCommandClient?
     private var platformInterface: LibboxPacketTunnelPlatformInterface?
     private var activeRelay: RelayDescriptor?
+
+    /// Status push interval, a Go time.Duration in nanoseconds.
+    private static let statusIntervalNs: Int64 = 3_000_000_000
 
     func start(relay: RelayDescriptor, tunnelProvider: NEPacketTunnelProvider) async throws {
         activeRelay = relay
@@ -77,10 +81,34 @@ final class EmbeddedProxyEngine: PacketTunnelProxyEngine {
 
         self.platformInterface = platformInterface
         self.commandServer = commandServer
+        statusClient = connectStatusClient()
         logger.info("libbox started for relay \(relay.id, privacy: .public)")
     }
 
+    /// Subscribes to the in-process libbox status stream, whose messages carry the tunnel's
+    /// cumulative uplink/downlink byte counters (enabled by the clash_api traffic accounting in
+    /// the sing-box config). Best-effort: if the subscription fails, sessions simply omit the
+    /// bytes_sent/bytes_received telemetry measurements.
+    private func connectStatusClient() -> LibboxCommandClient? {
+        let options = LibboxCommandClientOptions()
+        options.addCommand(LibboxCommandStatus)
+        options.statusInterval = Self.statusIntervalNs
+        guard let client = LibboxNewCommandClient(TrafficStatusHandler(), options) else {
+            logger.warning("Unable to create libbox status client; session traffic will not be reported")
+            return nil
+        }
+        do {
+            try client.connect()
+        } catch {
+            logger.warning("libbox status client connect failed: \(error.localizedDescription, privacy: .public)")
+            return nil
+        }
+        return client
+    }
+
     func stop() {
+        try? statusClient?.disconnect()
+        statusClient = nil
         try? commandServer?.closeService()
         commandServer?.close()
         platformInterface?.reset()
@@ -111,6 +139,37 @@ final class EmbeddedProxyEngine: PacketTunnelProxyEngine {
         TunnelDiagnostics.recordEvent("Using libbox command server port \(port)")
         logger.info("Using libbox command server port \(port, privacy: .public)")
         return port
+    }
+}
+
+/// Receives libbox status pushes and forwards the tunnel's traffic counters to telemetry.
+private final class TrafficStatusHandler: NSObject, LibboxCommandClientHandlerProtocol {
+    func connected() {}
+
+    func disconnected(_ message: String?) {}
+
+    func clearLogs() {}
+
+    func initializeClashMode(_ modeList: (any LibboxStringIteratorProtocol)?, currentMode: String?) {}
+
+    func setDefaultLogLevel(_ level: Int32) {}
+
+    func updateClashMode(_ newMode: String?) {}
+
+    func write(_ events: LibboxConnectionEvents?) {}
+
+    func writeGroups(_ message: (any LibboxOutboundGroupIteratorProtocol)?) {}
+
+    func writeLogs(_ messageList: (any LibboxLogIteratorProtocol)?) {}
+
+    func writeOutbounds(_ message: (any LibboxOutboundGroupItemIteratorProtocol)?) {}
+
+    func writeStatus(_ message: LibboxStatusMessage?) {
+        guard let message, message.trafficAvailable else { return }
+        TelemetryManager.updateTrafficCounters(
+            bytesSent: message.uplinkTotal,
+            bytesReceived: message.downlinkTotal
+        )
     }
 }
 

--- a/ios/Shared/SingBoxConfiguration.swift
+++ b/ios/Shared/SingBoxConfiguration.swift
@@ -113,6 +113,13 @@ public struct SingBoxConfiguration: Equatable, Sendable {
                     ]
                 ],
                 "final": "proxy"
+            ],
+            "experimental": [
+                // No external_controller is set, so nothing listens; an empty clash_api
+                // block just turns on sing-box's traffic accounting, which feeds the
+                // cumulative bytes_sent/bytes_received counters reported with session
+                // telemetry (see TelemetryManager.updateTrafficCounters).
+                "clash_api": [String: Any]()
             ]
         ]
     }

--- a/ios/Shared/TelemetryManager.swift
+++ b/ios/Shared/TelemetryManager.swift
@@ -4,6 +4,12 @@ import Foundation
 /// Usable from both processes — the extension drives the connection lifecycle/heartbeat, the app
 /// records speed-test results. Port of Android `TelemetryManager`.
 enum TelemetryManager {
+    /// Traffic counters for the active session, kept in memory only: the engine, the heartbeat
+    /// loop, and endSession all run in the packet tunnel extension, so nothing needs to cross
+    /// the app-group boundary (the app process never reports these measurements).
+    private static let trafficLock = NSLock()
+    private static var sessionTraffic: TrafficCounters?
+
     static func clientId() -> String {
         ClientIdentity.getOrCreate()
     }
@@ -16,8 +22,34 @@ enum TelemetryManager {
             brokerURL: brokerURL,
             startedElapsedMs: MonotonicClock.nowMs()
         )
+        resetTrafficCounters()
         TelemetrySessionStore.save(session)
         return session
+    }
+
+    /// Records the tunnel's traffic counters for the active session. Reported values must be
+    /// cumulative since the engine started; the high-water mark is kept so a counter reset
+    /// (engine restart) never regresses what the session already reported.
+    /// Port of Android `TelemetryManager.updateTrafficCounters`.
+    static func updateTrafficCounters(bytesSent: Int64, bytesReceived: Int64) {
+        trafficLock.lock()
+        defer { trafficLock.unlock() }
+        sessionTraffic = TrafficCounters(
+            bytesSent: max(bytesSent, sessionTraffic?.bytesSent ?? 0),
+            bytesReceived: max(bytesReceived, sessionTraffic?.bytesReceived ?? 0)
+        )
+    }
+
+    private static func trafficCounters() -> TrafficCounters? {
+        trafficLock.lock()
+        defer { trafficLock.unlock() }
+        return sessionTraffic
+    }
+
+    private static func resetTrafficCounters() {
+        trafficLock.lock()
+        defer { trafficLock.unlock() }
+        sessionTraffic = nil
     }
 
     static func activeSession() -> TelemetrySession? {
@@ -71,7 +103,11 @@ enum TelemetryManager {
         if let connected = session.connectedElapsedMs {
             measurements["connection_duration_ms"] = max(now - connected, 0)
         }
+        if let traffic = trafficCounters() {
+            measurements.merge(traffic.measurements()) { _, new in new }
+        }
         record("connection_ended", relayId: session.relayId, attributes: ["reason": reason], measurements: measurements)
+        resetTrafficCounters()
         TelemetrySessionStore.save(nil)
     }
 
@@ -102,7 +138,8 @@ enum TelemetryManager {
             session: session,
             occurredAt: iso8601Now(),
             elapsedRealtimeMs: MonotonicClock.nowMs(),
-            attributes: attributes
+            attributes: attributes,
+            trafficCounters: trafficCounters()
         ) else { return }
 
         let queued = TelemetryOutbox.peek(max: TelemetryOutboxState.uploadBatchSize - 1)

--- a/ios/Shared/TelemetrySession.swift
+++ b/ios/Shared/TelemetrySession.swift
@@ -38,19 +38,47 @@ public struct TelemetrySession: Codable, Sendable, Equatable {
     }
 }
 
+/// Cumulative tunneled-traffic counters for the active session, as last reported by the proxy
+/// engine. Port of Android `TelemetryManager.TrafficCounters`.
+public struct TrafficCounters: Sendable, Equatable {
+    public let bytesSent: Int64
+    public let bytesReceived: Int64
+
+    public init(bytesSent: Int64, bytesReceived: Int64) {
+        self.bytesSent = bytesSent
+        self.bytesReceived = bytesReceived
+    }
+
+    /// Broker contract (openrung docs/api.md): cumulative per session, zero values omitted.
+    public func measurements() -> [String: Int64] {
+        var measurements: [String: Int64] = [:]
+        if bytesSent > 0 { measurements["bytes_sent"] = bytesSent }
+        if bytesReceived > 0 { measurements["bytes_received"] = bytesReceived }
+        return measurements
+    }
+}
+
 /// Builds a `session_heartbeat` event, or nil if the session is not yet connected.
 /// Port of Android `buildSessionHeartbeat`.
 public func buildSessionHeartbeat(
     session: TelemetrySession,
     occurredAt: String,
     elapsedRealtimeMs: Int64,
-    attributes: [String: String]
+    attributes: [String: String],
+    trafficCounters: TrafficCounters? = nil
 ) -> TelemetryEvent? {
     guard let relayId = session.relayId, let connectedElapsedMs = session.connectedElapsedMs else {
         return nil
     }
     var merged = attributes
     merged["connection_state"] = "connected"
+    var measurements: [String: Int64] = [
+        "session_duration_ms": max(elapsedRealtimeMs - session.startedElapsedMs, 0),
+        "connected_duration_ms": max(elapsedRealtimeMs - connectedElapsedMs, 0),
+    ]
+    if let trafficCounters {
+        measurements.merge(trafficCounters.measurements()) { _, new in new }
+    }
     return TelemetryEvent(
         eventId: UUID().uuidString,
         event: "session_heartbeat",
@@ -59,9 +87,6 @@ public func buildSessionHeartbeat(
         sessionId: session.id,
         relayId: relayId,
         attributes: merged,
-        measurements: [
-            "session_duration_ms": max(elapsedRealtimeMs - session.startedElapsedMs, 0),
-            "connected_duration_ms": max(elapsedRealtimeMs - connectedElapsedMs, 0),
-        ]
+        measurements: measurements
     )
 }


### PR DESCRIPTION
## What

Both apps now attach cumulative `bytes_sent` (upload) and `bytes_received` (download) measurements to `session_heartbeat` and `connection_ended` telemetry events, feeding the broker dashboard's new per-session data-usage view (contract: openrung `docs/api.md`, "Clients that can measure tunneled traffic…").

## How

- **Config** (`SingBoxConfiguration` on both platforms): adds an empty `experimental.clash_api` block. No `external_controller` is set, so nothing listens — it only enables sing-box's traffic accounting.
- **Engine** (`LibboxProxyEngine` / `EmbeddedProxyEngine`): after the service starts, an in-process libbox `CommandClient` subscribes to the status stream (3 s interval), which pushes the tunnel's cumulative uplink/downlink byte totals. Best-effort: if the subscription fails or `trafficAvailable` is false, sessions simply omit the measurements, as the contract allows.
- **Telemetry** (`TelemetryManager` on both platforms, `TelemetrySession.swift`): a per-session `TrafficCounters` high-water mark — reported values are cumulative, and a counter reset (engine restart) can never regress what a session already reported. Zero values are omitted. On iOS the counters live in extension memory only; the engine, heartbeat loop, and `endSession` all run in the packet tunnel process, so nothing new crosses the app-group boundary.

## Verification

- Android compiles (debug + release); iOS `PacketTunnel` and `OpenRung` schemes both build.
- Live end-to-end on the Android emulator against a real relay (Japan): the tunnel starts with the new config (the fork's `checkConfig` accepts `experimental.clash_api` — the main regression risk here), the status stream reports `trafficAvailable=true` every 3 s, and counters climbed cumulatively (up 0→25,797 / down 0→335,182 bytes while browsing through the tunnel) across a heartbeat and a clean disconnect.
- Cross-checked against openrung `origin/main`: the dashboard reads `event.Measurements["bytes_sent"]` / `["bytes_received"]` and keeps the per-session max — matching where and how these are reported.

## Reviewer notes

- Traffic accounting wraps each tunneled connection with counters (same mechanism SFA/SFI use); overhead is a per-connection byte count, and the status subscription is one in-process push every 3 s.
- `statusInterval` is a Go `time.Duration` — nanoseconds, hence the `3_000_000_000` constants.
- Found in passing (not addressed here): since the v0.2.2 HTTPS-only hardening (34f31aa), Android *debug* builds can't load JS from Metro at all — the network security config blocks cleartext to `10.0.2.2`/`localhost` with no debug override. Verification for this PR used a release install; a debug-only dev-host exception is being handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)