### PR TITLE
Classify connection failures into shared reason enum (Android + iOS)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -137,6 +137,14 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
     }
+
+    testOptions {
+        unitTests {
+            // FailureClassifierErrnoTest runs under Robolectric, which needs the merged
+            // Android resources available to the JVM unit-test classpath.
+            includeAndroidResources = true
+        }
+    }
 }
 
 // Refuse to *assemble* a release without a real signing key rather than silently
@@ -183,4 +191,11 @@ dependencies {
     } else {
         implementation jscFlavor
     }
+
+    // Unit tests for the vpn failure classifier. Robolectric supplies real android.system
+    // OsConstants values and a working ErrnoException so the errno-based classification
+    // (connection_refused/reset/network_unreachable/…) can be exercised on the JVM — a plain
+    // stubbed android.jar reports every OsConstants value as 0.
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("org.robolectric:robolectric:4.14.1")
 }

--- a/android/app/src/main/java/com/openrung/net/BrokerClient.kt
+++ b/android/app/src/main/java/com/openrung/net/BrokerClient.kt
@@ -14,6 +14,14 @@ import java.net.URI
 import java.net.URL
 import java.net.URLEncoder
 
+/**
+ * A non-2xx HTTP response from the broker. Carries the status [code] so a failure can be classified
+ * (429 → `rate_limited`, otherwise `http_<code>`) instead of being flattened into a generic
+ * [IOException] message where the code is lost. Extends [IOException] so existing callers — which
+ * already treat broker failures as `IOException` — are unaffected.
+ */
+class BrokerHttpException(val status: Int, message: String) : IOException(message)
+
 class BrokerClient(
     private val baseUrl: String,
     private val json: Json = Json { ignoreUnknownKeys = true },
@@ -48,7 +56,10 @@ class BrokerClient(
             val body = stream.bufferedReader().use { it.readText() }
             if (status !in 200..299) {
                 val apiError = runCatching { json.decodeFromString<ErrorResponse>(body).error }.getOrNull()
-                throw IOException("broker list relays: ${apiError?.ifBlank { null } ?: body.ifBlank { connection.responseMessage }}")
+                throw BrokerHttpException(
+                    status,
+                    "broker list relays: ${apiError?.ifBlank { null } ?: body.ifBlank { connection.responseMessage }}",
+                )
             }
             json.decodeFromString<RelayListResponse>(body)
         } finally {

--- a/android/app/src/main/java/com/openrung/vpn/FailureClassifier.kt
+++ b/android/app/src/main/java/com/openrung/vpn/FailureClassifier.kt
@@ -1,0 +1,157 @@
+package com.openrung.vpn
+
+import android.system.ErrnoException
+import android.system.OsConstants
+import com.openrung.net.BrokerHttpException
+import java.io.InterruptedIOException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+import java.util.Collections
+import java.util.IdentityHashMap
+import java.util.concurrent.CancellationException
+import javax.net.ssl.SSLException
+
+/**
+ * Classifies a connection failure into a stable, lowercase snake_case reason token shared with the
+ * OpenRung Go clients (desktop/CLI) and honored by the broker's "Failure reasons" dashboard.
+ *
+ * The token set and the classification precedence mirror the Go classifier
+ * (`internal/clienttelemetry/classify.go` in the sibling `openrung` repo):
+ * cancellation → relay-selection sentinels → broker HTTP status → socket errno →
+ * DNS (before generic timeout, the more actionable signal) → TLS → permission →
+ * engine-exit → generic timeout → `unknown`.
+ *
+ * The entire `cause` chain is inspected, so a real root cause (e.g. a [SocketTimeoutException]
+ * wrapped in an `IllegalStateException` by the connect pipeline) is classified on its merits rather
+ * than reported as the generic wrapper class — which is why the dashboard used to show
+ * `relay_connect · IllegalStateException`.
+ */
+object FailureClassifier {
+    private const val MAX_DETAIL_BYTES = 256
+
+    /** Returns the reason token for [error], or `""` when [error] is null. */
+    fun classify(error: Throwable?): String {
+        if (error == null) return ""
+        val chain = causeChain(error)
+
+        // (1) cancellation (user stop / coroutine cancellation)
+        if (chain.any { it is CancellationException }) return "cancelled"
+
+        // (2) app relay-selection sentinels
+        chain.firstNotNullOfOrNull { it as? RelaySelectionException }?.let {
+            return when (it) {
+                is RelaySelectionException.NoRelaysAvailable -> "no_relays_available"
+                is RelaySelectionException.RelayNotInList -> "relay_not_in_list"
+                is RelaySelectionException.NoRelayInCountry -> "no_relay_in_country"
+                is RelaySelectionException.NoUsableRelay -> "no_usable_relay"
+            }
+        }
+
+        // (3) broker HTTP status (429 → rate_limited, else http_<code>)
+        chain.firstNotNullOfOrNull { it as? BrokerHttpException }?.let {
+            return if (it.status == 429) "rate_limited" else "http_${it.status}"
+        }
+
+        // (4) socket errno — refused / reset / unreachable. EACCES/EPERM and ETIMEDOUT are handled
+        // later (permission / timeout) to match the Go errno switch, which only maps these three.
+        val errno = chain.firstNotNullOfOrNull { it as? ErrnoException }
+        errno?.let {
+            when (it.errno) {
+                OsConstants.ECONNREFUSED -> return "connection_refused"
+                OsConstants.ECONNRESET -> return "connection_reset"
+                OsConstants.ENETUNREACH, OsConstants.EHOSTUNREACH -> return "network_unreachable"
+            }
+        }
+
+        // (5) DNS — before generic timeout, so a name-lookup timeout reports as dns_failure.
+        if (chain.any { it is UnknownHostException }) return "dns_failure"
+
+        // (6) TLS / SSL handshake or certificate failure (SSLHandshakeException is an SSLException).
+        if (chain.any { it is SSLException }) return "tls_handshake"
+
+        // (7) OS-denied permission (revoked VPN consent, EACCES/EPERM).
+        if (chain.any { it is SecurityException }) return "permission_denied"
+        errno?.let {
+            if (it.errno == OsConstants.EACCES || it.errno == OsConstants.EPERM) {
+                return "permission_denied"
+            }
+        }
+
+        // (8) embedded proxy engine failed to start / stopped unexpectedly.
+        if (chain.any { it is EngineStartException }) return "process_exited"
+
+        // (9) generic timeout — only after the typed checks above.
+        errno?.let { if (it.errno == OsConstants.ETIMEDOUT) return "timeout" }
+        // SocketTimeoutException is an InterruptedIOException; the base type also covers a bare
+        // connect/read timeout raised without the more specific subclass.
+        if (chain.any { it is InterruptedIOException }) return "timeout"
+
+        return "unknown"
+    }
+
+    /**
+     * The root cause's message (falling back to the outermost error's), truncated to fit the
+     * broker's 256-UTF-8-byte attribute limit. Returns `""` when there is no usable message.
+     */
+    fun detail(error: Throwable?): String {
+        if (error == null) return ""
+        val chain = causeChain(error)
+        val message = chain.last().message?.takeIf { it.isNotBlank() }
+            ?: error.message?.takeIf { it.isNotBlank() }
+            ?: return ""
+        return truncateToBytes(message, MAX_DETAIL_BYTES)
+    }
+
+    /**
+     * Truncates [value] to at most [maxBytes] UTF-8 bytes without splitting a multi-byte character:
+     * the boundary is backed off past any UTF-8 continuation byte (`0b10xxxxxx`) so the result is
+     * always decodable. The broker rejects attribute values whose UTF-8 encoding exceeds 256 bytes.
+     */
+    internal fun truncateToBytes(value: String, maxBytes: Int = MAX_DETAIL_BYTES): String {
+        if (value.isEmpty()) return value
+        val bytes = value.toByteArray(Charsets.UTF_8)
+        if (bytes.size <= maxBytes) return value
+        var end = maxBytes
+        while (end > 0 && (bytes[end].toInt() and 0xC0) == 0x80) end--
+        return String(bytes, 0, end, Charsets.UTF_8)
+    }
+
+    /** Self (plus every distinct `cause`) from the outermost error down to the root, cycle-safe. */
+    private fun causeChain(error: Throwable): List<Throwable> {
+        val chain = ArrayList<Throwable>()
+        val seen = Collections.newSetFromMap(IdentityHashMap<Throwable, Boolean>())
+        var current: Throwable? = error
+        while (current != null && seen.add(current)) {
+            chain.add(current)
+            current = current.cause
+        }
+        return chain
+    }
+}
+
+/**
+ * Relay-selection failures raised by the connect pipeline. A typed hierarchy (rather than a bare
+ * `IllegalStateException` from `check(...)`) lets [FailureClassifier] map each to its stable reason
+ * token without matching on the user-facing message text.
+ */
+sealed class RelaySelectionException(message: String) : Exception(message) {
+    /** Broker returned an empty / all-unusable relay list. */
+    class NoRelaysAvailable(message: String) : RelaySelectionException(message)
+
+    /** A targeted exact relay id was not present in the list. */
+    class RelayNotInList(message: String) : RelaySelectionException(message)
+
+    /** A targeted country had no usable relay. */
+    class NoRelayInCountry(message: String) : RelaySelectionException(message)
+
+    /** No relay passed the usability filter (generic). */
+    class NoUsableRelay(message: String) : RelaySelectionException(message)
+}
+
+/**
+ * Raised when the embedded proxy engine (libbox/sing-box) fails to start or stops unexpectedly.
+ * Maps to `process_exited` for parity with the Go clients, which run sing-box as a subprocess.
+ * The originating error is kept as the [cause] so a higher-precedence signal in the chain (a
+ * revoked-permission [SecurityException], a socket errno, …) still wins over `process_exited`.
+ */
+class EngineStartException(message: String?, cause: Throwable?) : Exception(message, cause)

--- a/android/app/src/main/java/com/openrung/vpn/OpenRungVpnService.kt
+++ b/android/app/src/main/java/com/openrung/vpn/OpenRungVpnService.kt
@@ -143,14 +143,18 @@ class OpenRungVpnService : VpnService() {
             OpenRungStatusStore.appendLog(
                 getString(R.string.log_broker_returned, relayResponse.relays.size, candidates.size),
             )
-            check(candidates.isNotEmpty()) { getString(R.string.error_no_usable_relay) }
+            if (candidates.isEmpty()) {
+                throw RelaySelectionException.NoUsableRelay(getString(R.string.error_no_usable_relay))
+            }
 
             val targetedCandidates = if (targetRelayId != null) {
                 // A relay picked from the list's expanded per-relay rows: pin that exact relay,
                 // never silently fall back to a different one.
                 failureStage = "relay_id_filter"
                 val matched = candidates.filter { it.id == targetRelayId }
-                check(matched.isNotEmpty()) { getString(R.string.error_relay_not_available) }
+                if (matched.isEmpty()) {
+                    throw RelaySelectionException.RelayNotInList(getString(R.string.error_relay_not_available))
+                }
                 val picked = matched.first()
                 OpenRungStatusStore.appendLog(
                     getString(R.string.log_connecting_relay, picked.label.ifBlank { picked.id }),
@@ -161,7 +165,11 @@ class OpenRungVpnService : VpnService() {
                 OpenRungStatusStore.appendLog(getString(R.string.log_connecting_country, countryName))
                 failureStage = "relay_geo_filter"
                 filterByCountry(candidates, targetCountry).also {
-                    check(it.isNotEmpty()) { getString(R.string.error_no_relay_in_country, countryName) }
+                    if (it.isEmpty()) {
+                        throw RelaySelectionException.NoRelayInCountry(
+                            getString(R.string.error_no_relay_in_country, countryName),
+                        )
+                    }
                 }
             } else {
                 candidates
@@ -203,12 +211,17 @@ class OpenRungVpnService : VpnService() {
             throw error
         } catch (error: Throwable) {
             cleanupActiveTunnel()
+            val failureReason = FailureClassifier.classify(error)
+            val failureDetail = FailureClassifier.detail(error)
             TelemetryManager.record(
                 event = "connection_failed",
-                attributes = mapOf(
-                    "failure_stage" to failureStage,
-                    "error_type" to error::class.java.simpleName,
-                ),
+                attributes = buildMap {
+                    put("failure_stage", failureStage)
+                    // Kept alongside failure_reason for dashboard continuity with older app versions.
+                    put("error_type", error::class.java.simpleName)
+                    if (failureReason.isNotBlank()) put("failure_reason", failureReason)
+                    if (failureDetail.isNotBlank()) put("failure_detail", failureDetail)
+                },
             )
             TelemetryManager.endSession("connection_failed")
             runCatching { TelemetryManager.flush(AppConfig.TELEMETRY_BROKER_URL) }
@@ -242,11 +255,21 @@ class OpenRungVpnService : VpnService() {
                 val config = SingBoxConfiguration(relay = relay).encodedJsonString()
                 val proxyEngine = ProxyEngineFactory.create()
                 val tunnelStarted = SystemClock.elapsedRealtime()
-                proxyEngine.start(
-                    relay = relay,
-                    configJson = config,
-                    vpnService = this,
-                )
+                // Tag an engine start/liveness failure as EngineStartException so it classifies as
+                // process_exited (the embedded-engine analogue of the Go clients' sing-box subprocess
+                // dying). The original error is kept as the cause so a more specific signal in its
+                // chain still wins over process_exited.
+                try {
+                    proxyEngine.start(
+                        relay = relay,
+                        configJson = config,
+                        vpnService = this,
+                    )
+                } catch (error: CancellationException) {
+                    throw error
+                } catch (error: Throwable) {
+                    throw EngineStartException(error.message, error)
+                }
                 val tunnelStartMs = SystemClock.elapsedRealtime() - tunnelStarted
                 engine = proxyEngine
                 OpenRungStatusStore.appendLog(getString(R.string.log_verifying_internet))
@@ -265,10 +288,17 @@ class OpenRungVpnService : VpnService() {
                 throw error
             } catch (error: Throwable) {
                 lastError = error
+                val attemptReason = FailureClassifier.classify(error)
+                val attemptDetail = FailureClassifier.detail(error)
                 TelemetryManager.record(
                     event = "relay_attempt_failed",
                     relayId = relay.id,
-                    attributes = mapOf("error_type" to error::class.java.simpleName),
+                    attributes = buildMap {
+                        // Kept alongside failure_reason for continuity with older app versions.
+                        put("error_type", error::class.java.simpleName)
+                        if (attemptReason.isNotBlank()) put("failure_reason", attemptReason)
+                        if (attemptDetail.isNotBlank()) put("failure_detail", attemptDetail)
+                    },
                     measurements = mapOf("attempt" to (index + 1).toLong()),
                 )
                 OpenRungStatusStore.appendLog(
@@ -282,11 +312,14 @@ class OpenRungVpnService : VpnService() {
             }
         }
 
+        // Preserve lastError as the cause so connection_failed classifies on the real root cause
+        // (timeout, connection_refused, process_exited, …) instead of this generic wrapper.
         throw IllegalStateException(
             getString(
                 R.string.error_all_relays_failed,
                 lastError?.message ?: getString(R.string.error_unknown),
             ),
+            lastError,
         )
     }
 

--- a/android/app/src/test/java/com/openrung/vpn/FailureClassifierErrnoTest.kt
+++ b/android/app/src/test/java/com/openrung/vpn/FailureClassifierErrnoTest.kt
@@ -1,0 +1,67 @@
+package com.openrung.vpn
+
+import android.app.Application
+import android.system.ErrnoException
+import android.system.OsConstants
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.net.ConnectException
+
+/**
+ * Errno-based classifier cases. These need real `android.system.OsConstants` values and a working
+ * [ErrnoException] constructor, which a plain stubbed `android.jar` does not provide (every
+ * OsConstants value reads as 0 there) — so they run under Robolectric. The rest of the classifier's
+ * behavior is covered by the plain-JUnit [FailureClassifierTest].
+ *
+ * `application = Application` keeps Robolectric from booting the real [com.openrung.MainApplication],
+ * whose `onCreate` initializes React Native / SoLoader and can't run in a JVM unit test.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = Application::class)
+class FailureClassifierErrnoTest {
+
+    private fun errno(code: Int): ErrnoException = ErrnoException("connect", code)
+
+    /** Mirrors how Android surfaces a socket errno: a ConnectException with the errno as its cause. */
+    private fun wrapped(code: Int): Throwable =
+        ConnectException("failed to connect to /1.2.3.4:443").apply { initCause(errno(code)) }
+
+    @Test
+    fun `ECONNREFUSED in the cause chain classifies as connection_refused`() {
+        assertEquals("connection_refused", FailureClassifier.classify(wrapped(OsConstants.ECONNREFUSED)))
+    }
+
+    @Test
+    fun `ECONNRESET classifies as connection_reset`() {
+        assertEquals("connection_reset", FailureClassifier.classify(wrapped(OsConstants.ECONNRESET)))
+    }
+
+    @Test
+    fun `ENETUNREACH and EHOSTUNREACH classify as network_unreachable`() {
+        assertEquals("network_unreachable", FailureClassifier.classify(wrapped(OsConstants.ENETUNREACH)))
+        assertEquals("network_unreachable", FailureClassifier.classify(wrapped(OsConstants.EHOSTUNREACH)))
+    }
+
+    @Test
+    fun `ETIMEDOUT classifies as timeout`() {
+        // Not handled by the errno refused/reset/unreachable switch; falls through to generic timeout.
+        assertEquals("timeout", FailureClassifier.classify(wrapped(OsConstants.ETIMEDOUT)))
+    }
+
+    @Test
+    fun `EACCES and EPERM classify as permission_denied`() {
+        assertEquals("permission_denied", FailureClassifier.classify(errno(OsConstants.EACCES)))
+        assertEquals("permission_denied", FailureClassifier.classify(errno(OsConstants.EPERM)))
+    }
+
+    @Test
+    fun `errno root cause wins over an engine-start wrapper`() {
+        // EngineStartException alone classifies as process_exited; the real ECONNREFUSED root cause
+        // has higher precedence (socket errno before engine-exit), so it wins.
+        val error = EngineStartException("engine failed", errno(OsConstants.ECONNREFUSED))
+        assertEquals("connection_refused", FailureClassifier.classify(error))
+    }
+}

--- a/android/app/src/test/java/com/openrung/vpn/FailureClassifierTest.kt
+++ b/android/app/src/test/java/com/openrung/vpn/FailureClassifierTest.kt
@@ -1,0 +1,136 @@
+package com.openrung.vpn
+
+import com.openrung.net.BrokerHttpException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.IOException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+import java.util.concurrent.CancellationException
+import javax.net.ssl.SSLException
+import javax.net.ssl.SSLHandshakeException
+
+/**
+ * Classifier cases that rely only on JVM exception types (no `android.system.*`), so they run under
+ * plain JUnit without Robolectric. The errno-based cases live in [FailureClassifierErrnoTest].
+ */
+class FailureClassifierTest {
+
+    @Test
+    fun `null error yields empty token`() {
+        assertEquals("", FailureClassifier.classify(null))
+    }
+
+    @Test
+    fun `socket timeout wrapped in IllegalStateException classifies as timeout`() {
+        // Mirrors the real bug: the connect pipeline wraps the root cause in an IllegalStateException,
+        // which used to surface on the dashboard as `relay_connect · IllegalStateException`.
+        val error = IllegalStateException("Relay 1.2.3.4:443 is not reachable", SocketTimeoutException("connect timed out"))
+        assertEquals("timeout", FailureClassifier.classify(error))
+    }
+
+    @Test
+    fun `unknown host classifies as dns_failure`() {
+        assertEquals("dns_failure", FailureClassifier.classify(UnknownHostException("Unable to resolve host")))
+    }
+
+    @Test
+    fun `dns failure wins over timeout when both are in the chain`() {
+        // DNS is the more actionable signal, so a name-lookup that also timed out reports dns_failure.
+        val error = SocketTimeoutException("timed out").apply { initCause(UnknownHostException("no address")) }
+        assertEquals("dns_failure", FailureClassifier.classify(error))
+    }
+
+    @Test
+    fun `ssl handshake failure classifies as tls_handshake`() {
+        assertEquals("tls_handshake", FailureClassifier.classify(SSLHandshakeException("cert untrusted")))
+        assertEquals("tls_handshake", FailureClassifier.classify(SSLException("record header error")))
+    }
+
+    @Test
+    fun `security exception classifies as permission_denied`() {
+        assertEquals("permission_denied", FailureClassifier.classify(SecurityException("VPN permission revoked")))
+    }
+
+    @Test
+    fun `broker http 429 classifies as rate_limited`() {
+        assertEquals("rate_limited", FailureClassifier.classify(BrokerHttpException(429, "broker list relays: too many requests")))
+    }
+
+    @Test
+    fun `broker http non-429 classifies as http prefix with code`() {
+        assertEquals("http_503", FailureClassifier.classify(BrokerHttpException(503, "broker list relays: unavailable")))
+        assertEquals("http_500", FailureClassifier.classify(BrokerHttpException(500, "broker list relays: server error")))
+    }
+
+    @Test
+    fun `cancellation classifies as cancelled`() {
+        assertEquals("cancelled", FailureClassifier.classify(CancellationException("stopped")))
+    }
+
+    @Test
+    fun `engine start failure classifies as process_exited`() {
+        val error = EngineStartException("libbox failed to start", RuntimeException("bad config"))
+        assertEquals("process_exited", FailureClassifier.classify(error))
+    }
+
+    @Test
+    fun `permission wins over engine-exit when a security exception is the engine failure cause`() {
+        // A revoked VPN permission surfacing during engine start must classify as permission_denied,
+        // not process_exited (permission has higher precedence than engine-exit).
+        val error = EngineStartException("engine failed", SecurityException("permission denied"))
+        assertEquals("permission_denied", FailureClassifier.classify(error))
+    }
+
+    @Test
+    fun `each relay-selection sentinel maps to its token`() {
+        assertEquals("no_relays_available", FailureClassifier.classify(RelaySelectionException.NoRelaysAvailable("none")))
+        assertEquals("relay_not_in_list", FailureClassifier.classify(RelaySelectionException.RelayNotInList("gone")))
+        assertEquals("no_relay_in_country", FailureClassifier.classify(RelaySelectionException.NoRelayInCountry("no relay in Peru")))
+        assertEquals("no_usable_relay", FailureClassifier.classify(RelaySelectionException.NoUsableRelay("none usable")))
+    }
+
+    @Test
+    fun `unrecognized error classifies as unknown`() {
+        assertEquals("unknown", FailureClassifier.classify(RuntimeException("boom")))
+        // A generic IOException (e.g. the "no broker endpoints reachable" fallback) is honestly unknown.
+        assertEquals("unknown", FailureClassifier.classify(IOException("no broker endpoints reachable")))
+    }
+
+    @Test
+    fun `detail reports the root cause message`() {
+        val error = IllegalStateException("all relay attempts failed", SocketTimeoutException("connect timed out"))
+        assertEquals("connect timed out", FailureClassifier.detail(error))
+    }
+
+    @Test
+    fun `detail is empty for a null error`() {
+        assertEquals("", FailureClassifier.detail(null))
+    }
+
+    @Test
+    fun `detail truncates on a UTF-8 character boundary`() {
+        // 254 ASCII bytes + a 4-byte emoji = 258 bytes; a naive 256-byte cut would split the emoji.
+        val base = "a".repeat(254)
+        val message = base + "😀" // U+1F600 😀, F0 9F 98 80
+        val truncated = FailureClassifier.truncateToBytes(message)
+
+        assertEquals(base, truncated)
+        assertTrue("must not exceed 256 UTF-8 bytes", truncated.toByteArray(Charsets.UTF_8).size <= 256)
+        assertFalse("must not contain a replacement char from a split sequence", truncated.contains('�'))
+    }
+
+    @Test
+    fun `truncate leaves values within the limit untouched`() {
+        val short = "connect timed out"
+        assertEquals(short, FailureClassifier.truncateToBytes(short))
+
+        val exactly256 = "a".repeat(256)
+        assertEquals(exactly256, FailureClassifier.truncateToBytes(exactly256))
+
+        val over = "a".repeat(300)
+        assertEquals(256, FailureClassifier.truncateToBytes(over).toByteArray(Charsets.UTF_8).size)
+    }
+}

--- a/ios/OpenRung.xcodeproj/project.pbxproj
+++ b/ios/OpenRung.xcodeproj/project.pbxproj
@@ -7,9 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		01C5EA0362C5AAB18ED81859 /* PacketTunnelError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C3C1158F41CEF59BEB36FEB /* PacketTunnelError.swift */; };
 		01FB4615E4C3105E861CBAA4 /* DeviceAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E77D10C22E8939116D44BD /* DeviceAttributes.swift */; };
 		024B9A8C62881E530EB591B4 /* RelaySelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD9B5CA88D770C6F0A9597FE /* RelaySelector.swift */; };
 		02A118A7025D0906AAA606E1 /* NetworkPathMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C127CAD14278743A1BD298 /* NetworkPathMonitor.swift */; };
+		02E9AD5F4252406BE29B4B5D /* BrokerClientError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683F07997A392045B7540E47 /* BrokerClientError.swift */; };
 		0483F1444764AB1812DC4A79 /* GeoIpClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 135777353E0B842A0E8E1A49 /* GeoIpClient.swift */; };
 		0B37B967668B130238C8E4EF /* BrokerEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF772A16497903CC49D1F76D /* BrokerEndpoint.swift */; };
 		1001D8102F7EA1A694366DFF /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A9B3E3F0BA7E28C5D05A1731 /* Images.xcassets */; };
