### PR TITLE
iOS: drop empty NSLocationWhenInUseUsageDescription (fixes ITMS-90738)

### DIFF
--- a/ios/OpenRung/Info.plist
+++ b/ios/OpenRung/Info.plist
@@ -26,8 +26,6 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string></string>
 	<key>RCTNewArchEnabled</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>


### PR DESCRIPTION
## What

Removes the empty `NSLocationWhenInUseUsageDescription` key from the main app's `Info.plist`.

## Why

Uploading 0.2.4 (build 6) to App Store Connect surfaced a delivery warning:

> **ITMS-90738**: Invalid purpose string value — the `""` value for the `NSLocationWhenInUseUsageDescription` key isn't allowed in `OpenRung.app`.

The key was declared with an empty string — a scaffolding leftover present since the first commit (`4c266c4`). App Store Connect rejects an empty purpose string.

The app uses **no** location APIs: there's no CoreLocation usage in app code, and the MapLibre map shows relay locations, never the user's position (no `showsUserLocation`/`userTrackingMode` anywhere in `src`). Only MapLibre's linked binary (SPM) references CoreLocation, which is what makes Apple's scanner notice the key at all. Per Apple's own guidance, when an app doesn't use the API the correct fix is to remove the purpose string rather than invent one for a permission the app never requests.

## Impact / rollout

- The warning is **non-blocking** — 0.2.4 build 6 already on TestFlight is unaffected and usable for internal testing.
- This fix takes effect on the **next uploaded binary**. The iOS `CURRENT_PROJECT_VERSION` (build number) is intentionally **not** bumped here — that's bumped per store upload, per `RELEASE.md` §6.

## Fallback note for reviewers

If a future upload ever reports a *missing* purpose string (ITMS-90683) because MapLibre's linked CoreLocation symbols are detected, the fallback is to re-add the key with a real, map-oriented string. No evidence that's needed — the app never instantiates a location manager — so removal is the honest first choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)