### PR TITLE
Complete i18n coverage for Settings, About, and all other screens

### DIFF
--- a/__tests__/core/i18nCoverage.test.ts
+++ b/__tests__/core/i18nCoverage.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Locale coverage guard. `stringsForTag` merges `{ ...en, ...override }`, so any key a
+ * locale forgets silently renders in English — which is exactly how the Settings/About
+ * strings drifted out of translation. These tests fail loudly the moment a locale falls
+ * behind `en`, so new keys must be translated everywhere before they can land.
+ *
+ * Imports the raw string tables (pure data, `import type` only) rather than ../../src/i18n,
+ * which would pull the store and require an AsyncStorage mock.
+ */
+import { en, type Strings } from '../../src/i18n/strings/en';
+import { ar } from '../../src/i18n/strings/ar';
+import { fa } from '../../src/i18n/strings/fa';
+import { my } from '../../src/i18n/strings/my';
+import { ru } from '../../src/i18n/strings/ru';
+import { tr } from '../../src/i18n/strings/tr';
+import { vi } from '../../src/i18n/strings/vi';
+import { zhCN } from '../../src/i18n/strings/zh-CN';
+import { zhTW } from '../../src/i18n/strings/zh-TW';
+
+// Every non-English locale in SUPPORTED_TAGS. A new locale must be registered here.
+const overrides: Record<string, Partial<Strings>> = {
+  'zh-CN': zhCN,
+  'zh-TW': zhTW,
+  fa,
+  ru,
+  ar,
+  tr,
+  vi,
+  my,
+};
+
+const enKeys = Object.keys(en) as (keyof Strings)[];
+
+describe('i18n locale coverage', () => {
+  for (const [tag, override] of Object.entries(overrides)) {
+    describe(tag, () => {
+      it('translates every key in en (no English fallback)', () => {
+        const missing = enKeys.filter(key => !(key in override));
+        expect(missing).toEqual([]);
+      });
+
+      it('defines no key that is absent from en (guards typos/renames)', () => {
+        const extra = Object.keys(override).filter(key => !(key in en));
+        expect(extra).toEqual([]);
+      });
+
+      it('matches en value kinds (plain string vs. formatter function)', () => {
+        const mismatched = enKeys.filter(
+          key => typeof override[key] !== typeof en[key],
+        );
+        expect(mismatched).toEqual([]);
+      });
+    });
+  }
+});

--- a/src/i18n/strings/ar.ts
+++ b/src/i18n/strings/ar.ts
@@ -53,4 +53,68 @@ export const ar: Partial<Strings> = {
   telemetryLocationsLabel: 'مواقع',
   telemetryCountriesLabel: 'دول',
   telemetryUptimeLabel: 'مدة الاتصال',
+
+  // Content description (accessibility).
+  openContentDescription: 'فتح',
+
+  // Volunteer speed test (settings + diagnostics).
+  speedTestSettingTitle: 'اختبار سرعة المُرحّل المتطوّع',
+  speedTestReady:
+    'تنزيل 10 MB عبر المُرحّل المتطوّع النشط والإبلاغ عن النتيجة.',
+  speedTestRequiresConnection: 'اتصل بمُرحّل متطوّع قبل إجراء اختبار السرعة.',
+  speedTestRunning: 'جار اختبار سرعة التنزيل عبر المُرحّل المتطوّع…',
+  speedTestResult: (mbps: number) => `سرعة التنزيل: ${mbps.toFixed(1)} Mbps`,
+  speedTestError: (error: string) => `فشل اختبار السرعة: ${error}`,
+  speedTestAction: 'تشغيل',
+
+  // Map view (volunteer exit nodes).
+  mapContentDescription:
+    'خريطة عقد الخروج المتطوّعة المتاحة في منطقة آسيا والمحيط الهادئ',
+  mapLoading: 'جار تحديد مواقع عقد الخروج المتاحة…',
+  mapFailed: 'تعذّر تحميل عقد الخروج — اضغط لإعادة المحاولة',
+  mapNodesAvailable: (count: number) => `${count} موقع متاح`,
+  mapNoNodes: 'لا توجد عقد خروج متاحة الآن',
+
+  // Recents, map/list toggle, and list view.
+  recentsLabel: 'الأخيرة',
+  recentsEmpty: 'لا توجد مواقع حديثة بعد.',
+  viewToggleMap: 'خريطة',
+  viewToggleList: 'قائمة',
+  listContentDescription: 'قائمة عقد الخروج المتطوّعة المتاحة',
+  listRelayCount: (count: number) =>
+    count === 1 ? 'مُرحّل واحد' : `${count} مُرحّلات`,
+
+  // Debug console (diagnostics).
+  debugSettingTitle: 'تصحيح الأخطاء',
+  debugSettingSubtitle: 'وحدة تحكم الاتصال والتشخيص.',
+  debugTitle: 'وحدة تحكم التصحيح',
+
+  // Open-source licenses screen.
+  licensesSettingTitle: 'تراخيص المصدر المفتوح',
+  licensesSettingSubtitle: 'التراخيص والإسناد للبرامج المُضمّنة.',
+  licensesTitle: 'تراخيص المصدر المفتوح',
+  licensesIntro:
+    'OpenRung برمجية حرة مُرخّصة بموجب GPL-3.0-or-later لأنها ترتبط بـ sing-box. الكود المصدري الكامل المقابل لهذا الإصدار متاح عبر الرابط أدناه.',
+  licensesSourceTitle: 'الكود المصدري',
+  licensesFullTextTitle: 'نصوص التراخيص الكاملة',
+  licensesFullTextSubtitle: 'GNU GPL-3.0 وإشعارات الجهات الخارجية.',
+  licensesComponentsHeader: 'المكوّنات',
+
+  // Home overlay and about screen.
+  homeTagline: 'شبكة المُرحّلات المتطوّعة',
+  aboutMissionBody:
+    'يوجّه OpenRung حركة مرورك عبر مُرحّلات يُشغّلها متطوّعون حول العالم، مع إبقاء الإنترنت المفتوح في المتناول عند تصفية الشبكات. بلا حسابات، بلا إعلانات، بلا تتبّع — مجرّد أشخاص يتشاركون عرض النطاق.',
+  aboutHowHeader: 'كيف يعمل',
+  aboutProjectHeader: 'المشروع',
+  aboutHow1Title: 'المتطوّعون يتشاركون عرض النطاق',
+  aboutHow1Body:
+    'يُشغّل أشخاص في كل مكان عُقد ترحيل صغيرة على اتصالاتهم الخاصة ويُسجّلونها لدى الشبكة.',
+  aboutHow2Title: 'الوسيط يعثر على مُرحّلك',
+  aboutHow2Body:
+    'عند الاتصال، يُسلّم الوسيط جهازك قائمة قصيرة بالمُرحّلات السليمة، ويختار التطبيق أوّل مُرحّل يستجيب.',
+  aboutHow3Title: 'المرور يعبُر نفقًا مشفّرًا',
+  aboutHow3Body:
+    'يتدفّق كل شيء عبر نفق VLESS/REALITY يبدو كأنه TLS عادي، ويعمل VPN بوضع fail-closed: لا مرحل، لا مرور.',
+  aboutFootnote:
+    'OpenRung برمجية حرة (GPL-3.0-or-later). بناه متطوّعون، للجميع.',
 };