@@ -21,14 +23,19 @@
 		27BE72CA10A4E0EC9A5643FB /* BrokerClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0CE1F672D5FAD1FBB511D5B /* BrokerClient.swift */; };
 		27D1C74BA3413782534C860E /* TelemetryClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4254868EF5882AD951E8D23B /* TelemetryClient.swift */; };
 		293B5AB965931E683887D8F4 /* TelemetryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA18FA5754E54F0ADC5189F0 /* TelemetryManager.swift */; };
+		2C3222CCA8C27C06BBA68F85 /* FailureClassifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F3B6378B98E464A9F306E7 /* FailureClassifier.swift */; };
 		2E0156D4F82558FA780E5EFD /* ClientIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD4088394FB9EBCF808F81C2 /* ClientIdentity.swift */; };
+		2F51432049497BF9149B2181 /* libPods-OpenRung.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 739B4A424248AA70C895A125 /* libPods-OpenRung.a */; };
 		352F6CA320938DBB039664C2 /* GeoIpClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 135777353E0B842A0E8E1A49 /* GeoIpClient.swift */; };
 		37B87770F048737201BAE35F /* TelemetryOutbox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BFFA22BC1A97C70EF5F275D /* TelemetryOutbox.swift */; };
+		39331D5AF76FB94FA1EB09CA /* PacketTunnelProxyEngineError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A0014BD8DAE8D1AB0AA819 /* PacketTunnelProxyEngineError.swift */; };
 		395673F4F22F8D43200B404C /* ConnectionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 584A04475F28B3CAC39B501E /* ConnectionStatus.swift */; };
