### PR TITLE
Report explicit os_name in telemetry device attributes

### DIFF
--- a/android/app/src/main/java/com/openrung/telemetry/TelemetryManager.kt
+++ b/android/app/src/main/java/com/openrung/telemetry/TelemetryManager.kt
@@ -255,6 +255,7 @@ object TelemetryManager {
         val capabilities = connectivity.getNetworkCapabilities(connectivity.activeNetwork)
         return mapOf(
             "app_version" to BuildConfig.VERSION_NAME,
+            "os_name" to "android",
             "android_api" to Build.VERSION.SDK_INT.toString(),
             "device_manufacturer" to Build.MANUFACTURER,
             "device_model" to Build.MODEL,

--- a/ios/Shared/DeviceAttributes.swift
+++ b/ios/Shared/DeviceAttributes.swift
@@ -38,6 +38,7 @@ public enum DeviceAttributes {
         let path = NetworkPathMonitor.shared.currentSnapshot
         return [
             "app_version": appVersion,
+            "os_name": "ios",
             "ios_version": osVersion,
             "device_manufacturer": "Apple",
             "device_model": deviceModel,


### PR DESCRIPTION
## What

Adds an explicit `os_name` attribute (`"ios"` / `"android"`) to the per-platform device-attribute map that is merged into every telemetry event.

- iOS — `ios/Shared/DeviceAttributes.swift` → `"os_name": "ios"`
- Android — `android/app/src/main/java/com/openrung/telemetry/TelemetryManager.kt` → `"os_name": "android"`

## Why

The iOS client wasn't reporting its OS name to broker telemetry. Root cause: **neither** platform ever sent an explicit OS-name field. The event envelope has no `os_name`/`platform` field, and the only OS signal was a platform-specific *version* key inside `attributes`:

| | Android | iOS |
|---|---|---|
| OS version key | `android_api` (`Build.VERSION.SDK_INT`) | `ios_version` (`UIDevice.systemVersion`) |
| Explicit `os_name` | ❌ absent | ❌ absent |

Because the OS was only inferable from *which version key was present*, the broker recognized Android's `android_api` but not iOS's `ios_version`, so iOS rows landed with no resolvable OS name. Adding a stable, symmetric `os_name` to both maps makes the OS name explicit rather than inferred.

## Notes for reviewers

- Version keys are unchanged — each event now carries both `os_name` and its existing version key (e.g. iOS: `os_name: "ios"` + `ios_version: "17.5.1"`).
- Added `os_name` to **Android too** (not just iOS) so the broker can key off one stable field on both platforms instead of two platform-specific version keys.
- **Broker-side not verified from this repo.** Ingestion/broker code lives elsewhere; whether iOS rows now display an OS name depends on the broker reading the new `os_name` attribute. Worth confirming ingestion consumes it (and ideally prefers it over inferring from the version keys).
- Pre-existing asymmetry left untouched (out of scope for this minimal fix): `ios_version` is a marketing version string (`17.5.1`) while `android_api` is the SDK API level (`34`).
- No tests assert on the device-attribute map shape, so nothing else is affected. Source edits only — not build-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)