--- a/src/i18n/strings/fa.ts
+++ b/src/i18n/strings/fa.ts
@@ -53,4 +53,67 @@ export const fa: Partial<Strings> = {
   telemetryLocationsLabel: 'مکان‌ها',
   telemetryCountriesLabel: 'کشورها',
   telemetryUptimeLabel: 'مدت اتصال',
+
+  // Content descriptions.
+  openContentDescription: 'باز کردن',
+
+  // Volunteer speed test.
+  speedTestSettingTitle: 'تست سرعت داوطلب',
+  speedTestReady: 'از طریق رله داوطلب فعال، 10 MB دانلود می‌کند و نتیجه را گزارش می‌دهد.',
+  speedTestRequiresConnection: 'پیش از اجرای تست سرعت، به یک رله داوطلب متصل شوید.',
+  speedTestRunning: 'در حال تست سرعت دانلود از طریق رله داوطلب…',
+  speedTestResult: (mbps: number) => `سرعت دانلود: ${mbps.toFixed(1)} Mbps`,
+  speedTestError: (error: string) => `تست سرعت ناموفق بود: ${error}`,
+  speedTestAction: 'اجرا',
+
+  // Map view (exit nodes).
+  mapContentDescription: 'نقشهٔ گره‌های خروجی داوطلب موجود در سراسر منطقهٔ آسیا-اقیانوسیه',
+  mapLoading: 'در حال یافتن گره‌های خروجی موجود…',
+  mapFailed: 'بارگذاری گره‌های خروجی ناموفق بود — برای تلاش دوباره ضربه بزنید',
+  mapNodesAvailable: (count: number) => `${count} مکان موجود`,
+  mapNoNodes: 'در حال حاضر هیچ گره خروجی موجود نیست',
+
+  // Recent locations.
+  recentsLabel: 'اخیر',
+  recentsEmpty: 'هنوز مکان اخیری وجود ندارد.',
+
+  // Map / list toggle.
+  viewToggleMap: 'نقشه',
+  viewToggleList: 'فهرست',
+  listContentDescription: 'فهرست گره‌های خروجی داوطلب موجود',
+  listRelayCount: (count: number) => (count === 1 ? '1 رله' : `${count} رله`),
+
+  // Debug console.
+  debugSettingTitle: 'اشکال‌زدایی',
+  debugSettingSubtitle: 'کنسول اتصال و عیب‌یابی.',
+  debugTitle: 'کنسول اشکال‌زدایی',
+
+  // Open-source licenses.
+  licensesSettingTitle: 'مجوزهای متن‌باز',
+  licensesSettingSubtitle: 'مجوزها و ذکر منبع برای نرم‌افزارهای همراه.',
+  licensesTitle: 'مجوزهای متن‌باز',
+  licensesIntro:
+    'OpenRung نرم‌افزار آزاد است و چون به sing-box پیوند می‌خورد، تحت مجوز GPL-3.0-or-later منتشر شده است. کد منبع کامل و متناظر این نسخه از طریق پیوند زیر در دسترس است.',
+  licensesSourceTitle: 'کد منبع',
+  licensesFullTextTitle: 'متن کامل مجوزها',
+  licensesFullTextSubtitle: 'GNU GPL-3.0 و اعلان‌های اشخاص ثالث.',
+  licensesComponentsHeader: 'مؤلفه‌ها',
+
+  // Home tagline + about screen.
+  homeTagline: 'شبکهٔ رله‌های داوطلب',
+  aboutMissionBody:
+    'OpenRung ترافیک شما را از طریق رله‌هایی که داوطلبان در سراسر جهان اجرا می‌کنند هدایت می‌کند و دسترسی به اینترنت آزاد را هنگام فیلتر شدن شبکه‌ها حفظ می‌کند. بدون حساب کاربری، بدون تبلیغات، بدون ردیابی — فقط مردمی که پهنای باند خود را به اشتراک می‌گذارند.',
+  aboutHowHeader: 'چگونه کار می‌کند',
+  aboutProjectHeader: 'پروژه',
+  aboutHow1Title: 'داوطلبان پهنای باند را به اشتراک می‌گذارند',
+  aboutHow1Body:
+    'مردم در همه‌جا گره‌های رلهٔ کوچکی را روی اتصال‌های خود اجرا می‌کنند و آن‌ها را در شبکه ثبت می‌کنند.',
+  aboutHow2Title: 'کارگزار رلهٔ شما را پیدا می‌کند',
+  aboutHow2Body:
+    'هنگامی که متصل می‌شوید، کارگزار فهرست کوتاهی از رله‌های سالم را به دستگاه شما می‌دهد و برنامه اولین رله‌ای را که پاسخ دهد انتخاب می‌کند.',
+  aboutHow3Title: 'ترافیک از یک تونل رمزنگاری‌شده عبور می‌کند',
+  aboutHow3Body:
+    'همه‌چیز از طریق یک تونل VLESS/REALITY جریان می‌یابد که شبیه TLS معمولی به نظر می‌رسد، و VPN در حالت fail-closed است: بدون رله، بدون ترافیک.',
+  aboutFootnote:
+    'OpenRung نرم‌افزار آزاد است (GPL-3.0-or-later). ساخته‌شده توسط داوطلبان، برای همه.',
 };