+		3CCF2F1EFD201AD5A17B3998 /* BrokerClientError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683F07997A392045B7540E47 /* BrokerClientError.swift */; };
 		3CF707854EB1FBBCFC3E354F /* ConnectionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 584A04475F28B3CAC39B501E /* ConnectionStatus.swift */; };
 		3D8CFD33EED8FE7AE1FB3299 /* TelemetryEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C9C9695B7E93F7A4F5460B /* TelemetryEvent.swift */; };
-		444B7B8B96A65D41DBBC81D4 /* libPods-OpenRung.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9123F30717BC92015BCA90A7 /* libPods-OpenRung.a */; };
+		3E600B1A4A0F6A075AB8D6E7 /* FailureClassifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E89C58EA730C659109459911 /* FailureClassifierTests.swift */; };
 		4AF8C7F150317AC00E8B27FA /* PacketTunnel.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 1EAA8B2F5746A87534F0C87B /* PacketTunnel.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		4F5E5D33E5E0532AB1153B1C /* PacketTunnelProxyEngineError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A0014BD8DAE8D1AB0AA819 /* PacketTunnelProxyEngineError.swift */; };
 		523936029217C10BD01D40DC /* ActivityLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C27022D3D9D7FEEC839F406 /* ActivityLog.swift */; };
 		597C72F1F64C95B607D0F5BD /* TelemetryOutboxState.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFA54F7B4B2DCC1F8706FD7C /* TelemetryOutboxState.swift */; };
 		598ABF6F03F652193C9D5B96 /* TelemetryEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C9C9695B7E93F7A4F5460B /* TelemetryEvent.swift */; };
@@ -54,8 +61,10 @@
 		A456EFF327FBA312F10D2DDA /* ActivityLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C27022D3D9D7FEEC839F406 /* ActivityLog.swift */; };
 		A47671E4D8F1625738EA3742 /* RelayReachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5AFE2F1F1556F9E70F0AC99 /* RelayReachability.swift */; };
 		AAD6ED5EDDC44F6648B06B22 /* TelemetryOutboxState.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFA54F7B4B2DCC1F8706FD7C /* TelemetryOutboxState.swift */; };
+		ADCA603D15EE662D1B0A279C /* RelayReachabilityError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FF4517B34B4819F6DCD4D1 /* RelayReachabilityError.swift */; };
 		B466AFF5D620F556EA05524F /* RelaySelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD9B5CA88D770C6F0A9597FE /* RelaySelector.swift */; };
 		B6964681672D4F326B16F976 /* TunnelDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B9BA54065E95B7262DA7A95 /* TunnelDiagnostics.swift */; };
+		BB0CE4474A9BF517F57AA4E8 /* BrokerClientError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683F07997A392045B7540E47 /* BrokerClientError.swift */; };
 		BB4F499FD2BC0AAC963D515B /* Libbox.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F19AE6300C331CB6C7B2B9E8 /* Libbox.xcframework */; };
 		BF55D9C9334181B84F1D36EC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 83209B5DF847F742A280CD21 /* LaunchScreen.storyboard */; };
 		C1A6F6AC896E2EE68FCD7AC9 /* RelayReachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5AFE2F1F1556F9E70F0AC99 /* RelayReachability.swift */; };
@@ -63,15 +72,19 @@
 		C4B31101802A2AE5B0E26703 /* LibboxPacketTunnelPlatformInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97D23B885595CDD6DD259A85 /* LibboxPacketTunnelPlatformInterface.swift */; };
 		C98C9E042E602DF887F4B995 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A025739761D97ABD7227B8DA /* PrivacyInfo.xcprivacy */; };
 		CCB2C474FEDC465EA9762C71 /* TelemetryClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4254868EF5882AD951E8D23B /* TelemetryClient.swift */; };
+		CE5FF08F60EA9B59A3FAD581 /* RelayReachabilityError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FF4517B34B4819F6DCD4D1 /* RelayReachabilityError.swift */; };
 		D095482C735B4750F9AC99BB /* RelayDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC6AEF8D510DD407C368119F /* RelayDescriptor.swift */; };
 		E23AB43D1F262132DECB88F3 /* PacketTunnelProxyEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = D65DF435DF84A90675DAFD54 /* PacketTunnelProxyEngine.swift */; };
 		E2C945F0A942AE0E937369EC /* OpenRungVpnModule.m in Sources */ = {isa = PBXBuildFile; fileRef = ED28831CA960E8B89D5D7D04 /* OpenRungVpnModule.m */; };
+		E6799BE42347DC306ADF2213 /* RelayReachabilityError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FF4517B34B4819F6DCD4D1 /* RelayReachabilityError.swift */; };
+		EAD1DFA9AB52E6A93CB60890 /* FailureClassifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F3B6378B98E464A9F306E7 /* FailureClassifier.swift */; };
 		ED0AA86BCFC9211195B7081E /* ClientIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD4088394FB9EBCF808F81C2 /* ClientIdentity.swift */; };
 		EE4F9A809147703D746C60EB /* libresolv.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = EC15DA1827B19848080D3452 /* libresolv.tbd */; };
 		F394E6F8661ECC0CFB89B18F /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 81CC00C2F7324111F25D07A0 /* UIKit.framework */; };
 		F3B793902F7CB0A41962275A /* SpeedTestClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A57C8F876ACF0B8B9BC73749 /* SpeedTestClient.swift */; };
 		F6D4EDF154A64B658BBAA677 /* TelemetrySession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A5299A99DA8ED8C75B1E25B /* TelemetrySession.swift */; };
 		F82F4E03FAD0D3DFDB106718 /* OpenRungVpnModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 719ACF45718CBF52773FCD6C /* OpenRungVpnModule.swift */; };
