### PR TITLE
Lower default tunnel MTU from 1500 to 1400

### DIFF
--- a/android/app/src/main/java/com/openrung/net/SingBoxConfiguration.kt
+++ b/android/app/src/main/java/com/openrung/net/SingBoxConfiguration.kt
@@ -17,7 +17,7 @@ data class SingBoxConfiguration(
     val tunnelIPv4Address: String = "172.19.0.1/30",
     val tunnelIPv6Address: String = "fdfe:dcba:9876::1/126",
     val dnsServers: List<String> = listOf("1.1.1.1", "8.8.8.8"),
-    val mtu: Int = 1500,
+    val mtu: Int = 1400,
 ) {
     fun encodedJsonString(): String {
         validateRelay()

--- a/ios/OpenRung.xcodeproj/project.pbxproj
+++ b/ios/OpenRung.xcodeproj/project.pbxproj
@@ -646,7 +646,7 @@
 					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
 					"\"$(inherited)\"",
 				);
-				MARKETING_VERSION = 0.2.4;
+				MARKETING_VERSION = 0.2.5;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -781,7 +781,7 @@
 					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
 					"\"$(inherited)\"",
 				);
-				MARKETING_VERSION = 0.2.4;
+				MARKETING_VERSION = 0.2.5;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				OTHER_CFLAGS = (

--- a/ios/Shared/SingBoxConfiguration.swift
+++ b/ios/Shared/SingBoxConfiguration.swift
@@ -12,7 +12,7 @@ public struct SingBoxConfiguration: Equatable, Sendable {
         tunnelIPv4Address: String = "172.19.0.1/30",
         tunnelIPv6Address: String = "fdfe:dcba:9876::1/126",
         dnsServers: [String] = ["1.1.1.1", "8.8.8.8"],
-        mtu: Int = 1500
+        mtu: Int = 1400
     ) {
         self.relay = relay
         self.tunnelIPv4Address = tunnelIPv4Address

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openrung-mobile-app",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
## What

Lowers the default TUN MTU from **1500 → 1400** on both Android and iOS.

- [`android/.../net/SingBoxConfiguration.kt`](android/app/src/main/java/com/openrung/net/SingBoxConfiguration.kt) — `mtu: Int = 1400`
- [`ios/Shared/SingBoxConfiguration.swift`](ios/Shared/SingBoxConfiguration.swift) — `mtu: Int = 1400`

## Why

A user behind a restrictive network reported the app reaching **connected** but being unable to load Google/YouTube. The connect path only reports connected after a mandatory internet probe (`generate_204`) succeeds *through the tunnel* — so the tunnel was carrying traffic, yet real browsing stalled.

That signature — tiny requests succeed, large transfers hang — is the classic **MTU/PMTU blackhole**: 1500-byte packets exceed the VLESS/REALITY path's effective MTU, PMTU discovery is blackholed, so full-size TLS handshakes and responses never complete while the one-packet probe sails through. Dropping to 1400 leaves headroom for tunnel/encapsulation overhead.

## Scope / notes

- The value flows end-to-end: both configs write it into the tun inbound `mtu`, and libbox applies it to the interface (Android `builder.setMtu`, iOS `settings.mtu`).
- No tests assert the MTU value, so nothing else changed. The `.design-sync` previews reference `mtu 1380` but those are cosmetic mock log strings, untouched.
- **Only takes effect in a fresh native build** (new APK / iOS build) — not via Metro reload against a stale binary.
- MTU remains client-only/hard-coded; making it broker- or volunteer-tunable (per-relay `mtu` field, broker-clamped) was considered and deferred.
- If 1400 proves insufficient for some relays, **1280** is the safe floor (IPv6 minimum).

🤖 Generated with [Claude Code](https://claude.com/claude-code)