--- a/src/i18n/strings/my.ts
+++ b/src/i18n/strings/my.ts
@@ -55,4 +55,77 @@ export const my: Partial<Strings> = {
   telemetryLocationsLabel: 'တည်နေရာ',
   telemetryCountriesLabel: 'နိုင်ငံ',
   telemetryUptimeLabel: 'ကြာချိန်',
+
+  // Open action (accessibility).
+  openContentDescription: 'ဖွင့်ရန်',
+
+  // Volunteer speed test.
+  speedTestSettingTitle: 'စေတနာ့ဝန်ထမ်း အမြန်နှုန်း စမ်းသပ်ခြင်း',
+  speedTestReady:
+    'လက်ရှိ စေတနာ့ဝန်ထမ်း ရီလေးမှတစ်ဆင့် 10 MB ကို ဒေါင်းလုဒ်လုပ်ပြီး ရလဒ်ကို ဖော်ပြပါ။',
+  speedTestRequiresConnection:
+    'အမြန်နှုန်း စမ်းသပ်မှု မလုပ်မီ စေတနာ့ဝန်ထမ်း ရီလေးတစ်ခုသို့ ချိတ်ဆက်ပါ။',
+  speedTestRunning:
+    'စေတနာ့ဝန်ထမ်း ရီလေးမှတစ်ဆင့် ဒေါင်းလုဒ် အမြန်နှုန်းကို စမ်းသပ်နေသည်…',
+  speedTestResult: (mbps: number) => `ဒေါင်းလုဒ် အမြန်နှုန်း: ${mbps.toFixed(1)} Mbps`,
+  speedTestError: (error: string) => `အမြန်နှုန်း စမ်းသပ်မှု မအောင်မြင်ပါ: ${error}`,
+  speedTestAction: 'စမ်းသပ်မည်',
+
+  // Map view (exit nodes).
+  mapContentDescription:
+    'အာရှ-ပစိဖိတ် ဒေသတစ်ဝှမ်းရှိ ရနိုင်သော စေတနာ့ဝန်ထမ်း ထွက်ပေါက်ဆုံမှတ်များ၏ မြေပုံ',
+  mapLoading: 'ရနိုင်သော ထွက်ပေါက်ဆုံမှတ်များကို ရှာဖွေနေသည်…',
+  mapFailed: 'ထွက်ပေါက်ဆုံမှတ်များ ရယူ၍မရပါ — ပြန်စမ်းရန် တို့ပါ',
+  mapNodesAvailable: (count: number) => `တည်နေရာ ${count} ခု ရနိုင်သည်`,
+  mapNoNodes: 'ယခုအချိန်တွင် ထွက်ပေါက်ဆုံမှတ် မရနိုင်ပါ',
+
+  // Recent locations.
+  recentsLabel: 'မကြာသေးမီက',
+  recentsEmpty: 'မကြာသေးမီက တည်နေရာများ မရှိသေးပါ။',
+
+  // Map / list view toggle.
+  viewToggleMap: 'မြေပုံ',
+  viewToggleList: 'စာရင်း',
+
+  // List view (exit nodes).
+  listContentDescription:
+    'ရနိုင်သော စေတနာ့ဝန်ထမ်း ထွက်ပေါက်ဆုံမှတ်များ၏ စာရင်း',
+  listRelayCount: (count: number) => (count === 1 ? 'ရီလေး 1 ခု' : `ရီလေး ${count} ခု`),
+
+  // Debug console.
+  debugSettingTitle: 'အမှားရှာဖွေခြင်း',
+  debugSettingSubtitle: 'ချိတ်ဆက်မှု ကွန်ဆိုးလ်နှင့် စစ်ဆေးမှုများ။',
+  debugTitle: 'အမှားရှာဖွေရေး ကွန်ဆိုးလ်',
+
+  // Open-source licenses.
+  licensesSettingTitle: 'ပွင့်လင်းအရင်းအမြစ် လိုင်စင်များ',
+  licensesSettingSubtitle:
+    'ပါဝင်သော ဆော့ဖ်ဝဲအတွက် လိုင်စင်များနှင့် ကျေးဇူးတင်လွှာ။',
+  licensesTitle: 'ပွင့်လင်းအရင်းအမြစ် လိုင်စင်များ',
+  licensesIntro:
+    'OpenRung သည် sing-box ကို ချိတ်ဆက်အသုံးပြုသောကြောင့် GPL-3.0-or-later အောက်တွင် လိုင်စင်ရရှိထားသော အခမဲ့ဆော့ဖ်ဝဲ ဖြစ်သည်။ ဤ build အတွက် ပြည့်စုံသော သက်ဆိုင်ရာ အရင်းအမြစ်ကုဒ်ကို အောက်ပါ လင့်ခ်တွင် ရယူနိုင်သည်။',
+  licensesSourceTitle: 'အရင်းအမြစ်ကုဒ်',
+  licensesFullTextTitle: 'လိုင်စင် စာသားအပြည့်အစုံ',
+  licensesFullTextSubtitle: 'GNU GPL-3.0 နှင့် ပြင်ပ အသိပေးချက်များ။',
+  licensesComponentsHeader: 'အစိတ်အပိုင်းများ',
+
+  // Home overlay tagline.
+  homeTagline: 'စေတနာ့ဝန်ထမ်း ရီလေး ကွန်ရက်',
+
+  // About screen (mission / how it works / project).
+  aboutMissionBody:
+    'OpenRung သည် ကမ္ဘာတစ်ဝှမ်းရှိ စေတနာ့ဝန်ထမ်းများ လည်ပတ်သော ရီလေးများမှတစ်ဆင့် သင့်ဒေတာအသွားအလာကို လမ်းကြောင်းချပေးပြီး၊ ကွန်ရက်များ စစ်ထုတ်ပိတ်ဆို့ခံရသည့်အခါ ပွင့်လင်းသော အင်တာနက်ကို ဆက်လက်အသုံးပြုနိုင်စေသည်။ အကောင့်မရှိ၊ ကြော်ငြာမရှိ၊ ခြေရာခံမှုမရှိ — လိုင်းအကျယ် မျှဝေပေးသည့် လူများသာ ဖြစ်သည်။',
+  aboutHowHeader: 'အလုပ်လုပ်ပုံ',
+  aboutProjectHeader: 'ပရောဂျက်',
+  aboutHow1Title: 'စေတနာ့ဝန်ထမ်းများ လိုင်းအကျယ် မျှဝေကြသည်',
+  aboutHow1Body:
+    'နေရာအနှံ့မှ လူများသည် မိမိတို့၏ ချိတ်ဆက်မှုများပေါ်တွင် သေးငယ်သော ရီလေးဆုံမှတ်များကို လည်ပတ်ပြီး ၎င်းတို့ကို ကွန်ရက်တွင် မှတ်ပုံတင်ကြသည်။',
+  aboutHow2Title: 'ကြားခံသည် သင့်ရီလေးကို ရှာဖွေပေးသည်',
+  aboutHow2Body:
+    'သင် ချိတ်ဆက်သည့်အခါ ကြားခံသည် သင့်စက်ပစ္စည်းသို့ ကောင်းမွန်သန်စွမ်းသော ရီလေးများ၏ စာရင်းတိုတစ်ခုကို ပေးအပ်ပြီး အက်ပ်သည် ပထမဆုံး တုံ့ပြန်သည့် ရီလေးကို ရွေးချယ်သည်။',
+  aboutHow3Title: 'ဒေတာအသွားအလာသည် ကုဒ်ဝှက်ထားသော ဥမင်မှတစ်ဆင့် ဖြတ်သန်းသည်',
+  aboutHow3Body:
+    'အရာအားလုံးသည် သာမန် TLS နှင့် တူသော VLESS/REALITY ဥမင်မှတစ်ဆင့် စီးဆင်းသွားပြီး VPN သည် fail-closed ဖြစ်သည်: ရီလေးမရှိလျှင် ဒေတာအသွားအလာ မရှိပါ။',
+  aboutFootnote:
+    'OpenRung သည် အခမဲ့ဆော့ဖ်ဝဲ (GPL-3.0-or-later) ဖြစ်သည်။ စေတနာ့ဝန်ထမ်းများက အားလုံးအတွက် တည်ဆောက်ထားသည်။',
 };