+		FE8C2A7A69C2E15601117C9F /* PacketTunnelError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C3C1158F41CEF59BEB36FEB /* PacketTunnelError.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -102,44 +115,51 @@
 		005F1F59591EC44366AC6B21 /* InternetProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternetProbe.swift; sourceTree = "<group>"; };
 		03703C68A02344020716751A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		135777353E0B842A0E8E1A49 /* GeoIpClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeoIpClient.swift; sourceTree = "<group>"; };
+		174E944F053F54F691E59C74 /* OpenRungTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = OpenRungTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		1EAA8B2F5746A87534F0C87B /* PacketTunnel.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = PacketTunnel.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		25CB8E64CF645C0DD1375294 /* EngineDirectories.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EngineDirectories.swift; sourceTree = "<group>"; };
-		2F1867CEADF069932D4C3D03 /* Pods-OpenRung.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OpenRung.release.xcconfig"; path = "Target Support Files/Pods-OpenRung/Pods-OpenRung.release.xcconfig"; sourceTree = "<group>"; };
 		3BFFA22BC1A97C70EF5F275D /* TelemetryOutbox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryOutbox.swift; sourceTree = "<group>"; };
 		4254868EF5882AD951E8D23B /* TelemetryClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryClient.swift; sourceTree = "<group>"; };
 		42FBF71585756F18035DA71D /* TelemetrySessionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetrySessionStore.swift; sourceTree = "<group>"; };
-		458A2430830FC5DDCA723E90 /* Pods-OpenRung.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OpenRung.debug.xcconfig"; path = "Target Support Files/Pods-OpenRung/Pods-OpenRung.debug.xcconfig"; sourceTree = "<group>"; };
 		49C9C9695B7E93F7A4F5460B /* TelemetryEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryEvent.swift; sourceTree = "<group>"; };
 		4B9BA54065E95B7262DA7A95 /* TunnelDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelDiagnostics.swift; sourceTree = "<group>"; };
 		584A04475F28B3CAC39B501E /* ConnectionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionStatus.swift; sourceTree = "<group>"; };
+		683F07997A392045B7540E47 /* BrokerClientError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrokerClientError.swift; sourceTree = "<group>"; };
 		6A5299A99DA8ED8C75B1E25B /* TelemetrySession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetrySession.swift; sourceTree = "<group>"; };
 		719ACF45718CBF52773FCD6C /* OpenRungVpnModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenRungVpnModule.swift; sourceTree = "<group>"; };
+		739B4A424248AA70C895A125 /* libPods-OpenRung.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-OpenRung.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		75EA37B450C63159CA5C16FA /* Pods-OpenRung.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OpenRung.release.xcconfig"; path = "Target Support Files/Pods-OpenRung/Pods-OpenRung.release.xcconfig"; sourceTree = "<group>"; };
 		7A07146C137269D283F062DB /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		81B10868A3F7FA99A84696A4 /* OpenRung.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = OpenRung.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		81CC00C2F7324111F25D07A0 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		83209B5DF847F742A280CD21 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
-		9123F30717BC92015BCA90A7 /* libPods-OpenRung.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-OpenRung.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		97D23B885595CDD6DD259A85 /* LibboxPacketTunnelPlatformInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibboxPacketTunnelPlatformInterface.swift; sourceTree = "<group>"; };
 		9C27022D3D9D7FEEC839F406 /* ActivityLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityLog.swift; sourceTree = "<group>"; };
+		9C3C1158F41CEF59BEB36FEB /* PacketTunnelError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PacketTunnelError.swift; sourceTree = "<group>"; };
 		A025739761D97ABD7227B8DA /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		A57C8F876ACF0B8B9BC73749 /* SpeedTestClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedTestClient.swift; sourceTree = "<group>"; };
 		A9B3E3F0BA7E28C5D05A1731 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		AB117725DF8A60D9A23412CC /* PacketTunnel.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PacketTunnel.entitlements; sourceTree = "<group>"; };
 		B0C127CAD14278743A1BD298 /* NetworkPathMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkPathMonitor.swift; sourceTree = "<group>"; };
+		B3A0014BD8DAE8D1AB0AA819 /* PacketTunnelProxyEngineError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PacketTunnelProxyEngineError.swift; sourceTree = "<group>"; };
 		B9D3B66E26E617B7B00140A4 /* PacketTunnelProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PacketTunnelProvider.swift; sourceTree = "<group>"; };
 		BA18FA5754E54F0ADC5189F0 /* TelemetryManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryManager.swift; sourceTree = "<group>"; };
+		C0B991DD5EDE0739BE56D2A4 /* Pods-OpenRung.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OpenRung.debug.xcconfig"; path = "Target Support Files/Pods-OpenRung/Pods-OpenRung.debug.xcconfig"; sourceTree = "<group>"; };
 		C28E2B488D1B810BD0BB8AA1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		C4E77D10C22E8939116D44BD /* DeviceAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceAttributes.swift; sourceTree = "<group>"; };
+		C9F3B6378B98E464A9F306E7 /* FailureClassifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FailureClassifier.swift; sourceTree = "<group>"; };
 		D0CE1F672D5FAD1FBB511D5B /* BrokerClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrokerClient.swift; sourceTree = "<group>"; };
 		D11601E153A60E8B30351E20 /* SharedConnectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedConnectionState.swift; sourceTree = "<group>"; };
 		D156734F7F68151301FEF878 /* SingBoxConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingBoxConfiguration.swift; sourceTree = "<group>"; };
 		D5AFE2F1F1556F9E70F0AC99 /* RelayReachability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayReachability.swift; sourceTree = "<group>"; };
 		D65DF435DF84A90675DAFD54 /* PacketTunnelProxyEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PacketTunnelProxyEngine.swift; sourceTree = "<group>"; };
+		D8FF4517B34B4819F6DCD4D1 /* RelayReachabilityError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayReachabilityError.swift; sourceTree = "<group>"; };
 		DC6AEF8D510DD407C368119F /* RelayDescriptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayDescriptor.swift; sourceTree = "<group>"; };
 		DD4088394FB9EBCF808F81C2 /* ClientIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientIdentity.swift; sourceTree = "<group>"; };
 		E015EBBA482879150C779611 /* OpenRung.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = OpenRung.entitlements; sourceTree = "<group>"; };
 		E2570C01745DA49558877810 /* CountryGeo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountryGeo.swift; sourceTree = "<group>"; };
 		E4783169BE46FEE9B0472504 /* AppConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfig.swift; sourceTree = "<group>"; };
+		E89C58EA730C659109459911 /* FailureClassifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FailureClassifierTests.swift; sourceTree = "<group>"; };
 		EC15DA1827B19848080D3452 /* libresolv.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libresolv.tbd; path = usr/lib/libresolv.tbd; sourceTree = SDKROOT; };
 		ED28831CA960E8B89D5D7D04 /* OpenRungVpnModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OpenRungVpnModule.m; sourceTree = "<group>"; };
 		EF772A16497903CC49D1F76D /* BrokerEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrokerEndpoint.swift; sourceTree = "<group>"; };
@@ -149,14 +169,6 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		5A424BAA0E6A17AC61C178C4 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				444B7B8B96A65D41DBBC81D4 /* libPods-OpenRung.a in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		668432D2A04B5D12772FB7F2 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -164,6 +176,14 @@
 				BB4F499FD2BC0AAC963D515B /* Libbox.xcframework in Frameworks */,
 				F394E6F8661ECC0CFB89B18F /* UIKit.framework in Frameworks */,
 				EE4F9A809147703D746C60EB /* libresolv.tbd in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F6A66E991A4B9EA0848A72AC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2F51432049497BF9149B2181 /* libPods-OpenRung.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -191,6 +211,7 @@
 				9C27022D3D9D7FEEC839F406 /* ActivityLog.swift */,
 				E4783169BE46FEE9B0472504 /* AppConfig.swift */,
 				D0CE1F672D5FAD1FBB511D5B /* BrokerClient.swift */,
+				683F07997A392045B7540E47 /* BrokerClientError.swift */,
 				EF772A16497903CC49D1F76D /* BrokerEndpoint.swift */,
 				DD4088394FB9EBCF808F81C2 /* ClientIdentity.swift */,
 				584A04475F28B3CAC39B501E /* ConnectionStatus.swift */,
@@ -201,6 +222,7 @@
 				B0C127CAD14278743A1BD298 /* NetworkPathMonitor.swift */,
 				DC6AEF8D510DD407C368119F /* RelayDescriptor.swift */,
 				D5AFE2F1F1556F9E70F0AC99 /* RelayReachability.swift */,
+				D8FF4517B34B4819F6DCD4D1 /* RelayReachabilityError.swift */,
 				FD9B5CA88D770C6F0A9597FE /* RelaySelector.swift */,
 				D11601E153A60E8B30351E20 /* SharedConnectionState.swift */,
 				D156734F7F68151301FEF878 /* SingBoxConfiguration.swift */,
@@ -217,13 +239,31 @@
 			path = Shared;
 			sourceTree = "<group>";
 		};
+		837FBBD5687C0AB326CC593E /* OpenRungTests */ = {
+			isa = PBXGroup;
+			children = (
+				E89C58EA730C659109459911 /* FailureClassifierTests.swift */,
+			);
+			path = OpenRungTests;
+			sourceTree = "<group>";
+		};
+		9FE6AFBA8B6C120542269256 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				C0B991DD5EDE0739BE56D2A4 /* Pods-OpenRung.debug.xcconfig */,
+				75EA37B450C63159CA5C16FA /* Pods-OpenRung.release.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
 		A1C815B9A63C637692C1C541 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
 				F19AE6300C331CB6C7B2B9E8 /* Libbox.xcframework */,
 				EC15DA1827B19848080D3452 /* libresolv.tbd */,
 				81CC00C2F7324111F25D07A0 /* UIKit.framework */,
-				9123F30717BC92015BCA90A7 /* libPods-OpenRung.a */,
+				739B4A424248AA70C895A125 /* libPods-OpenRung.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -232,29 +272,23 @@
 			isa = PBXGroup;
 			children = (
 				25CB8E64CF645C0DD1375294 /* EngineDirectories.swift */,
+				C9F3B6378B98E464A9F306E7 /* FailureClassifier.swift */,
 				C28E2B488D1B810BD0BB8AA1 /* Info.plist */,
 				97D23B885595CDD6DD259A85 /* LibboxPacketTunnelPlatformInterface.swift */,
 				AB117725DF8A60D9A23412CC /* PacketTunnel.entitlements */,
+				9C3C1158F41CEF59BEB36FEB /* PacketTunnelError.swift */,
 				B9D3B66E26E617B7B00140A4 /* PacketTunnelProvider.swift */,
 				D65DF435DF84A90675DAFD54 /* PacketTunnelProxyEngine.swift */,
+				B3A0014BD8DAE8D1AB0AA819 /* PacketTunnelProxyEngineError.swift */,
 			);
 			path = PacketTunnel;
