### PR TITLE
Ready multi-front discovery candidate list across mobile clients

### DIFF
--- a/android/app/src/main/java/com/openrung/config/AppConfig.kt
+++ b/android/app/src/main/java/com/openrung/config/AppConfig.kt
@@ -24,11 +24,21 @@ object AppConfig {
 
     /**
      * Ordered discovery candidates, tried in order until one returns relays (see
-     * [com.openrung.net.BrokerClient.firstReachable]). HTTPS-only: the unsigned relay list must never
-     * be fetched over a forgeable cleartext channel, so there is deliberately NO raw-IP fallback here.
-     * A blocked edge fails discovery CLOSED (offline) rather than open to an attacker-injected relay.
+     * [com.openrung.net.BrokerClient.firstReachable]). Every entry MUST be HTTPS: the relay list is
+     * not yet signed, so it is authenticated only by the TLS cert of the serving host — a
+     * cleartext/bare-IP entry would let an on-path censor inject a malicious relay set.
+     *
+     * Only one front is deployed today, so a censor who blocks it fails discovery CLOSED (offline).
+     * Closing that single point of failure is the front-diversity layer: adding more *HTTPS* fronts on
+     * independent CDNs/domains is safe now (still TLS-authenticated) and just needs the extra fronts
+     * deployed. Non-TLS / out-of-band channels (raw IP, cached blobs) stay off this list until the
+     * broker signs the relay list. Keep this in sync with the other clients' AppConfig.
      */
-    val DEFAULT_BROKER_URLS: List<String> = listOf(DEFAULT_BROKER_URL)
+    val DEFAULT_BROKER_URLS: List<String> = listOf(
+        DEFAULT_BROKER_URL,
+        // Additional HTTPS fronts once deployed (second domain / second CDN), e.g.:
+        //   "https://broker2.openrung.org/",
+    )
 
     /**
      * Ordered discovery candidates for a connection attempt: the caller-selected [primary] (a user

--- a/ios/Shared/AppConfig.swift
+++ b/ios/Shared/AppConfig.swift
@@ -26,10 +26,20 @@ enum AppConfig {
     static let telemetryBrokerURL = URL(string: "https://broker.openrung.org/")!
 
     /// Ordered discovery candidates, tried in order until one returns relays (see
-    /// `BrokerClient.firstReachable`). HTTPS-only: the unsigned relay list must never be fetched over
-    /// a forgeable cleartext channel, so there is deliberately NO raw-IP fallback here. A blocked edge
-    /// fails discovery CLOSED (offline) rather than open to an attacker-injected relay.
-    static let defaultBrokerURLs: [URL] = [defaultBrokerURL]
+    /// `BrokerClient.firstReachable`). Every entry MUST be HTTPS: the relay list is not yet signed, so
+    /// it is authenticated only by the TLS cert of the serving host — a cleartext/bare-IP entry would
+    /// let an on-path censor inject a malicious relay set.
+    ///
+    /// Only one front is deployed today, so a censor who blocks it fails discovery CLOSED (offline).
+    /// Closing that single point of failure is the front-diversity layer: adding more *HTTPS* fronts
+    /// on independent CDNs/domains is safe now (still TLS-authenticated) and just needs the extra
+    /// fronts deployed. Non-TLS / out-of-band channels (raw IP, cached blobs) stay off this list until
+    /// the broker signs the relay list. Keep this in sync with the other clients' AppConfig.
+    static let defaultBrokerURLs: [URL] = [
+        defaultBrokerURL,
+        // Additional HTTPS fronts once deployed (second domain / second CDN), e.g.:
+        //   URL(string: "https://broker2.openrung.org/")!,
+    ]
 
     /// Ordered broker candidates for a connection attempt: the caller-selected `primary` (the provider
     /// configuration's broker, today the default) first, then the built-in `defaultBrokerURLs`,

--- a/src/config.ts
+++ b/src/config.ts
@@ -32,11 +32,21 @@ export const AppConfig = {
 
   /**
    * Ordered discovery candidates, tried in order until one returns relays (see `firstReachable` in
-   * `net/brokerClient.ts`). HTTPS-only: the unsigned relay list must never be fetched over a
-   * forgeable cleartext channel, so there is deliberately NO raw-IP fallback here. A blocked edge
-   * fails discovery CLOSED (offline) rather than open to an attacker-injected relay.
+   * `net/brokerClient.ts`). Every entry MUST be HTTPS: the relay list is not yet signed, so it is
+   * authenticated only by the TLS cert of the serving host — a cleartext/bare-IP entry would let an
+   * on-path censor inject a malicious relay set.
+   *
+   * Only one front is deployed today, so a censor who blocks it fails discovery CLOSED (offline).
+   * Closing that single point of failure is the front-diversity layer: adding more *HTTPS* fronts on
+   * independent CDNs/domains is safe now (still TLS-authenticated) and just needs the extra fronts
+   * deployed. Non-TLS / out-of-band channels (raw IP, cached blobs) stay off this list until the
+   * broker signs the relay list. Keep this in sync with the other clients' AppConfig.
    */
-  DEFAULT_BROKER_URLS: ['https://broker.openrung.org/'],
+  DEFAULT_BROKER_URLS: [
+    'https://broker.openrung.org/',
+    // Additional HTTPS fronts once deployed (second domain / second CDN), e.g.:
+    //   'https://broker2.openrung.org/',
+  ],
 
   /**
    * Ordered discovery candidates for a connection attempt: the caller-selected `primary` (a user


### PR DESCRIPTION
## What & why

Companion to **openrung/openrung#34**. Groundwork for the broker **front-diversity resilience layer** — reducing the single point of failure where blocking one Cloudflare-fronted domain (`broker.openrung.org`) takes relay discovery fully offline for all clients.

Restructures the ordered broker-discovery candidate list in all three mobile clients so multiple HTTPS fronts can be added, and corrects a stale/misleading comment.

- `ios/Shared/AppConfig.swift` — `defaultBrokerURLs`
- `android/app/src/main/java/com/openrung/config/AppConfig.kt` — `DEFAULT_BROKER_URLS`
- `src/config.ts` — `DEFAULT_BROKER_URLS`

Each array now takes multiple entries with a one-uncomment-away slot for a second CDN/domain. The previous comments claimed there was "deliberately NO raw-IP fallback" and framed the single entry as a permanent stance; they now state the accurate rule:

- Additional **HTTPS-authenticated** fronts (second CDN, second domain) are safe to add **now** — still TLS-verified, so no relay-injection risk.
- **Non-TLS / out-of-band** channels (raw IP, cached/gossiped blobs) stay off the list until the broker signs the relay list.

## Behavior

**Unchanged.** The active candidate list is still the single working Cloudflare front — no dead endpoint is introduced, discovery is identical. This is a structure/comment change that makes activating multi-front a one-line uncomment once alternate fronts are deployed.

## Verification

- `tsc --noEmit` — clean for the touched files
- `jest brokerClient` — 70 tests pass

## Reviewer notes

- Keeps the three mobile clients in sync with the desktop client's `DefaultBrokerURLs` (changed in openrung/openrung#34). All four client configs are hand-mirrored, so they should land together.
- Actually deploying alternate fronts (second domain / second CDN) and the follow-up relay-list signing that unlocks the non-TLS channels are tracked on the core repo, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)