--- a/src/i18n/strings/ru.ts
+++ b/src/i18n/strings/ru.ts
@@ -54,4 +54,65 @@ export const ru: Partial<Strings> = {
   telemetryLocationsLabel: 'локации',
   telemetryCountriesLabel: 'страны',
   telemetryUptimeLabel: 'аптайм',
+
+  // Content description (open action).
+  openContentDescription: 'Открыть',
+
+  // Volunteer speed test (diagnostics).
+  speedTestSettingTitle: 'Волонтёрский тест скорости',
+  speedTestReady: 'Загрузить 10 MB через активный волонтёрский ретранслятор и показать результат.',
+  speedTestRequiresConnection: 'Перед запуском теста скорости подключитесь к волонтёрскому ретранслятору.',
+  speedTestRunning: 'Проверка скорости загрузки через волонтёрский ретранслятор…',
+  speedTestResult: (mbps: number) => `Скорость загрузки: ${mbps.toFixed(1)} Mbps`,
+  speedTestError: (error: string) => `Ошибка теста скорости: ${error}`,
+  speedTestAction: 'ЗАПУСК',
+
+  // Map view (exit-node overview).
+  mapContentDescription: 'Карта доступных волонтёрских выходных узлов в Азиатско-Тихоокеанском регионе',
+  mapLoading: 'поиск доступных выходных узлов…',
+  mapFailed: 'не удалось загрузить выходные узлы — нажмите, чтобы повторить',
+  mapNodesAvailable: (count: number) => `доступно локаций: ${count}`,
+  mapNoNodes: 'сейчас нет доступных выходных узлов',
+
+  // Recents, view toggle & list view.
+  recentsLabel: 'Недавние',
+  recentsEmpty: 'Пока нет недавних локаций.',
+  viewToggleMap: 'Карта',
+  viewToggleList: 'Список',
+  listContentDescription: 'Список доступных волонтёрских выходных узлов',
+  listRelayCount: (count: number) => (count === 1 ? '1 реле' : `${count} реле`),
+
+  // Debug console (diagnostics).
+  debugSettingTitle: 'Отладка',
+  debugSettingSubtitle: 'Консоль подключения и диагностика.',
+  debugTitle: 'Консоль отладки',
+
+  // Open-source licenses.
+  licensesSettingTitle: 'Лицензии с открытым исходным кодом',
+  licensesSettingSubtitle: 'Лицензии и атрибуция для включённого ПО.',
+  licensesTitle: 'Лицензии с открытым исходным кодом',
+  licensesIntro:
+    'OpenRung — свободное программное обеспечение под лицензией GPL-3.0-or-later, поскольку использует sing-box. Полный соответствующий исходный код этой сборки доступен по ссылке ниже.',
+  licensesSourceTitle: 'Исходный код',
+  licensesFullTextTitle: 'Полные тексты лицензий',
+  licensesFullTextSubtitle: 'GNU GPL-3.0 и уведомления третьих сторон.',
+  licensesComponentsHeader: 'Компоненты',
+
+  // Home overlay / about screen.
+  homeTagline: 'волонтёрская сеть ретрансляторов',
+  aboutMissionBody:
+    'OpenRung направляет ваш трафик через ретрансляторы, которыми управляют волонтёры по всему миру, сохраняя открытый интернет доступным, когда сети фильтруются. Без аккаунтов, без рекламы, без слежки — просто люди, делящиеся пропускной способностью.',
+  aboutHowHeader: 'Как это работает',
+  aboutProjectHeader: 'Проект',
+  aboutHow1Title: 'Волонтёры делятся пропускной способностью',
+  aboutHow1Body:
+    'Люди по всему миру запускают небольшие узлы-ретрансляторы на собственных подключениях и регистрируют их в сети.',
+  aboutHow2Title: 'Брокер находит ваш ретранслятор',
+  aboutHow2Body:
+    'Когда вы подключаетесь, брокер передаёт вашему устройству короткий список работающих ретрансляторов, и приложение выбирает первый ответивший.',
+  aboutHow3Title: 'Трафик идёт по зашифрованному туннелю',
+  aboutHow3Body:
+    'Всё проходит через туннель VLESS/REALITY, который выглядит как обычный TLS, а VPN работает fail-closed: нет ретранслятора, нет трафика.',
+  aboutFootnote:
+    'OpenRung — свободное программное обеспечение (GPL-3.0-or-later). Создано волонтёрами для всех.',
 };