-			sourceTree = "<group>";
-		};
-		CAD3FDC7038409A4A35431C1 /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				458A2430830FC5DDCA723E90 /* Pods-OpenRung.debug.xcconfig */,
-				2F1867CEADF069932D4C3D03 /* Pods-OpenRung.release.xcconfig */,
-			);
-			name = Pods;
-			path = Pods;
 			sourceTree = "<group>";
 		};
 		E73A5155909F9EFE9F13A6A1 /* Products */ = {
 			isa = PBXGroup;
 			children = (
 				81B10868A3F7FA99A84696A4 /* OpenRung.app */,
+				174E944F053F54F691E59C74 /* OpenRungTests.xctest */,
 				1EAA8B2F5746A87534F0C87B /* PacketTunnel.appex */,
 			);
 			name = Products;
@@ -264,11 +298,12 @@
 			isa = PBXGroup;
 			children = (
 				2407F79AC36C68D7F2761D5C /* OpenRung */,
+				837FBBD5687C0AB326CC593E /* OpenRungTests */,
 				AFDFC1D16B3A792D974E4A5D /* PacketTunnel */,
 				3F24A472F75132572E2891A1 /* Shared */,
 				A1C815B9A63C637692C1C541 /* Frameworks */,
 				E73A5155909F9EFE9F13A6A1 /* Products */,
-				CAD3FDC7038409A4A35431C1 /* Pods */,
+				9FE6AFBA8B6C120542269256 /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -295,15 +330,15 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F19D0D1C8CB7FB1B6B178E82 /* Build configuration list for PBXNativeTarget "OpenRung" */;
 			buildPhases = (
-				C31B3909DB979E8569D10D45 /* [CP] Check Pods Manifest.lock */,
+				88F41DF9A85053D4E116BDF2 /* [CP] Check Pods Manifest.lock */,
 				BC3282E3662088C7CF8F8BC7 /* Sources */,
 				7272F5C7D4F2765DAB69942D /* Resources */,
 				141D130B421160859A220937 /* Embed Foundation Extensions */,
 				7645E65DA025354651549041 /* Bundle React Native code and images */,
-				51FE3F259B3D0BE3AD1C4844 /* [MapLibre React Native] Remove MapLibre.xcframework-ios.signature */,
-				5A424BAA0E6A17AC61C178C4 /* Frameworks */,
-				612DDCC22D448E7FE68B0313 /* [CP] Embed Pods Frameworks */,
-				ECB8DD49E1B88439A2B8F002 /* [CP] Copy Pods Resources */,
+				E14B0AF1D929D24368D45514 /* [MapLibre React Native] Remove MapLibre.xcframework-ios.signature */,
+				F6A66E991A4B9EA0848A72AC /* Frameworks */,
+				23F6B208A008DEB0E6791759 /* [CP] Embed Pods Frameworks */,
+				5870AD9C69E407AC5CF86CA3 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -312,11 +347,26 @@
 			);
 			name = OpenRung;
 			packageProductDependencies = (
-				AA46995424D1019E7E7DFBC5 /* MapLibre */,
+				54789229C997837AEFCB20DF /* MapLibre */,
 			);
 			productName = OpenRung;
 			productReference = 81B10868A3F7FA99A84696A4 /* OpenRung.app */;
 			productType = "com.apple.product-type.application";
+		};
+		F015EA6D6BDCBE1C4CAF2180 /* OpenRungTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1A7137B4CB6CCEA767DA5C02 /* Build configuration list for PBXNativeTarget "OpenRungTests" */;
+			buildPhases = (
+				84B5D017783C0B87BE9B1DC3 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = OpenRungTests;
+			productName = OpenRungTests;
+			productReference = 174E944F053F54F691E59C74 /* OpenRungTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
 
@@ -335,6 +385,10 @@
 						DevelopmentTeam = 9VLV9A7KS9;
 						ProvisioningStyle = Automatic;
 					};
+					F015EA6D6BDCBE1C4CAF2180 = {
+						DevelopmentTeam = 9VLV9A7KS9;
+						ProvisioningStyle = Automatic;
+					};
 				};
 			};
 			buildConfigurationList = BE5FEF582D9F4428CE70CE8B /* Build configuration list for PBXProject "OpenRung" */;
@@ -347,7 +401,7 @@
 			mainGroup = F4646C7E57CBAA9E0DF5661F;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
-				F3083E0D1BCE9D6FB761E498 /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */,
+				DF1A68EFD7AE0666ED66EEAF /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = E73A5155909F9EFE9F13A6A1 /* Products */;
@@ -355,6 +409,7 @@
 			projectRoot = "";
 			targets = (
 				ADBDEA07895981C3C202875A /* OpenRung */,
+				F015EA6D6BDCBE1C4CAF2180 /* OpenRungTests */,
 				008A07C80B8C5B8E7AC13818 /* PacketTunnel */,
 			);
 		};
@@ -374,26 +429,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		51FE3F259B3D0BE3AD1C4844 /* [MapLibre React Native] Remove MapLibre.xcframework-ios.signature */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "[MapLibre React Native] Remove MapLibre.xcframework-ios.signature";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "rm -rf \"$CONFIGURATION_BUILD_DIR/MapLibre.xcframework-ios.signature\"";
-		};
-		612DDCC22D448E7FE68B0313 /* [CP] Embed Pods Frameworks */ = {
+		23F6B208A008DEB0E6791759 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -408,6 +444,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-OpenRung/Pods-OpenRung-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		5870AD9C69E407AC5CF86CA3 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-OpenRung/Pods-OpenRung-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-OpenRung/Pods-OpenRung-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-OpenRung/Pods-OpenRung-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		7645E65DA025354651549041 /* Bundle React Native code and images */ = {
@@ -430,7 +483,7 @@
 			shellPath = /bin/sh;
 			shellScript = "set -e\n\nWITH_ENVIRONMENT=\"$REACT_NATIVE_PATH/scripts/xcode/with-environment.sh\"\nREACT_NATIVE_XCODE=\"$REACT_NATIVE_PATH/scripts/react-native-xcode.sh\"\n\n/bin/sh -c \"\\\"$WITH_ENVIRONMENT\\\" \\\"$REACT_NATIVE_XCODE\\\"\"\n";
 		};
-		C31B3909DB979E8569D10D45 /* [CP] Check Pods Manifest.lock */ = {
+		88F41DF9A85053D4E116BDF2 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -452,22 +505,24 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		ECB8DD49E1B88439A2B8F002 /* [CP] Copy Pods Resources */ = {
+		E14B0AF1D929D24368D45514 /* [MapLibre React Native] Remove MapLibre.xcframework-ios.signature */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-OpenRung/Pods-OpenRung-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			name = "[CP] Copy Pods Resources";
+			inputPaths = (
+			);
+			name = "[MapLibre React Native] Remove MapLibre.xcframework-ios.signature";
 			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-OpenRung/Pods-OpenRung-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-OpenRung/Pods-OpenRung-resources.sh\"\n";
-			showEnvVarsInLog = 0;
+			shellScript = "rm -rf \"$CONFIGURATION_BUILD_DIR/MapLibre.xcframework-ios.signature\"";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -479,20 +534,25 @@
 				523936029217C10BD01D40DC /* ActivityLog.swift in Sources */,
 				952EFF368D06083B89F5EE8D /* AppConfig.swift in Sources */,
 				662019FD66D0F3A9572970F8 /* BrokerClient.swift in Sources */,
+				BB0CE4474A9BF517F57AA4E8 /* BrokerClientError.swift in Sources */,
 				0B37B967668B130238C8E4EF /* BrokerEndpoint.swift in Sources */,
 				2E0156D4F82558FA780E5EFD /* ClientIdentity.swift in Sources */,
 				395673F4F22F8D43200B404C /* ConnectionStatus.swift in Sources */,
 				2226FA02DA3CF06280AA3D27 /* CountryGeo.swift in Sources */,
 				01FB4615E4C3105E861CBAA4 /* DeviceAttributes.swift in Sources */,
 				91DF94A8B176C8B90DCFF6A5 /* EngineDirectories.swift in Sources */,
+				EAD1DFA9AB52E6A93CB60890 /* FailureClassifier.swift in Sources */,
 				352F6CA320938DBB039664C2 /* GeoIpClient.swift in Sources */,
 				9604E15625FCE8C234279160 /* InternetProbe.swift in Sources */,
 				C4B31101802A2AE5B0E26703 /* LibboxPacketTunnelPlatformInterface.swift in Sources */,
 				02A118A7025D0906AAA606E1 /* NetworkPathMonitor.swift in Sources */,
+				FE8C2A7A69C2E15601117C9F /* PacketTunnelError.swift in Sources */,
 				81C2338B54BA856645F46A5E /* PacketTunnelProvider.swift in Sources */,
 				E23AB43D1F262132DECB88F3 /* PacketTunnelProxyEngine.swift in Sources */,
+				4F5E5D33E5E0532AB1153B1C /* PacketTunnelProxyEngineError.swift in Sources */,
 				D095482C735B4750F9AC99BB /* RelayDescriptor.swift in Sources */,
 				C1A6F6AC896E2EE68FCD7AC9 /* RelayReachability.swift in Sources */,
+				CE5FF08F60EA9B59A3FAD581 /* RelayReachabilityError.swift in Sources */,
 				024B9A8C62881E530EB591B4 /* RelaySelector.swift in Sources */,
 				C30EDE383463DB3F401D317E /* SharedConnectionState.swift in Sources */,
 				62AE36E16F5E162B6C7921DF /* SingBoxConfiguration.swift in Sources */,
@@ -508,6 +568,19 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		84B5D017783C0B87BE9B1DC3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3CCF2F1EFD201AD5A17B3998 /* BrokerClientError.swift in Sources */,
+				2C3222CCA8C27C06BBA68F85 /* FailureClassifier.swift in Sources */,
+				3E600B1A4A0F6A075AB8D6E7 /* FailureClassifierTests.swift in Sources */,
+				01C5EA0362C5AAB18ED81859 /* PacketTunnelError.swift in Sources */,
+				39331D5AF76FB94FA1EB09CA /* PacketTunnelProxyEngineError.swift in Sources */,
+				E6799BE42347DC306ADF2213 /* RelayReachabilityError.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		BC3282E3662088C7CF8F8BC7 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -516,6 +589,7 @@
 				A2BD7C4271FDE1F796CA7E77 /* AppConfig.swift in Sources */,
 				2367D4EBC8213B6D57E65A0E /* AppDelegate.swift in Sources */,
 				27BE72CA10A4E0EC9A5643FB /* BrokerClient.swift in Sources */,
+				02E9AD5F4252406BE29B4B5D /* BrokerClientError.swift in Sources */,
 				6D2F7518B6C1ECD12E8EEDDB /* BrokerEndpoint.swift in Sources */,
 				ED0AA86BCFC9211195B7081E /* ClientIdentity.swift in Sources */,
 				3CF707854EB1FBBCFC3E354F /* ConnectionStatus.swift in Sources */,
@@ -528,6 +602,7 @@
 				F82F4E03FAD0D3DFDB106718 /* OpenRungVpnModule.swift in Sources */,
 				7AD3CF8197D457CDDC3CCBCE /* RelayDescriptor.swift in Sources */,
 				A47671E4D8F1625738EA3742 /* RelayReachability.swift in Sources */,
+				ADCA603D15EE662D1B0A279C /* RelayReachabilityError.swift in Sources */,
 				B466AFF5D620F556EA05524F /* RelaySelector.swift in Sources */,
 				9E3FE5CDA11DD5EEC1F54942 /* SharedConnectionState.swift in Sources */,
 				6BE03273C0331255B97BE15A /* SingBoxConfiguration.swift in Sources */,
@@ -556,7 +631,7 @@
 /* Begin XCBuildConfiguration section */
 		0D953B3D127C0BB08E644293 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2F1867CEADF069932D4C3D03 /* Pods-OpenRung.release.xcconfig */;
+			baseConfigurationReference = 75EA37B450C63159CA5C16FA /* Pods-OpenRung.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = OpenRung/OpenRung.entitlements;
@@ -579,6 +654,23 @@
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;
+		};
+		1739C10E668DF0A6946A2474 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGNING_ALLOWED = NO;
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.openrung.mobile.OpenRungTests;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
 		};
 		4C35976FB891B137DBD5BFBC /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -677,7 +769,7 @@
 		};
 		73BE8C16CB91640112F4357A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 458A2430830FC5DDCA723E90 /* Pods-OpenRung.debug.xcconfig */;
+			baseConfigurationReference = C0B991DD5EDE0739BE56D2A4 /* Pods-OpenRung.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = OpenRung/OpenRung.entitlements;
@@ -700,6 +792,23 @@
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Debug;
+		};
+		D9763941706511C8F6084FFA /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGNING_ALLOWED = NO;
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.openrung.mobile.OpenRungTests;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
 		};
 		F1E0D202F4B2E3CC5ACCF2C5 /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -834,6 +943,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		1A7137B4CB6CCEA767DA5C02 /* Build configuration list for PBXNativeTarget "OpenRungTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1739C10E668DF0A6946A2474 /* Debug */,
+				D9763941706511C8F6084FFA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		559BD093D2D0ABCE855F2C85 /* Build configuration list for PBXNativeTarget "PacketTunnel" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -864,7 +982,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		F3083E0D1BCE9D6FB761E498 /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */ = {
+		DF1A68EFD7AE0666ED66EEAF /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/maplibre/maplibre-gl-native-distribution";
 			requirement = {
@@ -875,9 +993,9 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		AA46995424D1019E7E7DFBC5 /* MapLibre */ = {
+		54789229C997837AEFCB20DF /* MapLibre */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = F3083E0D1BCE9D6FB761E498 /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */;
+			package = DF1A68EFD7AE0666ED66EEAF /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */;
 			productName = MapLibre;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/ios/OpenRung.xcodeproj/xcshareddata/xcschemes/OpenRungTests.xcscheme
+++ b/ios/OpenRung.xcodeproj/xcshareddata/xcschemes/OpenRungTests.xcscheme
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1430"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F015EA6D6BDCBE1C4CAF2180"
+               BuildableName = "OpenRungTests.xctest"
+               BlueprintName = "OpenRungTests"
+               ReferencedContainer = "container:OpenRung.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F015EA6D6BDCBE1C4CAF2180"
+            BuildableName = "OpenRungTests.xctest"
+            BlueprintName = "OpenRungTests"
+            ReferencedContainer = "container:OpenRung.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F015EA6D6BDCBE1C4CAF2180"
+               BuildableName = "OpenRungTests.xctest"
+               BlueprintName = "OpenRungTests"
+               ReferencedContainer = "container:OpenRung.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F015EA6D6BDCBE1C4CAF2180"
+            BuildableName = "OpenRungTests.xctest"
+            BlueprintName = "OpenRungTests"
+            ReferencedContainer = "container:OpenRung.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F015EA6D6BDCBE1C4CAF2180"
+            BuildableName = "OpenRungTests.xctest"
+            BlueprintName = "OpenRungTests"
+            ReferencedContainer = "container:OpenRung.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ios/OpenRungTests/FailureClassifierTests.swift
+++ b/ios/OpenRungTests/FailureClassifierTests.swift
@@ -1,0 +1,149 @@
+import Foundation
+import NetworkExtension
+import XCTest
+
+/// Unit tests for `FailureClassifier`. The classifier and the error types it maps
+/// (`PacketTunnelError`, `BrokerClientError`, `RelayReachabilityError`,
+/// `PacketTunnelProxyEngineError`) are compiled directly into this test target — see the
+/// `OpenRungTests` target in `project.yml` — so no import of the app/extension is needed.
+final class FailureClassifierTests: XCTestCase {
+
+    // MARK: - PacketTunnelError sentinels
+
+    func testRelaySelectionSentinels() {
+        XCTAssertEqual(FailureClassifier.classify(PacketTunnelError.noUsableRelay), "no_usable_relay")
+        XCTAssertEqual(FailureClassifier.classify(PacketTunnelError.noRelayInCountry("Peru")), "no_relay_in_country")
+        XCTAssertEqual(FailureClassifier.classify(PacketTunnelError.relayNotAvailable), "relay_not_in_list")
+    }
+
+    // MARK: - Wrappers unwrap and classify the real cause
+
+    func testAllRelaysFailedUnwrapsUnderlyingError() {
+        XCTAssertEqual(
+            FailureClassifier.classify(PacketTunnelError.allRelaysFailed(URLError(.timedOut))),
+            "timeout"
+        )
+        XCTAssertEqual(
+            FailureClassifier.classify(PacketTunnelError.allRelaysFailed(BrokerClientError.httpStatus(429))),
+            "rate_limited"
+        )
+        // No last error captured → generic.
+        XCTAssertEqual(FailureClassifier.classify(PacketTunnelError.allRelaysFailed(nil)), "no_usable_relay")
+    }
+
+    func testAllRelaysFailedUnwrapsEngineFailure() {
+        XCTAssertEqual(
+            FailureClassifier.classify(PacketTunnelError.allRelaysFailed(PacketTunnelProxyEngineError.engineStartFailed("boom"))),
+            "process_exited"
+        )
+    }
+
+    func testRelayUnreachableUnwrapsUnderlyingError() {
+        XCTAssertEqual(
+            FailureClassifier.classify(PacketTunnelError.relayUnreachable(host: "1.2.3.4", port: 443, underlying: URLError(.cannotConnectToHost))),
+            "connection_refused"
+        )
+        XCTAssertEqual(
+            FailureClassifier.classify(PacketTunnelError.relayUnreachable(host: "1.2.3.4", port: 443, underlying: RelayReachabilityError.timeout)),
+            "timeout"
+        )
+        // No underlying cause → reachability fallback token.
+        XCTAssertEqual(
+            FailureClassifier.classify(PacketTunnelError.relayUnreachable(host: "1.2.3.4", port: 443, underlying: nil)),
+            "network_unreachable"
+        )
+    }
+
+    // MARK: - Cancellation
+
+    func testCancellation() {
+        XCTAssertEqual(FailureClassifier.classify(CancellationError()), "cancelled")
+        XCTAssertEqual(FailureClassifier.classify(URLError(.cancelled)), "cancelled")
+    }
+
+    // MARK: - Broker HTTP status
+
+    func testBrokerHTTPStatus() {
+        XCTAssertEqual(FailureClassifier.classify(BrokerClientError.httpStatus(429)), "rate_limited")
+        XCTAssertEqual(FailureClassifier.classify(BrokerClientError.httpStatus(503)), "http_503")
+        XCTAssertEqual(FailureClassifier.classify(BrokerClientError.httpStatus(500)), "http_500")
+        XCTAssertEqual(FailureClassifier.classify(BrokerClientError.invalidResponse), "unknown")
+    }
+
+    // MARK: - URLError codes
+
+    func testURLErrorCodes() {
+        XCTAssertEqual(FailureClassifier.classify(URLError(.timedOut)), "timeout")
+        XCTAssertEqual(FailureClassifier.classify(URLError(.cannotFindHost)), "dns_failure")
+        XCTAssertEqual(FailureClassifier.classify(URLError(.dnsLookupFailed)), "dns_failure")
+        XCTAssertEqual(FailureClassifier.classify(URLError(.secureConnectionFailed)), "tls_handshake")
+        XCTAssertEqual(FailureClassifier.classify(URLError(.serverCertificateUntrusted)), "tls_handshake")
+        XCTAssertEqual(FailureClassifier.classify(URLError(.cannotConnectToHost)), "connection_refused")
+        XCTAssertEqual(FailureClassifier.classify(URLError(.notConnectedToInternet)), "network_unreachable")
+        XCTAssertEqual(FailureClassifier.classify(URLError(.networkConnectionLost)), "network_unreachable")
+    }
+
+    // MARK: - POSIX errno (bridged as NSError, as NWError/POSIXError would surface)
+
+    private func posix(_ code: POSIXErrorCode) -> NSError {
+        NSError(domain: NSPOSIXErrorDomain, code: Int(code.rawValue))
+    }
+
+    func testPOSIXErrno() {
+        XCTAssertEqual(FailureClassifier.classify(posix(.ECONNREFUSED)), "connection_refused")
+        XCTAssertEqual(FailureClassifier.classify(posix(.ECONNRESET)), "connection_reset")
+        XCTAssertEqual(FailureClassifier.classify(posix(.ENETUNREACH)), "network_unreachable")
+        XCTAssertEqual(FailureClassifier.classify(posix(.EHOSTUNREACH)), "network_unreachable")
+        XCTAssertEqual(FailureClassifier.classify(posix(.ETIMEDOUT)), "timeout")
+        XCTAssertEqual(FailureClassifier.classify(posix(.EACCES)), "permission_denied")
+        XCTAssertEqual(FailureClassifier.classify(posix(.EPERM)), "permission_denied")
+    }
+
+    func testErrnoRootCauseWinsOverWrapper() {
+        // A refused connection surfacing as the last relay error must classify as connection_refused,
+        // unwrapped from the allRelaysFailed wrapper (socket errno before engine-exit / unknown).
+        XCTAssertEqual(
+            FailureClassifier.classify(PacketTunnelError.allRelaysFailed(posix(.ECONNREFUSED))),
+            "connection_refused"
+        )
+    }
+
+    // MARK: - Permission / engine / unknown
+
+    func testPermissionAndEngineAndUnknown() {
+        XCTAssertEqual(FailureClassifier.classify(NSError(domain: NEVPNErrorDomain, code: 1)), "permission_denied")
+        XCTAssertEqual(FailureClassifier.classify(PacketTunnelProxyEngineError.engineStartFailed("died")), "process_exited")
+        XCTAssertEqual(FailureClassifier.classify(PacketTunnelProxyEngineError.engineNotLinked), "process_exited")
+        XCTAssertEqual(FailureClassifier.classify(NSError(domain: "com.example.other", code: 7)), "unknown")
+    }
+
+    // MARK: - failure_detail truncation
+
+    func testDetailTruncatesOnUTF8Boundary() {
+        // 254 ASCII bytes + a 4-byte emoji = 258 bytes; a naive 256-byte cut would split the emoji.
+        let base = String(repeating: "a", count: 254)
+        let message = base + "😀" // U+1F600, F0 9F 98 80
+        let truncated = FailureClassifier.truncate(message)
+
+        XCTAssertEqual(truncated, base)
+        XCTAssertLessThanOrEqual(truncated.utf8.count, 256)
+        XCTAssertFalse(truncated.contains("\u{FFFD}"))
+    }
+
+    func testTruncateLeavesValuesWithinLimitUntouched() {
+        let short = "connect timed out"
+        XCTAssertEqual(FailureClassifier.truncate(short), short)
+
+        let exactly256 = String(repeating: "a", count: 256)
+        XCTAssertEqual(FailureClassifier.truncate(exactly256), exactly256)
+
+        let over = String(repeating: "a", count: 300)
+        XCTAssertEqual(FailureClassifier.truncate(over).utf8.count, 256)
+    }
+
+    func testDetailUsesLocalizedDescription() {
+        // allRelaysFailed's errorDescription embeds the unwrapped last error's description.
+        let detail = FailureClassifier.detail(PacketTunnelError.allRelaysFailed(URLError(.timedOut)))
+        XCTAssertTrue(detail.hasPrefix("All relay connection attempts failed."))
+    }
+}

--- a/ios/OpenRungTests/FailureClassifierTests.swift
+++ b/ios/OpenRungTests/FailureClassifierTests.swift
@@ -141,9 +141,23 @@ final class FailureClassifierTests: XCTestCase {
         XCTAssertEqual(FailureClassifier.truncate(over).utf8.count, 256)
     }
 
-    func testDetailUsesLocalizedDescription() {
-        // allRelaysFailed's errorDescription embeds the unwrapped last error's description.
-        let detail = FailureClassifier.detail(PacketTunnelError.allRelaysFailed(URLError(.timedOut)))
+    func testDetailUsesUnderlyingDescription() {
+        struct RootCause: LocalizedError {
+            var errorDescription: String? { "connect timed out root cause" }
+        }
+
+        XCTAssertEqual(
+            FailureClassifier.detail(PacketTunnelError.allRelaysFailed(RootCause())),
+            "connect timed out root cause"
+        )
+        XCTAssertEqual(
+            FailureClassifier.detail(PacketTunnelError.relayUnreachable(host: "1.2.3.4", port: 443, underlying: RootCause())),
+            "connect timed out root cause"
+        )
+    }
+
+    func testDetailFallsBackToWrapperDescriptionWithoutUnderlyingError() {
+        let detail = FailureClassifier.detail(PacketTunnelError.allRelaysFailed(nil))
         XCTAssertTrue(detail.hasPrefix("All relay connection attempts failed."))
     }
 }

--- a/ios/PacketTunnel/FailureClassifier.swift
+++ b/ios/PacketTunnel/FailureClassifier.swift
@@ -99,7 +99,7 @@ enum FailureClassifier {
                 return "dns_failure"
             case .tls:
                 return "tls_handshake"
-            @unknown default:
+            default:
                 break
             }
         }
@@ -143,9 +143,31 @@ enum FailureClassifier {
         String(describing: type(of: error))
     }
 
-    /// `describe(error)` truncated to fit the broker's 256-UTF-8-byte attribute limit.
+    /// The underlying/root error's description, truncated to fit the broker's 256-UTF-8-byte
+    /// attribute limit. This keeps `failure_detail` aligned with `failure_reason`: wrapper errors
+    /// like `allRelaysFailed` classify on their underlying cause, so their detail should too.
     static func detail(_ error: Error) -> String {
-        truncate(describe(error))
+        truncate(detailDescription(error))
+    }
+
+    private static func detailDescription(_ error: Error, depth: Int = 0) -> String {
+        if depth < 8, let underlying = underlyingDetailError(error) {
+            return detailDescription(underlying, depth: depth + 1)
+        }
+        return describe(error)
+    }
+
+    private static func underlyingDetailError(_ error: Error) -> Error? {
+        if let tunnelError = error as? PacketTunnelError {
+            switch tunnelError {
+            case .relayUnreachable(_, _, let underlying), .allRelaysFailed(let underlying):
+                return underlying
+            default:
+                return nil
+            }
+        }
+
+        return (error as NSError).userInfo[NSUnderlyingErrorKey] as? Error
     }
 
     /// Truncates `value` to at most `maxBytes` UTF-8 bytes without splitting a multi-byte character:

--- a/ios/PacketTunnel/FailureClassifier.swift
+++ b/ios/PacketTunnel/FailureClassifier.swift
@@ -1,0 +1,161 @@
+import Foundation
+import Network
+import NetworkExtension
+
+/// Classifies a connection failure into a stable, lowercase snake_case reason token shared with the
+/// OpenRung Go clients (desktop/CLI) and honored by the broker's "Failure reasons" dashboard.
+///
+/// The token set and precedence mirror the Go classifier (`internal/clienttelemetry/classify.go` in
+/// the sibling `openrung` repo): cancellation → relay-selection sentinels → broker HTTP status →
+/// socket errno → DNS (before generic timeout, the more actionable signal) → TLS → permission →
+/// engine-exit → generic timeout → `unknown`.
+///
+/// `PacketTunnelError.allRelaysFailed` / `.relayUnreachable` carry the underlying `Error`, so the
+/// real root cause is unwrapped and classified on its merits instead of being reported as the
+/// generic wrapper type (which is why the dashboard used to show generic Swift type names).
+enum FailureClassifier {
+    private static let maxDetailBytes = 256
+
+    /// The reason token for `error`.
+    static func classify(_ error: Error) -> String {
+        // (1) cancellation (user stop / task cancellation)
+        if error is CancellationError { return "cancelled" }
+
+        // (2) app relay-selection sentinels; unwrap the wrappers that carry the real cause.
+        if let tunnelError = error as? PacketTunnelError {
+            switch tunnelError {
+            case .noUsableRelay:
+                return "no_usable_relay"
+            case .noRelayInCountry:
+                return "no_relay_in_country"
+            case .relayNotAvailable:
+                return "relay_not_in_list"
+            case .relayUnreachable(_, _, let underlying):
+                if let underlying { return classify(underlying) }
+                return "network_unreachable"
+            case .allRelaysFailed(let underlying):
+                if let underlying { return classify(underlying) }
+                return "no_usable_relay"
+            }
+        }
+
+        // (3) broker HTTP status (429 → rate_limited, else http_<code>)
+        if let brokerError = error as? BrokerClientError {
+            switch brokerError {
+            case .httpStatus(let code):
+                return code == 429 ? "rate_limited" : "http_\(code)"
+            case .invalidResponse:
+                return "unknown"
+            }
+        }
+
+        // App reachability timeout (raised by the NWConnection probe's own deadline).
+        if let reachabilityError = error as? RelayReachabilityError {
+            switch reachabilityError {
+            case .timeout: return "timeout"
+            case .invalidPort: return "unknown"
+            }
+        }
+
+        // (4)–(9) system errors: socket errno → DNS → TLS → permission → timeout. A single
+        // URLError/NWError/POSIXError maps to exactly one of these, so DNS-before-timeout holds
+        // naturally (distinct codes) without a chain walk.
+        if let token = classifySystemError(error) { return token }
+
+        // (8) embedded proxy engine failed to start / stopped unexpectedly. It carries no nested
+        // Error, so it never coexists with a higher-precedence system error above.
+        if error is PacketTunnelProxyEngineError { return "process_exited" }
+
+        return "unknown"
+    }
+
+    private static func classifySystemError(_ error: Error) -> String? {
+        if let urlError = error as? URLError {
+            switch urlError.code {
+            case .cancelled:
+                return "cancelled"
+            case .cannotFindHost, .dnsLookupFailed:
+                return "dns_failure"
+            case .secureConnectionFailed, .serverCertificateUntrusted, .serverCertificateHasBadDate,
+                 .serverCertificateHasUnknownRoot, .serverCertificateNotYetValid,
+                 .clientCertificateRejected, .clientCertificateRequired:
+                return "tls_handshake"
+            case .cannotConnectToHost:
+                return "connection_refused"
+            case .notConnectedToInternet, .networkConnectionLost:
+                return "network_unreachable"
+            case .timedOut:
+                return "timeout"
+            default:
+                break
+            }
+        }
+
+        if let nwError = error as? NWError {
+            switch nwError {
+            case .posix(let code):
+                if let token = classifyPOSIX(code) { return token }
+            case .dns:
+                return "dns_failure"
+            case .tls:
+                return "tls_handshake"
+            @unknown default:
+                break
+            }
+        }
+
+        if let posixError = error as? POSIXError, let token = classifyPOSIX(posixError.code) {
+            return token
+        }
+
+        // Fallbacks for errors bridged as NSError (raw POSIX-domain errno, NEVPN/permission errors).
+        let nsError = error as NSError
+        if nsError.domain == NSPOSIXErrorDomain,
+           let code = POSIXErrorCode(rawValue: Int32(nsError.code)),
+           let token = classifyPOSIX(code) {
+            return token
+        }
+        if nsError.domain == NEVPNErrorDomain {
+            return "permission_denied"
+        }
+
+        return nil
+    }
+
+    private static func classifyPOSIX(_ code: POSIXErrorCode) -> String? {
+        switch code {
+        case .ECONNREFUSED: return "connection_refused"
+        case .ECONNRESET: return "connection_reset"
+        case .ENETUNREACH, .EHOSTUNREACH: return "network_unreachable"
+        case .ETIMEDOUT: return "timeout"
+        case .EACCES, .EPERM: return "permission_denied"
+        default: return nil
+        }
+    }
+
+    /// The human-readable message for `error` — the source for `failure_detail`.
+    static func describe(_ error: Error) -> String {
+        (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+    }
+
+    /// The error's type name — kept as the `error_type` attribute for dashboard continuity.
+    static func errorType(_ error: Error) -> String {
+        String(describing: type(of: error))
+    }
+
+    /// `describe(error)` truncated to fit the broker's 256-UTF-8-byte attribute limit.
+    static func detail(_ error: Error) -> String {
+        truncate(describe(error))
+    }
+
+    /// Truncates `value` to at most `maxBytes` UTF-8 bytes without splitting a multi-byte character:
+    /// the boundary is backed off past any UTF-8 continuation byte (`0b10xxxxxx`). The broker rejects
+    /// attribute values whose UTF-8 encoding exceeds 256 bytes.
+    static func truncate(_ value: String, maxBytes: Int = maxDetailBytes) -> String {
+        let bytes = Array(value.utf8)
+        if bytes.count <= maxBytes { return value }
+        var end = maxBytes
+        while end > 0 && (bytes[end] & 0xC0) == 0x80 { end -= 1 }
+        return String(decoding: bytes[0..<end], as: UTF8.self)
+    }
+}

--- a/ios/PacketTunnel/PacketTunnelError.swift
+++ b/ios/PacketTunnel/PacketTunnelError.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Connection-flow errors raised by `PacketTunnelProvider`.
+///
+/// `relayUnreachable` and `allRelaysFailed` carry the underlying `Error` (not just a message) so
+/// `FailureClassifier` can unwrap and classify the real root cause — a per-relay TCP failure or the
+/// last relay attempt's error — instead of reporting the generic wrapper. Kept in its own file so
+/// the classifier and its tests can depend on it without the NetworkExtension-backed provider.
+enum PacketTunnelError: LocalizedError {
+    case noUsableRelay
+    case noRelayInCountry(String)
+    case relayNotAvailable
+    case relayUnreachable(host: String, port: Int, underlying: Error?)
+    case allRelaysFailed(Error?)
+
+    var errorDescription: String? {
+        switch self {
+        case .noUsableRelay:
+            return "No usable VLESS Reality Vision direct-exit relay is available."
+        case .noRelayInCountry(let countryName):
+            return "No volunteer relay available in \(countryName) right now."
+        case .relayNotAvailable:
+            return "The selected relay is no longer available."
+        case .relayUnreachable(let host, let port, _):
+            return "Relay \(host):\(port) is not reachable from this device."
+        case .allRelaysFailed(let underlying):
+            if let underlying {
+                return "All relay connection attempts failed. Last error: \(FailureClassifier.describe(underlying))"
+            }
+            return "All relay connection attempts failed."
+        }
+    }
+}

--- a/ios/PacketTunnel/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider.swift
@@ -183,11 +183,14 @@ final class PacketTunnelProvider: NEPacketTunnelProvider {
         } catch {
             engine?.stop()
             engine = nil
-            let message = Self.describe(error)
-            TelemetryManager.record(
-                "connection_failed",
-                attributes: ["failure_stage": failureStage, "error_type": Self.errorType(error)]
-            )
+            let message = FailureClassifier.describe(error)
+            var attributes = ["failure_stage": failureStage, "error_type": FailureClassifier.errorType(error)]
+            // Additive: keep error_type; the broker prefers failure_reason and falls back to it.
+            let reason = FailureClassifier.classify(error)
+            if reason.isEmpty == false { attributes["failure_reason"] = reason }
+            let detail = FailureClassifier.detail(error)
+            if detail.isEmpty == false { attributes["failure_detail"] = detail }
+            TelemetryManager.record("connection_failed", attributes: attributes)
             TelemetryManager.endSession(reason: "connection_failed")
             try? await TelemetryManager.flush(brokerURL: AppConfig.telemetryBrokerURL.absoluteString)
             SharedConnectionState.fail(message)
@@ -209,8 +212,14 @@ final class PacketTunnelProvider: NEPacketTunnelProvider {
                 let tcpLatencyMs: Int64
                 do {
                     tcpLatencyMs = try await RelayReachability.checkTcp(relay)
+                } catch is CancellationError {
+                    // A racing stop cancelled the probe; propagate cancellation rather than masking
+                    // it as an unreachable relay (handled by the outer cancellation catch).
+                    throw CancellationError()
                 } catch {
-                    throw PacketTunnelError.relayUnreachable(host: relay.publicHost, port: relay.publicPort)
+                    // Carry the real cause so the failure classifies on its merits (timeout,
+                    // connection_refused, …) instead of a generic reachability token.
+                    throw PacketTunnelError.relayUnreachable(host: relay.publicHost, port: relay.publicPort, underlying: error)
                 }
 
                 let proxyEngine = EmbeddedProxyEngine()
@@ -238,19 +247,26 @@ final class PacketTunnelProvider: NEPacketTunnelProvider {
                 throw CancellationError()
             } catch {
                 lastError = error
+                var attributes = ["error_type": FailureClassifier.errorType(error)]
+                let reason = FailureClassifier.classify(error)
+                if reason.isEmpty == false { attributes["failure_reason"] = reason }
+                let detail = FailureClassifier.detail(error)
+                if detail.isEmpty == false { attributes["failure_detail"] = detail }
                 TelemetryManager.record(
                     "relay_attempt_failed",
                     relayId: relay.id,
-                    attributes: ["error_type": Self.errorType(error)],
+                    attributes: attributes,
                     measurements: ["attempt": Int64(index + 1)]
                 )
-                SharedConnectionState.appendLog("relay \(relay.id) failed: \(Self.describe(error))")
+                SharedConnectionState.appendLog("relay \(relay.id) failed: \(FailureClassifier.describe(error))")
                 engine?.stop()
                 engine = nil
             }
         }
 
-        throw PacketTunnelError.allRelaysFailed(lastError.map(Self.describe))
+        // Carry the last error itself (not just its message) so connection_failed classifies on the
+        // real root cause instead of this generic wrapper.
+        throw PacketTunnelError.allRelaysFailed(lastError)
     }
 
     /**
@@ -340,14 +356,6 @@ final class PacketTunnelProvider: NEPacketTunnelProvider {
         return normalized.isEmpty ? nil : normalized
     }
 
-    private static func errorType(_ error: Error) -> String {
-        String(describing: type(of: error))
-    }
-
-    private static func describe(_ error: Error) -> String {
-        (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
-    }
-
     private struct ConnectedRelay {
         let relay: RelayDescriptor
         let tcpLatencyMs: Int64
@@ -357,28 +365,5 @@ final class PacketTunnelProvider: NEPacketTunnelProvider {
     }
 }
 
-enum PacketTunnelError: LocalizedError {
-    case noUsableRelay
-    case noRelayInCountry(String)
-    case relayNotAvailable
-    case relayUnreachable(host: String, port: Int)
-    case allRelaysFailed(String?)
-
-    var errorDescription: String? {
-        switch self {
-        case .noUsableRelay:
-            return "No usable VLESS Reality Vision direct-exit relay is available."
-        case .noRelayInCountry(let countryName):
-            return "No volunteer relay available in \(countryName) right now."
-        case .relayNotAvailable:
-            return "The selected relay is no longer available."
-        case .relayUnreachable(let host, let port):
-            return "Relay \(host):\(port) is not reachable from this device."
-        case .allRelaysFailed(let message):
-            if let message {
-                return "All relay connection attempts failed. Last error: \(message)"
-            }
-            return "All relay connection attempts failed."
-        }
-    }
-}
+// PacketTunnelError moved to PacketTunnelError.swift so FailureClassifier and its tests can depend
+// on it without the NetworkExtension-backed provider. Its cases now carry the underlying Error.

--- a/ios/PacketTunnel/PacketTunnelProxyEngine.swift
+++ b/ios/PacketTunnel/PacketTunnelProxyEngine.swift
@@ -195,16 +195,5 @@ final class EmbeddedProxyEngine: PacketTunnelProxyEngine {
 
 #endif
 
-enum PacketTunnelProxyEngineError: LocalizedError {
-    case engineNotLinked
-    case engineStartFailed(String)
-
-    var errorDescription: String? {
-        switch self {
-        case .engineNotLinked:
-            return "Libbox.xcframework is not linked yet. Build sing-box lib_apple and add Libbox to the PacketTunnel target."
-        case .engineStartFailed(let message):
-            return "The embedded VLESS Reality Vision engine failed to start: \(message)"
-        }
-    }
-}
+// PacketTunnelProxyEngineError moved to PacketTunnelProxyEngineError.swift so FailureClassifier and
+// its tests can depend on it without linking Libbox.

--- a/ios/PacketTunnel/PacketTunnelProxyEngineError.swift
+++ b/ios/PacketTunnel/PacketTunnelProxyEngineError.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Error surfaced by the embedded libbox/sing-box proxy engine. Kept in its own file so
+/// `FailureClassifier` and its tests can depend on it without linking Libbox. Classifies as
+/// `process_exited` — the embedded-engine analogue of the Go clients' sing-box subprocess dying.
+enum PacketTunnelProxyEngineError: LocalizedError {
+    case engineNotLinked
+    case engineStartFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .engineNotLinked:
+            return "Libbox.xcframework is not linked yet. Build sing-box lib_apple and add Libbox to the PacketTunnel target."
+        case .engineStartFailed(let message):
+            return "The embedded VLESS Reality Vision engine failed to start: \(message)"
+        }
+    }
+}

--- a/ios/Shared/BrokerClient.swift
+++ b/ios/Shared/BrokerClient.swift
@@ -1,9 +1,7 @@
 import Foundation
 
-public enum BrokerClientError: Error, Equatable {
-    case invalidResponse
-    case httpStatus(Int)
-}
+// BrokerClientError moved to BrokerClientError.swift so FailureClassifier and its tests can depend
+// on it without the rest of the networking stack.
 
 /// A successful relay fetch together with the broker endpoint that served it.
 public struct BrokerFetch: Sendable {

--- a/ios/Shared/BrokerClientError.swift
+++ b/ios/Shared/BrokerClientError.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Error surfaced by `BrokerClient`. `httpStatus` carries the raw status code so a failure can be
+/// classified (429 → `rate_limited`, otherwise `http_<code>`) rather than collapsed into a generic
+/// error. Kept in its own file so `FailureClassifier` and its tests can depend on it without
+/// pulling in the whole networking stack.
+public enum BrokerClientError: Error, Equatable {
+    case invalidResponse
+    case httpStatus(Int)
+}

--- a/ios/Shared/RelayReachability.swift
+++ b/ios/Shared/RelayReachability.swift
@@ -1,10 +1,8 @@
 import Foundation
 import Network
 
-public enum RelayReachabilityError: Error, Equatable {
-    case invalidPort
-    case timeout
-}
+// RelayReachabilityError moved to RelayReachabilityError.swift so FailureClassifier and its tests
+// can depend on it without this Network-backed implementation.
 
 /// Measures TCP connect latency to a relay endpoint. Port of Android `RelayReachability.checkTcp`.
 public enum RelayReachability {

--- a/ios/Shared/RelayReachabilityError.swift
+++ b/ios/Shared/RelayReachabilityError.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/// Error surfaced by `RelayReachability.checkTcp`. Kept in its own file so `FailureClassifier` and
+/// its tests can depend on it without pulling in the `Network`-backed reachability implementation.
+public enum RelayReachabilityError: Error, Equatable {
+    case invalidPort
+    case timeout
+}

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -112,6 +112,25 @@ targets:
         CODE_SIGN_ENTITLEMENTS: PacketTunnel/PacketTunnel.entitlements
         APPLICATION_EXTENSION_API_ONLY: "YES"
 
+  # Hostless logic-test bundle for the failure classifier. It compiles FailureClassifier and the
+  # small error types it maps directly into the test module (rather than @testable-importing the
+  # extension), so the suite builds and runs without the app, CocoaPods, or Libbox.
+  OpenRungTests:
+    type: bundle.unit-test
+    platform: iOS
+    sources:
+      - path: OpenRungTests
+      - path: PacketTunnel/FailureClassifier.swift
+      - path: PacketTunnel/PacketTunnelError.swift
+      - path: PacketTunnel/PacketTunnelProxyEngineError.swift
+      - path: Shared/BrokerClientError.swift
+      - path: Shared/RelayReachabilityError.swift
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.openrung.mobile.OpenRungTests
+        GENERATE_INFOPLIST_FILE: "YES"
+        CODE_SIGNING_ALLOWED: "NO"
+
 schemes:
   # Explicit so the scheme name stays `OpenRung` for the Podfile target + xcodebuild -scheme.
   OpenRung:
@@ -122,3 +141,11 @@ schemes:
       config: Debug
     archive:
       config: Release
+  OpenRungTests:
+    build:
+      targets:
+        OpenRungTests: [test]
+    test:
+      config: Debug
+      targets:
+        - OpenRungTests


### PR DESCRIPTION
## What & why

Phase 3 of the connection-failure diagnostics work. The Android and iOS native VPN clients now **classify a connection failure into a stable reason token** and report it as `failure_reason` (plus a human-readable `failure_detail`) on the `connection_failed` and `relay_attempt_failed` telemetry events — the mobile counterpart to what already shipped in the broker and the two Go clients.

Until now both clients sent only `error_type` = the exception/error class name, which is nearly useless on the broker's "Failure reasons" panel: it showed `relay_connect · IllegalStateException` (Android wraps the real cause) and generic Swift type names, because the true root cause was buried under a generic wrapper. Now those become real tokens like `relay_connect · timeout` or `broker_fetch · rate_limited`.

## The reason enum (contract)

Lowercase snake_case tokens, **identical to the Go clients / broker** so the dashboard aggregates every client together:

`cancelled`, `timeout`, `no_relays_available`, `relay_not_in_list`, `no_relay_in_country`, `no_usable_relay`, `rate_limited`, `http_<code>`, `connection_refused`, `connection_reset`, `network_unreachable`, `dns_failure`, `tls_handshake`, `permission_denied`, `process_exited`, `unknown`.

- **`http_<code>` is a prefix pattern**, not a fixed value (e.g. `http_503`); `429` maps to `rate_limited`.
- Classification precedence mirrors the Go classifier (`internal/clienttelemetry/classify.go`): cancellation → relay-selection sentinels → broker HTTP status → socket errno → **DNS before generic timeout** → TLS → permission → engine-exit → generic timeout → `unknown`.
- `process_exited` = the *embedded* proxy engine (libbox/sing-box) failed to start or died — the mobile analogue of the Go clients' sing-box subprocess exiting.

## Backward compatible / additive

The change is purely additive: `error_type` is still sent, and the broker already prefers `failure_reason` and falls back to `error_type`. **Old app versions keep working unchanged**, and the dashboard improves the moment a new version ships these attributes.

`failure_detail` is the root cause's message, truncated to **256 UTF-8 bytes on a character boundary** (the broker rejects longer attribute values). Blank keys are omitted.

## Android — `com.openrung.vpn`

- New `FailureClassifier` walks the **entire `cause` chain to the root**, so a `SocketTimeoutException` wrapped in an `IllegalStateException` classifies as `timeout` instead of `IllegalStateException`. Errno cases inspect `android.system.ErrnoException`/`OsConstants` rather than message text.
- Replaced the bare `check(...)`/`IllegalStateException` selection failures with a typed `RelaySelectionException` sealed hierarchy (user-facing strings preserved). Added `EngineStartException` (engine start/liveness failure → `process_exited`), and the final "all relays failed" throw now preserves the last error as its cause.
- `BrokerClient` now throws a typed `BrokerHttpException(status)` (extends `IOException`, so existing callers are unaffected) instead of collapsing non-2xx into a status-less `IOException`.

## iOS — `PacketTunnel`

- New `FailureClassifier` maps `PacketTunnelError`, `URLError`, `NWError`/`POSIXError`, TLS and `NEVPN`/permission errors to the enum.
- `PacketTunnelError.allRelaysFailed` and `.relayUnreachable` now **carry the underlying `Error`** (previously a string / dropped), so the real last error is unwrapped and classified. A racing cancel during the reachability probe now propagates instead of being masked as unreachable.
- Extracted the small error enums (`PacketTunnelError`, `PacketTunnelProxyEngineError`, `BrokerClientError`, `RelayReachabilityError`) into their own files so the classifier and its tests are self-contained.

## Useful side effect

Classifying broker-fetch `429`s as `rate_limited` will finally reveal on the dashboard whether the mobile `broker_fetch` failures are the broker's per-IP rate limits or genuine network errors — previously both were an opaque `SocketException`/`IOException`.

## What I built & tested (honest status)

- **Android — built & tested here.** `./gradlew :app:compileDebugKotlin` succeeds. `./gradlew :app:testDebugUnitTest` runs **23 tests, all passing** (17 plain-JUnit cases + 6 Robolectric cases). This adds the repo's first Android unit-test source set + `testImplementation` deps (`junit`, `robolectric`). Robolectric is required only because a stubbed `android.jar` reports every `OsConstants` value as `0` and can't construct an `ErrnoException`; those errno cases run under Robolectric (`@Config(application = Application::class)` so it doesn't boot React Native / SoLoader).
- **iOS — built & tested here.** The new `OpenRungTests` logic-test target builds and runs on the iPhone 17 Pro simulator via `xcodebuild ... -scheme OpenRungTests test` — **13 tests, all passing** (`** TEST SUCCEEDED **`). The edited production code was verified to compile *and link* via `xcodebuild -target PacketTunnel -sdk iphonesimulator` (`** BUILD SUCCEEDED **`). I did **not** run a full app archive / signed build (needs signing + the RN/CocoaPods app build; out of scope and not needed to validate this change).
- **iOS project regeneration required.** `ios/project.yml` (the XcodeGen source of truth) is updated with the `OpenRungTests` target; the new Swift files land in their targets via folder globs. I intentionally did **not** commit the regenerated `OpenRung.xcodeproj`/`Podfile.lock`, because regenerating rewrites the environment-specific `hermes-engine` checksum and reshuffles CocoaPods `[CP]` phases. **Run `ios/scripts/generate-project.sh`** (xcodegen + pod install — the repo's standard step after adding native files) to materialize the target and files into Xcode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
