### PR TITLE
Fix Android debug builds: allow cleartext to Metro dev hosts only

### DIFF
--- a/android/app/src/debug/res/xml/network_security_config.xml
+++ b/android/app/src/debug/res/xml/network_security_config.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  DEBUG-ONLY override of the main network security config (resource merging: this file replaces
+  src/main/res/xml/network_security_config.xml in debug builds only; release builds are untouched).
+
+  The base-config keeps the same cleartext ban as production: discovery must never fall back to
+  cleartext, because the relay list is unsigned and a forged one would redirect the whole tunnel.
+  The ONLY exception below is the fixed set of loopback / emulator-host addresses Metro serves the
+  JS bundle from during development. These resolve to the developer's own machine, never to any
+  relay, discovery, or telemetry endpoint, so the production rationale is not weakened. Do not add
+  any other hosts here — a real hostname or routable IP in this list would let debug builds talk
+  cleartext to the network at large.
+-->
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false" />
+    <domain-config cleartextTrafficPermitted="true">
+        <!-- Metro bundler dev hosts only -->
+        <domain includeSubdomains="false">localhost</domain>
+        <domain includeSubdomains="false">127.0.0.1</domain>
+        <!-- Android emulator's alias for the host machine -->
+        <domain includeSubdomains="false">10.0.2.2</domain>
+        <!-- Genymotion's alias for the host machine -->
+        <domain includeSubdomains="false">10.0.3.2</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
## What changed

Adds `android/app/src/debug/res/xml/network_security_config.xml` — a debug-source-set-only override of the network security config. It keeps the identical global cleartext ban (`<base-config cleartextTrafficPermitted="false" />`) and adds one `<domain-config cleartextTrafficPermitted="true">` scoped to the fixed Metro dev hosts: `localhost`, `127.0.0.1`, `10.0.2.2` (emulator host alias), and `10.0.3.2` (Genymotion), all with `includeSubdomains="false"`. No manifest or Gradle changes; Android resource merging substitutes this file for the main config in debug variants only.

## Why

The v0.2.2 HTTPS-only hardening (34f31aa) added a strict network security config with no debug-variant override. Debug builds could therefore no longer fetch the JS bundle from Metro — okhttp fails with `CLEARTEXT communication to 10.0.2.2 not permitted by network security policy`, React Native falls back to a nonexistent asset bundle ("Unable to load script"), and the entire Android dev loop was broken (only workaround: installing release APKs).

## Security notes for reviewers

- The main config's rationale (discovery must never fall back to cleartext because the relay list is unsigned) is preserved: the base-config ban is unchanged, and the whitelisted addresses resolve to the developer's own machine, never to relay/discovery/telemetry endpoints. The file's comment mirrors this reasoning and warns against ever adding a routable host.
- Release builds are provably unaffected:
  - `aapt2 dump xmltree` on the linked release resources (`:app:processReleaseResources`) shows only the strict `<base-config cleartextTrafficPermitted="false" />` — no domain-config.
  - The merged release manifest still references `@xml/network_security_config` from `src/main`.

## Verification

On the Pixel emulator: built and installed `:app:installDebug`, started Metro in the checkout, relaunched the app. Metro log shows `BUNDLE ./index.js` being compiled and served, logcat has no cleartext or "Unable to load script" errors, and the app renders the full home screen from the Metro-served bundle. `aapt2 dump xmltree` on the debug APK confirms the merged config is the dev-host-scoped one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)