--- a/src/i18n/strings/tr.ts
+++ b/src/i18n/strings/tr.ts
@@ -53,4 +53,71 @@ export const tr: Partial<Strings> = {
   telemetryLocationsLabel: 'konumlar',
   telemetryCountriesLabel: 'ülkeler',
   telemetryUptimeLabel: 'süre',
+
+  // Content description for the open action.
+  openContentDescription: 'Aç',
+
+  // Volunteer speed test (diagnostics).
+  speedTestSettingTitle: 'Gönüllü hız testi',
+  speedTestReady: 'Aktif gönüllü röle üzerinden 10 MB indirin ve sonucu bildirin.',
+  speedTestRequiresConnection: 'Hız testini çalıştırmadan önce bir gönüllü röleye bağlanın.',
+  speedTestRunning: 'Gönüllü röle üzerinden indirme hızı test ediliyor…',
+  speedTestResult: (mbps: number) => `İndirme hızı: ${mbps.toFixed(1)} Mbps`,
+  speedTestError: (error: string) => `Hız testi başarısız: ${error}`,
+  speedTestAction: 'ÇALIŞTIR',
+
+  // Exit node map view.
+  mapContentDescription: 'Asya-Pasifik bölgesindeki mevcut gönüllü çıkış düğümlerinin haritası',
+  mapLoading: 'mevcut çıkış düğümleri bulunuyor…',
+  mapFailed: 'çıkış düğümleri yüklenemedi — yeniden denemek için dokunun',
+  mapNodesAvailable: (count: number) => `${count} konum mevcut`,
+  mapNoNodes: 'şu anda mevcut çıkış düğümü yok',
+
+  // Recent locations.
+  recentsLabel: 'Son kullanılanlar',
+  recentsEmpty: 'Henüz son kullanılan konum yok.',
+
+  // Map / list view toggle.
+  viewToggleMap: 'Harita',
+  viewToggleList: 'Liste',
+
+  // Exit node list view.
+  listContentDescription: 'Mevcut gönüllü çıkış düğümlerinin listesi',
+  listRelayCount: (count: number) => (count === 1 ? '1 röle' : `${count} röle`),
+
+  // Debug console (diagnostics).
+  debugSettingTitle: 'Hata ayıklama',
+  debugSettingSubtitle: 'Bağlantı konsolu ve tanılama.',
+  debugTitle: 'Hata ayıklama konsolu',
+
+  // Open-source licenses screen.
+  licensesSettingTitle: 'Açık kaynak lisansları',
+  licensesSettingSubtitle: 'Paketlenmiş yazılımlar için lisanslar ve atıflar.',
+  licensesTitle: 'Açık kaynak lisansları',
+  licensesIntro:
+    "OpenRung, sing-box'a bağlandığı için GPL-3.0-or-later ile lisanslanan özgür bir yazılımdır. Bu derlemeye karşılık gelen eksiksiz kaynak kodu aşağıdaki bağlantıda mevcuttur.",
+  licensesSourceTitle: 'Kaynak kodu',
+  licensesFullTextTitle: 'Tam lisans metinleri',
+  licensesFullTextSubtitle: 'GNU GPL-3.0 ve üçüncü taraf bildirimleri.',
+  licensesComponentsHeader: 'Bileşenler',
+
+  // Home overlay tagline.
+  homeTagline: 'gönüllü röle ağı',
+
+  // About screen (mission, how it works, project).
+  aboutMissionBody:
+    'OpenRung, trafiğinizi dünyanın dört bir yanındaki gönüllülerin çalıştırdığı röleler üzerinden yönlendirir; böylece ağlar filtrelendiğinde açık internet erişilebilir kalır. Hesap yok, reklam yok, takip yok — yalnızca bant genişliğini paylaşan insanlar.',
+  aboutHowHeader: 'Nasıl çalışır',
+  aboutProjectHeader: 'Proje',
+  aboutHow1Title: 'Gönüllüler bant genişliği paylaşır',
+  aboutHow1Body:
+    'Dünyanın her yerindeki insanlar kendi bağlantıları üzerinde küçük röle düğümleri çalıştırır ve bunları ağa kaydeder.',
+  aboutHow2Title: 'Aracı rölenizi bulur',
+  aboutHow2Body:
+    'Bağlandığınızda aracı, cihazınıza sağlıklı rölelerden oluşan kısa bir liste verir ve uygulama yanıt veren ilk röleyi seçer.',
+  aboutHow3Title: 'Trafik şifreli bir tünelden geçer',
+  aboutHow3Body:
+    'Her şey, sıradan TLS gibi görünen bir VLESS/REALITY tüneli üzerinden akar ve VPN fail-closed çalışır: röle yoksa trafik yok.',
+  aboutFootnote:
+    'OpenRung özgür bir yazılımdır (GPL-3.0-or-later). Gönüllüler tarafından, herkes için geliştirildi.',
 };

--- a/src/i18n/strings/vi.ts
+++ b/src/i18n/strings/vi.ts
@@ -53,4 +53,64 @@ export const vi: Partial<Strings> = {
   telemetryLocationsLabel: 'địa điểm',
   telemetryCountriesLabel: 'quốc gia',
   telemetryUptimeLabel: 'thời lượng',
+
+  // Content description (open action).
+  openContentDescription: 'Mở',
+
+  // Volunteer speed test (diagnostics).
+  speedTestSettingTitle: 'Kiểm tra tốc độ relay tình nguyện',
+  speedTestReady: 'Tải xuống 10 MB qua relay tình nguyện đang hoạt động và báo cáo kết quả.',
+  speedTestRequiresConnection: 'Kết nối với relay tình nguyện trước khi chạy kiểm tra tốc độ.',
+  speedTestRunning: 'Đang kiểm tra tốc độ tải xuống qua relay tình nguyện…',
+  speedTestResult: (mbps: number) => `Tốc độ tải xuống: ${mbps.toFixed(1)} Mbps`,
+  speedTestError: (error: string) => `Kiểm tra tốc độ thất bại: ${error}`,
+  speedTestAction: 'CHẠY',
+
+  // Map and list views (exit nodes).
+  mapContentDescription:
+    'Bản đồ các nút thoát tình nguyện khả dụng khắp khu vực Châu Á - Thái Bình Dương',
+  mapLoading: 'đang định vị các nút thoát khả dụng…',
+  mapFailed: 'không tải được các nút thoát — nhấn để thử lại',
+  mapNodesAvailable: (count: number) => `${count} địa điểm khả dụng`,
+  mapNoNodes: 'hiện không có nút thoát nào khả dụng',
+  recentsLabel: 'Gần đây',
+  recentsEmpty: 'Chưa có địa điểm gần đây.',
+  viewToggleMap: 'Bản đồ',
+  viewToggleList: 'Danh sách',
+  listContentDescription: 'Danh sách các nút thoát tình nguyện khả dụng',
+  listRelayCount: (count: number) => (count === 1 ? '1 relay' : `${count} relay`),
+
+  // Debug console (diagnostics).
+  debugSettingTitle: 'Gỡ lỗi',
+  debugSettingSubtitle: 'Bảng điều khiển kết nối và chẩn đoán.',
+  debugTitle: 'Bảng điều khiển gỡ lỗi',
+
+  // Open-source licenses.
+  licensesSettingTitle: 'Giấy phép nguồn mở',
+  licensesSettingSubtitle: 'Giấy phép và ghi công cho phần mềm đi kèm.',
+  licensesTitle: 'Giấy phép nguồn mở',
+  licensesIntro:
+    'OpenRung là phần mềm tự do được cấp phép theo GPL-3.0-or-later vì nó liên kết sing-box. Toàn bộ mã nguồn tương ứng của bản dựng này có sẵn tại liên kết bên dưới.',
+  licensesSourceTitle: 'Mã nguồn',
+  licensesFullTextTitle: 'Toàn văn giấy phép',
+  licensesFullTextSubtitle: 'GNU GPL-3.0 và thông báo của bên thứ ba.',
+  licensesComponentsHeader: 'Thành phần',
+
+  // Home overlay and about screen.
+  homeTagline: 'mạng lưới relay tình nguyện',
+  aboutMissionBody:
+    'OpenRung định tuyến lưu lượng của bạn qua các relay do tình nguyện viên khắp thế giới vận hành, giữ cho internet mở luôn truy cập được khi mạng bị lọc chặn. Không tài khoản, không quảng cáo, không theo dõi — chỉ là những người chia sẻ băng thông.',
+  aboutHowHeader: 'Cách hoạt động',
+  aboutProjectHeader: 'Dự án',
+  aboutHow1Title: 'Tình nguyện viên chia sẻ băng thông',
+  aboutHow1Body:
+    'Mọi người khắp nơi vận hành các nút relay nhỏ trên kết nối của chính họ và đăng ký chúng với mạng lưới.',
+  aboutHow2Title: 'Bộ điều phối tìm relay cho bạn',
+  aboutHow2Body:
+    'Khi bạn kết nối, bộ điều phối trao cho thiết bị của bạn một danh sách ngắn các relay khỏe mạnh và ứng dụng chọn relay đầu tiên phản hồi.',
+  aboutHow3Title: 'Lưu lượng đi qua đường hầm mã hóa',
+  aboutHow3Body:
+    'Mọi thứ đều đi qua một đường hầm VLESS/REALITY trông như TLS thông thường, và VPN ở chế độ fail-closed: không có relay, không có lưu lượng.',
+  aboutFootnote:
+    'OpenRung là phần mềm tự do (GPL-3.0-or-later). Được xây dựng bởi tình nguyện viên, cho mọi người.',
 };

--- a/src/i18n/strings/zh-CN.ts
+++ b/src/i18n/strings/zh-CN.ts
@@ -53,4 +53,69 @@ export const zhCN: Partial<Strings> = {
   telemetryLocationsLabel: '地点',
   telemetryCountriesLabel: '国家',
   telemetryUptimeLabel: '在线时长',
+
+  // Generic open affordance (accessibility).
+  openContentDescription: '打开',
+
+  // Volunteer speed test (settings screen).
+  speedTestSettingTitle: '志愿者测速',
+  speedTestReady: '通过当前活动的志愿者中继下载 10 MB 并报告结果。',
+  speedTestRequiresConnection: '请先连接志愿者中继，再运行测速。',
+  speedTestRunning: '正在通过志愿者中继测试下载速度…',
+  speedTestResult: (mbps: number) => `下载速度：${mbps.toFixed(1)} Mbps`,
+  speedTestError: (error: string) => `测速失败：${error}`,
+  speedTestAction: '运行',
+
+  // Map view (volunteer exit nodes).
+  mapContentDescription: '亚太地区可用志愿者出口节点的地图',
+  mapLoading: '正在定位可用的出口节点…',
+  mapFailed: '无法加载出口节点 — 点按重试',
+  mapNodesAvailable: (count: number) => `${count} 个地点可用`,
+  mapNoNodes: '当前没有可用的出口节点',
+
+  // Recent locations.
+  recentsLabel: '最近使用',
+  recentsEmpty: '暂无最近使用的地点。',
+
+  // Map / list view toggle.
+  viewToggleMap: '地图',
+  viewToggleList: '列表',
+
+  // List view (volunteer exit nodes).
+  listContentDescription: '可用志愿者出口节点列表',
+  listRelayCount: (count: number) => (count === 1 ? '1 个中继' : `${count} 个中继`),
+
+  // Debug console (diagnostics).
+  debugSettingTitle: '调试',
+  debugSettingSubtitle: '连接控制台与诊断信息。',
+  debugTitle: '调试控制台',
+
+  // Open-source licenses.
+  licensesSettingTitle: '开源许可',
+  licensesSettingSubtitle: '捆绑软件的许可与署名。',
+  licensesTitle: '开源许可',
+  licensesIntro:
+    'OpenRung 是自由软件，依据 GPL-3.0-or-later 授权，因为它链接了 sing-box。本次构建的完整对应源代码可通过下方链接获取。',
+  licensesSourceTitle: '源代码',
+  licensesFullTextTitle: '完整许可文本',
+  licensesFullTextSubtitle: 'GNU GPL-3.0 及第三方声明。',
+  licensesComponentsHeader: '组件',
+
+  // Home tagline and about screen.
+  homeTagline: '志愿者中继网络',
+  aboutMissionBody:
+    'OpenRung 通过世界各地志愿者运行的中继来路由你的流量，在网络被过滤时依然让开放互联网保持可达。没有账户、没有广告、没有追踪 — 只有人们共享带宽。',
+  aboutHowHeader: '工作原理',
+  aboutProjectHeader: '项目',
+  aboutHow1Title: '志愿者共享带宽',
+  aboutHow1Body:
+    '世界各地的人们在自己的网络连接上运行小型中继节点，并将其注册到网络中。',
+  aboutHow2Title: '中介为你找到中继',
+  aboutHow2Body:
+    '当你连接时，中介会向你的设备提供一份健康中继的简短列表，应用会选择第一个响应的中继。',
+  aboutHow3Title: '流量通过加密隧道传输',
+  aboutHow3Body:
+    '所有流量都通过一条看起来像普通 TLS 的 VLESS/REALITY 隧道传输，并且 VPN 采用失败关闭：没有中继，就没有流量。',
+  aboutFootnote:
+    'OpenRung 是自由软件（GPL-3.0-or-later）。由志愿者打造，为所有人服务。',
 };

--- a/src/i18n/strings/zh-TW.ts
+++ b/src/i18n/strings/zh-TW.ts
@@ -53,4 +53,61 @@ export const zhTW: Partial<Strings> = {
   telemetryLocationsLabel: '地點',
   telemetryCountriesLabel: '國家',
   telemetryUptimeLabel: '連線時長',
+
+  // Open control + volunteer speed test.
+  openContentDescription: '開啟',
+  speedTestSettingTitle: '志願者速度測試',
+  speedTestReady: '透過使用中的志願者中繼下載 10 MB 並回報結果。',
+  speedTestRequiresConnection: '執行速度測試前，請先連線至志願者中繼。',
+  speedTestRunning: '正在透過志願者中繼測試下載速度…',
+  speedTestResult: (mbps: number) => `下載速度：${mbps.toFixed(1)} Mbps`,
+  speedTestError: (error: string) => `速度測試失敗：${error}`,
+  speedTestAction: '執行',
+
+  // Map / list views.
+  mapContentDescription: '橫跨亞太地區的可用志願者出口節點地圖',
+  mapLoading: '正在尋找可用的出口節點…',
+  mapFailed: '無法載入出口節點 — 點選以重試',
+  mapNodesAvailable: (count: number) => `${count} 個地點可用`,
+  mapNoNodes: '目前沒有可用的出口節點',
+  recentsLabel: '最近使用',
+  recentsEmpty: '尚無最近使用的地點。',
+  viewToggleMap: '地圖',
+  viewToggleList: '清單',
+  listContentDescription: '可用志願者出口節點的清單',
+  listRelayCount: (count: number) => (count === 1 ? '1 個中繼' : `${count} 個中繼`),
+
+  // Debug console.
+  debugSettingTitle: '除錯',
+  debugSettingSubtitle: '連線主控台與診斷。',
+  debugTitle: '除錯主控台',
+
+  // Open-source licenses.
+  licensesSettingTitle: '開放原始碼授權',
+  licensesSettingSubtitle: '隨附軟體的授權與出處標示。',
+  licensesTitle: '開放原始碼授權',
+  licensesIntro:
+    'OpenRung 是自由軟體；由於連結了 sing-box，因此依 GPL-3.0-or-later 授權。此版本的完整對應原始碼可透過下方連結取得。',
+  licensesSourceTitle: '原始碼',
+  licensesFullTextTitle: '完整授權條款全文',
+  licensesFullTextSubtitle: 'GNU GPL-3.0 與第三方聲明。',
+  licensesComponentsHeader: '元件',
+
+  // Home tagline + about screen.
+  homeTagline: '志願者中繼網路',
+  aboutMissionBody:
+    'OpenRung 會透過世界各地志願者營運的中繼路由你的流量，在網路遭到過濾時，仍讓開放的網際網路保持可連線。沒有帳號、沒有廣告、沒有追蹤 — 只有人們彼此分享頻寬。',
+  aboutHowHeader: '運作方式',
+  aboutProjectHeader: '專案',
+  aboutHow1Title: '志願者分享頻寬',
+  aboutHow1Body:
+    '世界各地的人們會在自己的網路連線上架設小型中繼節點，並向網路註冊。',
+  aboutHow2Title: '中介為你找到中繼',
+  aboutHow2Body:
+    '當你連線時，中介會將一份簡短的健康中繼清單交給你的裝置，而應用程式會挑選第一個有回應的中繼。',
+  aboutHow3Title: '流量行經加密通道',
+  aboutHow3Body:
+    '一切都會流經看起來就像一般 TLS 的 VLESS/REALITY 通道，而 VPN 採用失敗關閉：沒有中繼，就沒有流量。',
+  aboutFootnote:
+    'OpenRung 是自由軟體（GPL-3.0-or-later）。由志願者打造，獻給每一個人。',
 };


### PR DESCRIPTION
## What & why

The Settings and About screens were showing English text in every non-English language. The screens themselves were fine — they already render through `useStrings()`. The bug was in the **translation data**: `stringsForTag` merges `{ ...en, ...override }`, so any key a locale omits silently falls back to English.

During the shell redesign, **41 keys were added to `en.ts` and never propagated to any locale file** — all 8 non-English locales were missing the *same* 41 keys:

- **23 on Settings/About** — volunteer speed test, debug, open-source licenses, and the entire "About us" mission / how-it-works / footnote.
- **18 more** on the map, recents, list-toggle, and licenses screens.

## Changes

| Area | Change |
|---|---|
| `src/i18n/strings/{zh-CN,zh-TW,fa,ru,ar,tr,vi,my}.ts` | Added all 41 missing keys, translated — **510 insertions, 0 deletions** (no existing key modified) |
| `__tests__/core/i18nCoverage.test.ts` | New regression guard: fails whenever any locale falls behind `en` |

Each language matches the terminology already established in its own file (e.g. relay → 中继/中繼/röle/реле/رله). Brand/protocol tokens (`OpenRung`, `VLESS/REALITY`, `TLS`, `GPL-3.0-or-later`, `Mbps`) are kept verbatim, and the four formatter-valued keys (`speedTestResult`, `speedTestError`, `mapNodesAvailable`, `listRelayCount`) preserve their exact signatures and `${…}` interpolations.

## Verification

- **Coverage:** 0 missing keys across all 8 locales (was 41 each).
- **`tsc --noEmit`:** clean — guarantees every added key is a real `Strings` member (no typos/excess props) and all four formatter signatures match.
- **`eslint`:** clean for all changed files.
- **`jest`:** 9 suites / 93 tests pass (this PR adds 1 suite / 24 tests). The new test would have caught this exact drift.

## Reviewer notes

- The **root cause was the missing test** — nothing enforced locale completeness, so keys drifted unnoticed. The new test closes that gap; any future key added to `en.ts` without translations will fail CI.
- Changes are data + a test only; no screen/logic code changed. The render path for these keys is identical to the already-working translated keys.
- I did **not** do an on-device pass. Worth spot-checking the RTL languages (fa/ar) on a simulator. Note the existing caveat: switching to fa/ar updates strings but doesn't relayout RTL without an app restart.
