### PR TITLE
Try a genuine broker override strictly before racing default fronts

### DIFF
--- a/__tests__/core/brokerClient.test.ts
+++ b/__tests__/core/brokerClient.test.ts
@@ -127,31 +127,48 @@ describe('decodeRelayListResponse', () => {
 describe('candidates', () => {
   const fallbacks = ['https://broker.openrung.org/', 'http://54.238.185.205:8080/'];
 
-  it('puts a genuine primary override first, then the fallbacks', () => {
-    expect(candidates('https://my-broker.example/', fallbacks)).toEqual([
-      'https://my-broker.example/',
-      'https://broker.openrung.org/',
-      'http://54.238.185.205:8080/',
-    ]);
+  it('puts a genuine primary override first, then the fallbacks, and flags the override', () => {
+    expect(candidates('https://my-broker.example/', fallbacks)).toEqual({
+      urls: [
+        'https://my-broker.example/',
+        'https://broker.openrung.org/',
+        'http://54.238.185.205:8080/',
+      ],
+      overrideFirst: true,
+    });
   });
 
-  it('does NOT let a primary that echoes a fallback reorder the HTTPS-first defaults', () => {
-    expect(candidates('http://54.238.185.205:8080/', fallbacks)).toEqual(fallbacks);
-    expect(candidates('https://broker.openrung.org/', fallbacks)).toEqual(fallbacks);
+  it('does NOT let a primary that echoes a fallback reorder the HTTPS-first defaults or claim the override phase', () => {
+    expect(candidates('http://54.238.185.205:8080/', fallbacks)).toEqual({
+      urls: fallbacks,
+      overrideFirst: false,
+    });
+    expect(candidates('https://broker.openrung.org/', fallbacks)).toEqual({
+      urls: fallbacks,
+      overrideFirst: false,
+    });
   });
 
   it('trims the primary before comparing against fallbacks', () => {
-    expect(candidates('  https://broker.openrung.org/  ', fallbacks)).toEqual(fallbacks);
+    expect(candidates('  https://broker.openrung.org/  ', fallbacks)).toEqual({
+      urls: fallbacks,
+      overrideFirst: false,
+    });
   });
 
   it('drops blank entries and de-duplicates while preserving order', () => {
-    expect(candidates(null, ['  ', 'https://a/', 'https://a/', 'https://b/'])).toEqual([
-      'https://a/',
-      'https://b/',
-    ]);
-    expect(candidates('', fallbacks)).toEqual(fallbacks);
+    expect(candidates(null, ['  ', 'https://a/', 'https://a/', 'https://b/'])).toEqual({
+      urls: ['https://a/', 'https://b/'],
+      overrideFirst: false,
+    });
+    expect(candidates('', fallbacks)).toEqual({ urls: fallbacks, overrideFirst: false });
   });
 });
+
+/** Wraps urls as a pure-race candidate list — what `candidates()` builds without an override. */
+const noOverride = (...urls: string[]) => ({ urls, overrideFirst: false });
+/** Wraps urls as a candidate list whose FIRST entry is a genuine user override. */
+const withOverride = (...urls: string[]) => ({ urls, overrideFirst: true });
 
 describe('firstReachable (staggered discovery race)', () => {
   const STAGGER_MS = AppConfig.DISCOVERY_STAGGER_MS;
@@ -198,7 +215,7 @@ describe('firstReachable (staggered discovery race)', () => {
   it('lets a healthy primary win without ever starting the fallback', async () => {
     installFetch(async () => okResponse());
 
-    const result = await firstReachable([PRIMARY, SECONDARY]);
+    const result = await firstReachable(noOverride(PRIMARY, SECONDARY));
 
     expect(result.brokerUrl).toBe(PRIMARY);
     expect(fetchStub).toHaveBeenCalledTimes(1);
@@ -214,7 +231,7 @@ describe('firstReachable (staggered discovery race)', () => {
       url.startsWith(PRIMARY) ? hangingFetch(init) : Promise.resolve(okResponse()),
     );
 
-    const race = firstReachable([PRIMARY, SECONDARY]);
+    const race = firstReachable(noOverride(PRIMARY, SECONDARY));
 
     // Just before the stagger elapses, only the primary has been contacted.
     await jest.advanceTimersByTimeAsync(STAGGER_MS - 1);
@@ -236,7 +253,7 @@ describe('firstReachable (staggered discovery race)', () => {
       url.startsWith(TERTIARY) ? Promise.resolve(okResponse()) : hangingFetch(init),
     );
 
-    const race = firstReachable([PRIMARY, SECONDARY, TERTIARY]);
+    const race = firstReachable(noOverride(PRIMARY, SECONDARY, TERTIARY));
     expect(fetchStub).toHaveBeenCalledTimes(1); // t=0: primary starts immediately
 
     await jest.advanceTimersByTimeAsync(STAGGER_MS);
@@ -258,7 +275,7 @@ describe('firstReachable (staggered discovery race)', () => {
     installFetch(url => Promise.reject(url.startsWith(PRIMARY) ? primaryError : fallbackError));
 
     // Attach handlers up front so the eventual rejection is captured, then drive the clock.
-    const outcome = firstReachable([PRIMARY, SECONDARY]).then(
+    const outcome = firstReachable(noOverride(PRIMARY, SECONDARY)).then(
       () => {
         throw new Error('expected the race to fail');
       },
@@ -282,7 +299,7 @@ describe('firstReachable (staggered discovery race)', () => {
     installFetch(() => Promise.reject(failure));
 
     // The error propagates unchanged (same instance, not wrapped or replaced).
-    await expect(firstReachable([PRIMARY])).rejects.toBe(failure);
+    await expect(firstReachable(noOverride(PRIMARY))).rejects.toBe(failure);
     expect(fetchStub).toHaveBeenCalledTimes(1);
     // No stagger timer was ever scheduled, and the attempt's timeout timer was cleaned up.
     expect(jest.getTimerCount()).toBe(0);
@@ -290,7 +307,90 @@ describe('firstReachable (staggered discovery race)', () => {
 
   it('rejects when no candidates are configured', async () => {
     installFetch(async () => okResponse());
-    await expect(firstReachable([])).rejects.toThrow('no broker endpoints configured');
+    await expect(firstReachable(noOverride())).rejects.toThrow('no broker endpoints configured');
     expect(fetchStub).not.toHaveBeenCalled();
+  });
+
+  describe('user-override strict phase (spec point 6)', () => {
+    it('lets a genuine override slower than the stagger win — defaults are never contacted', async () => {
+      // The override answers only after 3 stagger intervals: under pure race semantics the
+      // default front would long since have won; under override-first it must never even start.
+      installFetch(url =>
+        url.startsWith(PRIMARY)
+          ? new Promise(resolve => setTimeout(() => resolve(okResponse()), STAGGER_MS * 3))
+          : Promise.resolve(okResponse()),
+      );
+
+      const outcome = firstReachable(withOverride(PRIMARY, SECONDARY));
+
+      // Well past several stagger intervals, no default has been contacted.
+      await jest.advanceTimersByTimeAsync(STAGGER_MS * 2);
+      expect(fetchStub).toHaveBeenCalledTimes(1);
+
+      await jest.advanceTimersByTimeAsync(STAGGER_MS);
+      await expect(outcome).resolves.toMatchObject({ brokerUrl: PRIMARY });
+      expect(fetchStub).toHaveBeenCalledTimes(1);
+    });
+
+    it('starts the remaining defaults only when the override FAILS, then races them on the stagger cadence', async () => {
+      const overrideError = new Error('override down');
+      installFetch((url, init) => {
+        if (url.startsWith(PRIMARY)) {
+          return new Promise((_resolve, reject) => setTimeout(() => reject(overrideError), 1_000));
+        }
+        return url.startsWith(SECONDARY) ? hangingFetch(init) : Promise.resolve(okResponse());
+      });
+
+      const outcome = firstReachable(withOverride(PRIMARY, SECONDARY, TERTIARY));
+
+      // While the override is pending, no default is contacted — there is no race yet.
+      await jest.advanceTimersByTimeAsync(999);
+      expect(fetchStub).toHaveBeenCalledTimes(1);
+
+      // The override's failure starts the remainder race: its first candidate immediately...
+      await jest.advanceTimersByTimeAsync(1);
+      expect(fetchStub).toHaveBeenCalledTimes(2);
+
+      // ...and the next one a full stagger later, on the usual cadence.
+      await jest.advanceTimersByTimeAsync(STAGGER_MS - 1);
+      expect(fetchStub).toHaveBeenCalledTimes(2);
+      await jest.advanceTimersByTimeAsync(1);
+      await expect(outcome).resolves.toMatchObject({ brokerUrl: TERTIARY });
+      expect(fetchStub).toHaveBeenCalledTimes(3);
+
+      // The hanging default that lost the remainder race was aborted for real.
+      const inits = fetchStub.mock.calls.map(([, init]) => init);
+      expect(inits[1].signal.aborted).toBe(true);
+      expect(inits[2].signal.aborted).toBe(false);
+    });
+
+    it('surfaces the override error when the remainder race also fails', async () => {
+      const overrideError = new Error('override: connection refused');
+      const defaultError = new Error('default: HTTP 502');
+      installFetch(url =>
+        Promise.reject(url.startsWith(PRIMARY) ? overrideError : defaultError),
+      );
+
+      const outcome = firstReachable(withOverride(PRIMARY, SECONDARY)).then(
+        () => {
+          throw new Error('expected the override flow to fail');
+        },
+        (error: unknown) => error,
+      );
+
+      // The override is candidates[0]: its error stays the surfaced diagnostic (spec point 4) —
+      // the user configured that broker, so its failure is what they need to see.
+      expect(await outcome).toBe(overrideError);
+      expect(fetchStub).toHaveBeenCalledTimes(2);
+    });
+
+    it('with a single overridden candidate behaves exactly like one plain attempt', async () => {
+      const failure = new Error('override broker down');
+      installFetch(() => Promise.reject(failure));
+
+      await expect(firstReachable(withOverride(PRIMARY))).rejects.toBe(failure);
+      expect(fetchStub).toHaveBeenCalledTimes(1);
+      expect(jest.getTimerCount()).toBe(0);
+    });
   });
 });

--- a/android/app/src/main/java/com/openrung/config/AppConfig.kt
+++ b/android/app/src/main/java/com/openrung/config/AppConfig.kt
@@ -45,11 +45,14 @@ object AppConfig {
     /**
      * Ordered discovery candidates for a connection attempt: the caller-selected [primary] (a user
      * override or the persisted choice) first, then the built-in [DEFAULT_BROKER_URLS], de-duplicated
-     * while preserving order. The primary is never discarded, so a user's custom broker always
-     * starts the discovery race first — in the staggered race, list position is expressed purely
-     * as a head start of [DISCOVERY_STAGGER_MS] per position — and the defaults act as fallbacks.
+     * while preserving order. A GENUINE override (a primary that is not one of the defaults) is
+     * flagged `overrideFirst`: `firstReachable` tries it strictly first with its full per-attempt
+     * timeout — a user's custom broker is never silently outrun by a default front merely for being
+     * slower than the stagger — and the defaults race as fallbacks only after it fails. A primary
+     * that echoes a default keeps the pure staggered race, where list position is just a head start
+     * of [DISCOVERY_STAGGER_MS] per position.
      */
-    fun brokerCandidates(primary: String?): List<String> =
+    fun brokerCandidates(primary: String?): com.openrung.net.BrokerClient.Candidates =
         com.openrung.net.BrokerClient.candidates(primary, DEFAULT_BROKER_URLS)
 
     /**

--- a/android/app/src/main/java/com/openrung/net/BrokerClient.kt
+++ b/android/app/src/main/java/com/openrung/net/BrokerClient.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -94,25 +95,42 @@ class BrokerClient(
     /** A successful relay fetch together with the broker endpoint that served it. */
     data class Fetch(val brokerUrl: String, val response: RelayListResponse)
 
+    /**
+     * The ordered discovery endpoints for one request, plus whether `urls[0]` is a genuine user
+     * override. Built by [candidates] and consumed by [firstReachable]; carrying the flag
+     * alongside the list keeps the two from being computed inconsistently.
+     *
+     * [overrideFirst] is true when `urls[0]` is a genuine user override — a non-blank primary
+     * that is not one of the built-in defaults. [firstReachable] then tries it strictly first
+     * (full per-attempt timeout) and only races the remaining defaults after it fails, so a
+     * custom broker that is merely slower than the stagger is never silently outrun by a
+     * default front.
+     */
+    data class Candidates(val urls: List<String>, val overrideFirst: Boolean = false)
+
     companion object {
         /**
          * Builds the ordered broker candidate list, de-duplicated while preserving order. A non-blank
          * [primary] is tried FIRST only when it is a genuine override — i.e. not already one of the
-         * [fallbacks]. A persisted value that merely echoes a built-in default must NOT reorder the
-         * defaults' preferred (HTTPS-first) ordering, otherwise an upgrader whose last-used default was
-         * the raw IP would keep hitting the IP before the Cloudflare-fronted endpoint. Pure and
-         * side-effect free so it is unit-testable.
+         * [fallbacks] — and only such an override sets [Candidates.overrideFirst], giving it the
+         * strict head phase described on [Candidates]. A persisted value that merely echoes a
+         * built-in default must NOT reorder the defaults' preferred (HTTPS-first) ordering (or claim
+         * the override phase), otherwise an upgrader whose last-used default was the raw IP would
+         * keep hitting the IP before the Cloudflare-fronted endpoint. Pure and side-effect free so
+         * it is unit-testable.
          */
-        fun candidates(primary: String?, fallbacks: List<String>): List<String> {
+        fun candidates(primary: String?, fallbacks: List<String>): Candidates {
             val ordered = LinkedHashSet<String>()
+            var overrideFirst = false
             val trimmedPrimary = primary?.trim()?.takeIf { it.isNotEmpty() }
             if (trimmedPrimary != null && fallbacks.none { it.trim() == trimmedPrimary }) {
                 ordered.add(trimmedPrimary)
+                overrideFirst = true
             }
             fallbacks.forEach { fallback ->
                 fallback.trim().takeIf { it.isNotEmpty() }?.let { ordered.add(it) }
             }
-            return ordered.toList()
+            return Candidates(ordered.toList(), overrideFirst)
         }
 
         /**
@@ -140,11 +158,21 @@ class BrokerClient(
          *     secondary.
          *  5. With a single candidate the observable behavior equals the old sequential loop:
          *     one attempt, no stagger timers, its error propagated unchanged.
+         *  6. When [Candidates.overrideFirst] is set, `urls[0]` is a GENUINE user override and
+         *     racing it would betray the user's choice: a custom broker that is merely slower
+         *     than the stagger would silently lose to a default front. The override is therefore
+         *     attempted strictly first, alone, with its full per-attempt timeout — no default is
+         *     contacted while it is pending — and it wins on any success, exactly like the old
+         *     sequential loop. Only when the override FAILS does the race of points 1–5 start
+         *     over the REMAINING candidates (the first of them immediately, the next one stagger
+         *     later, and so on). If the override and every remaining candidate fail, the
+         *     override's error is rethrown — it is `urls[0]`, so point 4's diagnostic is
+         *     unchanged.
          *
-         * Cancelling the caller cancels the whole race, including every in-flight attempt.
+         * Cancelling the caller cancels the whole flow, including every in-flight attempt.
          */
         suspend fun firstReachable(
-            candidates: List<String>,
+            candidates: Candidates,
             limit: Int = 5,
             clientId: String? = null,
             sessionId: String? = null,
@@ -154,15 +182,47 @@ class BrokerClient(
         }
 
         /**
-         * Race core behind [firstReachable] with the per-candidate fetch injectable, so the
-         * stagger / first-success / all-fail semantics are unit-testable on the JVM under
-         * virtual time (see `BrokerClientTest`) without real sockets.
+         * Core behind [firstReachable] with the per-candidate fetch injectable, so the override /
+         * stagger / first-success / all-fail semantics are unit-testable on the JVM under virtual
+         * time (see `BrokerClientTest`) without real sockets.
          */
         internal suspend fun firstReachable(
+            candidates: Candidates,
+            attempt: suspend (String) -> RelayListResponse,
+        ): Fetch {
+            require(candidates.urls.isNotEmpty()) { "no broker endpoints configured" }
+            if (!candidates.overrideFirst) return race(candidates.urls, attempt)
+
+            val overrideUrl = candidates.urls.first()
+            val overrideError: Throwable = try {
+                // Strict override phase (spec point 6): one plain attempt, full timeout, no race.
+                return Fetch(overrideUrl, attempt(overrideUrl))
+            } catch (cancellation: CancellationException) {
+                // The caller went away: rethrow its cancellation. Only an attempt that threw
+                // CancellationException of its own accord while we are still live counts as an
+                // ordinary failure (mirrors the race core's loser handling).
+                if (!currentCoroutineContext().isActive) throw cancellation
+                cancellation
+            } catch (error: Throwable) {
+                error
+            }
+            val remaining = candidates.urls.drop(1)
+            if (remaining.isEmpty()) throw overrideError
+            return try {
+                race(remaining, attempt)
+            } catch (cancellation: CancellationException) {
+                throw cancellation // the caller went away mid-race — not a broker diagnostic
+            } catch (_: Throwable) {
+                // All-fail keeps surfacing candidates[0]'s — the override's — error (spec point 4).
+                throw overrideError
+            }
+        }
+
+        /** The staggered-race core (spec points 1–5), sans override handling. */
+        private suspend fun race(
             candidates: List<String>,
             attempt: suspend (String) -> RelayListResponse,
         ): Fetch {
-            require(candidates.isNotEmpty()) { "no broker endpoints configured" }
             // Failure of each settled attempt, index-aligned with [candidates]; errors[0] is the
             // surfaced diagnostic (spec point 4). Attempts fail on arbitrary threads, but every
             // slot is written before its incrementAndGet below, so the increment that completes

--- a/android/app/src/main/java/com/openrung/vpn/OpenRungVpnService.kt
+++ b/android/app/src/main/java/com/openrung/vpn/OpenRungVpnService.kt
@@ -118,9 +118,10 @@ class OpenRungVpnService : VpnService() {
                 }
                 val brokerStarted = SystemClock.elapsedRealtime()
                 // When targeting a specific country or relay, fetch the full relay set so the
-                // target is present (the default page may otherwise miss it). Races the broker
-                // candidates with a staggered start, so a blocked primary endpoint costs one
-                // DISCOVERY_STAGGER_MS of extra latency instead of taking discovery offline.
+                // target is present (the default page may otherwise miss it). A genuine user
+                // override is tried strictly first with its full attempt timeout; the defaults
+                // race with a staggered start, so a blocked front costs one DISCOVERY_STAGGER_MS
+                // of extra latency instead of taking discovery offline.
                 val targeted = targetCountry != null || targetRelayId != null
                 val result = BrokerClient.firstReachable(
                     candidates = brokerEndpoints,
@@ -133,8 +134,9 @@ class OpenRungVpnService : VpnService() {
                 result to elapsed
             }
             val relayResponse = fetch.response
-            // If a fallback front won the discovery race (primary blocked, down, or just slower than
-            // its head start), pin the rest of this session's broker traffic (telemetry, heartbeats)
+            // If a fallback front won discovery — a genuine override is beaten only by FAILING
+            // outright (it is tried strictly first); a default primary also when merely slower than
+            // its head start — pin the rest of this session's broker traffic (telemetry, heartbeats)
             // to the endpoint that worked. The persisted/configured broker URL is left untouched so a
             // user's custom choice survives.
             if (fetch.brokerUrl != brokerUrl) {

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -12,7 +12,7 @@
     <string name="status_disconnecting">Disconnecting</string>
     <string name="status_failed">Failed</string>
     <string name="log_fetching_relays">fetching relays from %1$s</string>
-    <string name="log_broker_fallback">primary broker lost the discovery race; using fallback %1$s</string>
+    <string name="log_broker_fallback">configured broker did not win discovery; using fallback %1$s</string>
     <string name="log_broker_returned">broker returned %1$d relays; %2$d usable</string>
     <string name="log_connecting_country">connecting to a volunteer in %1$s</string>
     <string name="log_connecting_relay">connecting to relay %1$s</string>

--- a/android/app/src/test/java/com/openrung/net/BrokerClientTest.kt
+++ b/android/app/src/test/java/com/openrung/net/BrokerClientTest.kt
@@ -4,7 +4,9 @@ import com.openrung.config.AppConfig
 import com.openrung.model.RelayListResponse
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.currentTime
 import kotlinx.coroutines.test.runTest
@@ -15,6 +17,13 @@ import java.io.IOException
 
 private const val PRIMARY = "https://primary.example/"
 private const val FALLBACK = "https://fallback.example/"
+
+/** Wraps urls as a pure-race candidate list — what [BrokerClient.candidates] builds without an override. */
+private fun noOverride(vararg urls: String) = BrokerClient.Candidates(urls.toList())
+
+/** Wraps urls as a candidate list whose FIRST entry is a genuine user override. */
+private fun withOverride(vararg urls: String) =
+    BrokerClient.Candidates(urls.toList(), overrideFirst = true)
 
 /**
  * Virtual-time tests for the staggered-race discovery in [BrokerClient.firstReachable], driven
@@ -31,7 +40,7 @@ class BrokerClientTest {
     @Test
     fun `healthy primary wins without the fallback ever starting`() = runTest {
         val started = mutableListOf<String>()
-        val fetch = BrokerClient.firstReachable(listOf(PRIMARY, FALLBACK)) { url ->
+        val fetch = BrokerClient.firstReachable(noOverride(PRIMARY, FALLBACK)) { url ->
             started += url
             delay(40) // healthy: answers well inside the first stagger window
             relayList
@@ -47,7 +56,7 @@ class BrokerClientTest {
     @Test
     fun `fallback beats a hanging primary one stagger in and the loser is cancelled`() = runTest {
         var primaryCancelled = false
-        val fetch = BrokerClient.firstReachable(listOf(PRIMARY, FALLBACK)) { url ->
+        val fetch = BrokerClient.firstReachable(noOverride(PRIMARY, FALLBACK)) { url ->
             if (url == PRIMARY) {
                 try {
                     awaitCancellation() // blackholed: never answers, never fails
@@ -71,7 +80,7 @@ class BrokerClientTest {
         val urls = listOf("https://a.example/", "https://b.example/", "https://c.example/")
         val startTimes = linkedMapOf<String, Long>()
         val cancelled = mutableSetOf<String>()
-        val fetch = BrokerClient.firstReachable(urls) { url ->
+        val fetch = BrokerClient.firstReachable(BrokerClient.Candidates(urls)) { url ->
             startTimes[url] = currentTime
             if (url != urls.last()) {
                 try {
@@ -102,7 +111,7 @@ class BrokerClientTest {
         val startTimes = mutableListOf<Long>()
         val primaryError = IOException("primary down")
         val thrown = runCatching {
-            BrokerClient.firstReachable(urls) { url ->
+            BrokerClient.firstReachable(BrokerClient.Candidates(urls)) { url ->
                 startTimes += currentTime
                 throw if (url == urls.first()) primaryError else IOException("$url down")
             }
@@ -125,7 +134,7 @@ class BrokerClientTest {
         var attempts = 0
         val error = IOException("only broker down")
         val thrown = runCatching {
-            BrokerClient.firstReachable(listOf(PRIMARY)) {
+            BrokerClient.firstReachable(noOverride(PRIMARY)) {
                 attempts++
                 throw error
             }
@@ -139,9 +148,107 @@ class BrokerClientTest {
     @Test
     fun `an empty candidate list is rejected up front`() = runTest {
         val thrown = runCatching {
-            BrokerClient.firstReachable(emptyList()) { relayList }
+            BrokerClient.firstReachable(BrokerClient.Candidates(emptyList())) { relayList }
         }.exceptionOrNull()
         assertTrue(thrown is IllegalArgumentException)
         assertEquals("no broker endpoints configured", thrown?.message)
+    }
+
+    // User-override strict phase (spec point 6).
+
+    @Test
+    fun `an override slower than the stagger still wins and the default is never contacted`() = runTest {
+        // The override answers only after 3 stagger intervals: under pure race semantics the
+        // default front would long since have won; under override-first it must never even start.
+        val started = mutableListOf<String>()
+        val fetch = BrokerClient.firstReachable(withOverride(PRIMARY, FALLBACK)) { url ->
+            started += url
+            delay(3 * AppConfig.DISCOVERY_STAGGER_MS) // slower than the stagger, inside its timeout
+            relayList
+        }
+        assertEquals(PRIMARY, fetch.brokerUrl)
+        assertEquals(3 * AppConfig.DISCOVERY_STAGGER_MS, currentTime)
+        // Long after the override won, no default has been contacted — there was never a race.
+        advanceTimeBy(3 * AppConfig.DISCOVERY_STAGGER_MS)
+        assertEquals(listOf(PRIMARY), started)
+    }
+
+    @Test
+    fun `an override failure starts the remaining defaults on the race cadence`() = runTest {
+        val urls = listOf("https://override.example/", "https://a.example/", "https://b.example/")
+        val startTimes = linkedMapOf<String, Long>()
+        val fetch = BrokerClient.firstReachable(BrokerClient.Candidates(urls, overrideFirst = true)) { url ->
+            startTimes[url] = currentTime
+            when (url) {
+                urls[0] -> {
+                    delay(1_000)
+                    throw IOException("override down")
+                }
+                urls[1] -> awaitCancellation() // hangs; loses the remainder race
+                else -> relayList
+            }
+        }
+        assertEquals(urls[2], fetch.brokerUrl)
+        assertEquals(
+            mapOf(
+                urls[0] to 0L,
+                // The first default starts only when the override fails — not one stagger in —
+                // and the next one joins a full stagger later, on the usual cadence.
+                urls[1] to 1_000L,
+                urls[2] to 1_000L + AppConfig.DISCOVERY_STAGGER_MS,
+            ),
+            startTimes,
+        )
+    }
+
+    @Test
+    fun `the override error is surfaced when the remainder race also fails`() = runTest {
+        // The override is candidates[0]: its error stays the surfaced diagnostic (spec point 4) —
+        // the user configured that broker, so its failure is what they need to see.
+        val overrideError = IOException("override down")
+        val thrown = runCatching {
+            BrokerClient.firstReachable(withOverride(PRIMARY, FALLBACK)) { url ->
+                throw if (url == PRIMARY) overrideError else IOException("fallback down")
+            }
+        }.exceptionOrNull()
+        assertTrue(thrown === overrideError || thrown?.cause === overrideError)
+        assertEquals("override down", thrown?.message)
+    }
+
+    @Test
+    fun `a single overridden candidate behaves exactly like the old sequential attempt`() = runTest {
+        var attempts = 0
+        val error = IOException("only broker down")
+        val thrown = runCatching {
+            BrokerClient.firstReachable(withOverride(PRIMARY)) {
+                attempts++
+                throw error
+            }
+        }.exceptionOrNull()
+        assertEquals(1, attempts)
+        assertTrue(thrown === error || thrown?.cause === error)
+        assertEquals(0L, currentTime) // no remainder race, no stagger timer
+    }
+
+    @Test
+    fun `cancelling the caller mid-remainder-race propagates the cancellation`() = runTest {
+        // The override fails fast, the remaining default hangs, then the caller cancels. The
+        // surfaced error must be the cancellation — what the caller classifies on — not the
+        // override's stale failure.
+        var thrown: Throwable? = null
+        val job = launch {
+            try {
+                BrokerClient.firstReachable(withOverride(PRIMARY, FALLBACK)) { url ->
+                    if (url == PRIMARY) throw IOException("override down")
+                    awaitCancellation()
+                }
+            } catch (error: Throwable) {
+                thrown = error
+                throw error
+            }
+        }
+        advanceTimeBy(1) // let the override fail and the default start hanging
+        job.cancelAndJoin()
+        assertTrue(thrown is CancellationException)
     }
 }

--- a/ios/OpenRung.xcodeproj/project.pbxproj
+++ b/ios/OpenRung.xcodeproj/project.pbxproj
@@ -649,7 +649,7 @@
 					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
 					"\"$(inherited)\"",
 				);
-				MARKETING_VERSION = "${APP_VERSION}";
+				MARKETING_VERSION = 0.2.5;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -791,7 +791,7 @@
 					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
 					"\"$(inherited)\"",
 				);
-				MARKETING_VERSION = "${APP_VERSION}";
+				MARKETING_VERSION = 0.2.5;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				OTHER_CPLUSPLUSFLAGS = (

--- a/ios/OpenRung.xcodeproj/project.pbxproj
+++ b/ios/OpenRung.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		02A118A7025D0906AAA606E1 /* NetworkPathMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C127CAD14278743A1BD298 /* NetworkPathMonitor.swift */; };
 		02E9AD5F4252406BE29B4B5D /* BrokerClientError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683F07997A392045B7540E47 /* BrokerClientError.swift */; };
 		0483F1444764AB1812DC4A79 /* GeoIpClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 135777353E0B842A0E8E1A49 /* GeoIpClient.swift */; };
+		069A422F72032F6301328723 /* AppConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4783169BE46FEE9B0472504 /* AppConfig.swift */; };
 		0B37B967668B130238C8E4EF /* BrokerEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF772A16497903CC49D1F76D /* BrokerEndpoint.swift */; };
 		1001D8102F7EA1A694366DFF /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A9B3E3F0BA7E28C5D05A1731 /* Images.xcassets */; };
 		101812ACF2D87E69B666B516 /* DeviceAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E77D10C22E8939116D44BD /* DeviceAttributes.swift */; };
@@ -25,9 +26,10 @@
 		293B5AB965931E683887D8F4 /* TelemetryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA18FA5754E54F0ADC5189F0 /* TelemetryManager.swift */; };
 		2C3222CCA8C27C06BBA68F85 /* FailureClassifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F3B6378B98E464A9F306E7 /* FailureClassifier.swift */; };
 		2E0156D4F82558FA780E5EFD /* ClientIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD4088394FB9EBCF808F81C2 /* ClientIdentity.swift */; };
-		2F51432049497BF9149B2181 /* libPods-OpenRung.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 739B4A424248AA70C895A125 /* libPods-OpenRung.a */; };
+		3211CE2D43E97CFA91D9E7FF /* BrokerClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9771BD2BC7057921FF185C4C /* BrokerClientTests.swift */; };
 		352F6CA320938DBB039664C2 /* GeoIpClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 135777353E0B842A0E8E1A49 /* GeoIpClient.swift */; };
 		37B87770F048737201BAE35F /* TelemetryOutbox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BFFA22BC1A97C70EF5F275D /* TelemetryOutbox.swift */; };
+		37E79B346F6A9846A9410761 /* BrokerEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF772A16497903CC49D1F76D /* BrokerEndpoint.swift */; };
 		39331D5AF76FB94FA1EB09CA /* PacketTunnelProxyEngineError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A0014BD8DAE8D1AB0AA819 /* PacketTunnelProxyEngineError.swift */; };
 		395673F4F22F8D43200B404C /* ConnectionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 584A04475F28B3CAC39B501E /* ConnectionStatus.swift */; };
 		3CCF2F1EFD201AD5A17B3998 /* BrokerClientError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683F07997A392045B7540E47 /* BrokerClientError.swift */; };
@@ -69,15 +71,19 @@
 		BF55D9C9334181B84F1D36EC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 83209B5DF847F742A280CD21 /* LaunchScreen.storyboard */; };
 		C1A6F6AC896E2EE68FCD7AC9 /* RelayReachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5AFE2F1F1556F9E70F0AC99 /* RelayReachability.swift */; };
 		C30EDE383463DB3F401D317E /* SharedConnectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D11601E153A60E8B30351E20 /* SharedConnectionState.swift */; };
+		C434209DCAFA9B2D3BA91E84 /* DeviceAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E77D10C22E8939116D44BD /* DeviceAttributes.swift */; };
 		C4B31101802A2AE5B0E26703 /* LibboxPacketTunnelPlatformInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97D23B885595CDD6DD259A85 /* LibboxPacketTunnelPlatformInterface.swift */; };
 		C98C9E042E602DF887F4B995 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A025739761D97ABD7227B8DA /* PrivacyInfo.xcprivacy */; };
 		CCB2C474FEDC465EA9762C71 /* TelemetryClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4254868EF5882AD951E8D23B /* TelemetryClient.swift */; };
 		CE5FF08F60EA9B59A3FAD581 /* RelayReachabilityError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FF4517B34B4819F6DCD4D1 /* RelayReachabilityError.swift */; };
 		D095482C735B4750F9AC99BB /* RelayDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC6AEF8D510DD407C368119F /* RelayDescriptor.swift */; };
+		D222D8CD2611D57559062B89 /* NetworkPathMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C127CAD14278743A1BD298 /* NetworkPathMonitor.swift */; };
+		DA7F413E3D63AC3050CE4A6B /* BrokerClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0CE1F672D5FAD1FBB511D5B /* BrokerClient.swift */; };
 		E23AB43D1F262132DECB88F3 /* PacketTunnelProxyEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = D65DF435DF84A90675DAFD54 /* PacketTunnelProxyEngine.swift */; };
 		E2C945F0A942AE0E937369EC /* OpenRungVpnModule.m in Sources */ = {isa = PBXBuildFile; fileRef = ED28831CA960E8B89D5D7D04 /* OpenRungVpnModule.m */; };
 		E6799BE42347DC306ADF2213 /* RelayReachabilityError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FF4517B34B4819F6DCD4D1 /* RelayReachabilityError.swift */; };
 		EAD1DFA9AB52E6A93CB60890 /* FailureClassifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F3B6378B98E464A9F306E7 /* FailureClassifier.swift */; };
+		EB4BB9C6B76C65809224DF35 /* RelayDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC6AEF8D510DD407C368119F /* RelayDescriptor.swift */; };
 		ED0AA86BCFC9211195B7081E /* ClientIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD4088394FB9EBCF808F81C2 /* ClientIdentity.swift */; };
 		EE4F9A809147703D746C60EB /* libresolv.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = EC15DA1827B19848080D3452 /* libresolv.tbd */; };
 		F394E6F8661ECC0CFB89B18F /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 81CC00C2F7324111F25D07A0 /* UIKit.framework */; };
@@ -127,12 +133,11 @@
 		683F07997A392045B7540E47 /* BrokerClientError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrokerClientError.swift; sourceTree = "<group>"; };
 		6A5299A99DA8ED8C75B1E25B /* TelemetrySession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetrySession.swift; sourceTree = "<group>"; };
 		719ACF45718CBF52773FCD6C /* OpenRungVpnModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenRungVpnModule.swift; sourceTree = "<group>"; };
-		739B4A424248AA70C895A125 /* libPods-OpenRung.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-OpenRung.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		75EA37B450C63159CA5C16FA /* Pods-OpenRung.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OpenRung.release.xcconfig"; path = "Target Support Files/Pods-OpenRung/Pods-OpenRung.release.xcconfig"; sourceTree = "<group>"; };
 		7A07146C137269D283F062DB /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		81B10868A3F7FA99A84696A4 /* OpenRung.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = OpenRung.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		81CC00C2F7324111F25D07A0 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		83209B5DF847F742A280CD21 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
+		9771BD2BC7057921FF185C4C /* BrokerClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrokerClientTests.swift; sourceTree = "<group>"; };
 		97D23B885595CDD6DD259A85 /* LibboxPacketTunnelPlatformInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibboxPacketTunnelPlatformInterface.swift; sourceTree = "<group>"; };
 		9C27022D3D9D7FEEC839F406 /* ActivityLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityLog.swift; sourceTree = "<group>"; };
 		9C3C1158F41CEF59BEB36FEB /* PacketTunnelError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PacketTunnelError.swift; sourceTree = "<group>"; };
@@ -144,7 +149,6 @@
 		B3A0014BD8DAE8D1AB0AA819 /* PacketTunnelProxyEngineError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PacketTunnelProxyEngineError.swift; sourceTree = "<group>"; };
 		B9D3B66E26E617B7B00140A4 /* PacketTunnelProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PacketTunnelProvider.swift; sourceTree = "<group>"; };
 		BA18FA5754E54F0ADC5189F0 /* TelemetryManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryManager.swift; sourceTree = "<group>"; };
-		C0B991DD5EDE0739BE56D2A4 /* Pods-OpenRung.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OpenRung.debug.xcconfig"; path = "Target Support Files/Pods-OpenRung/Pods-OpenRung.debug.xcconfig"; sourceTree = "<group>"; };
 		C28E2B488D1B810BD0BB8AA1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		C4E77D10C22E8939116D44BD /* DeviceAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceAttributes.swift; sourceTree = "<group>"; };
 		C9F3B6378B98E464A9F306E7 /* FailureClassifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FailureClassifier.swift; sourceTree = "<group>"; };
@@ -176,14 +180,6 @@
 				BB4F499FD2BC0AAC963D515B /* Libbox.xcframework in Frameworks */,
 				F394E6F8661ECC0CFB89B18F /* UIKit.framework in Frameworks */,
 				EE4F9A809147703D746C60EB /* libresolv.tbd in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		F6A66E991A4B9EA0848A72AC /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				2F51432049497BF9149B2181 /* libPods-OpenRung.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -242,19 +238,10 @@
 		837FBBD5687C0AB326CC593E /* OpenRungTests */ = {
 			isa = PBXGroup;
 			children = (
+				9771BD2BC7057921FF185C4C /* BrokerClientTests.swift */,
 				E89C58EA730C659109459911 /* FailureClassifierTests.swift */,
 			);
 			path = OpenRungTests;
-			sourceTree = "<group>";
-		};
-		9FE6AFBA8B6C120542269256 /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				C0B991DD5EDE0739BE56D2A4 /* Pods-OpenRung.debug.xcconfig */,
-				75EA37B450C63159CA5C16FA /* Pods-OpenRung.release.xcconfig */,
-			);
-			name = Pods;
-			path = Pods;
 			sourceTree = "<group>";
 		};
 		A1C815B9A63C637692C1C541 /* Frameworks */ = {
@@ -263,7 +250,6 @@
 				F19AE6300C331CB6C7B2B9E8 /* Libbox.xcframework */,
 				EC15DA1827B19848080D3452 /* libresolv.tbd */,
 				81CC00C2F7324111F25D07A0 /* UIKit.framework */,
-				739B4A424248AA70C895A125 /* libPods-OpenRung.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -303,7 +289,6 @@
 				3F24A472F75132572E2891A1 /* Shared */,
 				A1C815B9A63C637692C1C541 /* Frameworks */,
 				E73A5155909F9EFE9F13A6A1 /* Products */,
-				9FE6AFBA8B6C120542269256 /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -322,6 +307,8 @@
 			dependencies = (
 			);
 			name = PacketTunnel;
+			packageProductDependencies = (
+			);
 			productName = PacketTunnel;
 			productReference = 1EAA8B2F5746A87534F0C87B /* PacketTunnel.appex */;
 			productType = "com.apple.product-type.app-extension";
@@ -330,15 +317,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F19D0D1C8CB7FB1B6B178E82 /* Build configuration list for PBXNativeTarget "OpenRung" */;
 			buildPhases = (
-				88F41DF9A85053D4E116BDF2 /* [CP] Check Pods Manifest.lock */,
 				BC3282E3662088C7CF8F8BC7 /* Sources */,
 				7272F5C7D4F2765DAB69942D /* Resources */,
 				141D130B421160859A220937 /* Embed Foundation Extensions */,
 				7645E65DA025354651549041 /* Bundle React Native code and images */,
-				E14B0AF1D929D24368D45514 /* [MapLibre React Native] Remove MapLibre.xcframework-ios.signature */,
-				F6A66E991A4B9EA0848A72AC /* Frameworks */,
-				23F6B208A008DEB0E6791759 /* [CP] Embed Pods Frameworks */,
-				5870AD9C69E407AC5CF86CA3 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -347,7 +329,6 @@
 			);
 			name = OpenRung;
 			packageProductDependencies = (
-				54789229C997837AEFCB20DF /* MapLibre */,
 			);
 			productName = OpenRung;
 			productReference = 81B10868A3F7FA99A84696A4 /* OpenRung.app */;
@@ -364,6 +345,8 @@
 			dependencies = (
 			);
 			name = OpenRungTests;
+			packageProductDependencies = (
+			);
 			productName = OpenRungTests;
 			productReference = 174E944F053F54F691E59C74 /* OpenRungTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -400,9 +383,6 @@
 			);
 			mainGroup = F4646C7E57CBAA9E0DF5661F;
 			minimizedProjectReferenceProxies = 1;
-			packageReferences = (
-				DF1A68EFD7AE0666ED66EEAF /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */,
-			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = E73A5155909F9EFE9F13A6A1 /* Products */;
 			projectDirPath = "";
@@ -429,40 +409,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		23F6B208A008DEB0E6791759 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-OpenRung/Pods-OpenRung-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-OpenRung/Pods-OpenRung-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-OpenRung/Pods-OpenRung-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		5870AD9C69E407AC5CF86CA3 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-OpenRung/Pods-OpenRung-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-OpenRung/Pods-OpenRung-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-OpenRung/Pods-OpenRung-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		7645E65DA025354651549041 /* Bundle React Native code and images */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -482,47 +428,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -e\n\nWITH_ENVIRONMENT=\"$REACT_NATIVE_PATH/scripts/xcode/with-environment.sh\"\nREACT_NATIVE_XCODE=\"$REACT_NATIVE_PATH/scripts/react-native-xcode.sh\"\n\n/bin/sh -c \"\\\"$WITH_ENVIRONMENT\\\" \\\"$REACT_NATIVE_XCODE\\\"\"\n";
-		};
-		88F41DF9A85053D4E116BDF2 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-OpenRung-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		E14B0AF1D929D24368D45514 /* [MapLibre React Native] Remove MapLibre.xcframework-ios.signature */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "[MapLibre React Native] Remove MapLibre.xcframework-ios.signature";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "rm -rf \"$CONFIGURATION_BUILD_DIR/MapLibre.xcframework-ios.signature\"";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -572,11 +477,18 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				069A422F72032F6301328723 /* AppConfig.swift in Sources */,
+				DA7F413E3D63AC3050CE4A6B /* BrokerClient.swift in Sources */,
 				3CCF2F1EFD201AD5A17B3998 /* BrokerClientError.swift in Sources */,
+				3211CE2D43E97CFA91D9E7FF /* BrokerClientTests.swift in Sources */,
+				37E79B346F6A9846A9410761 /* BrokerEndpoint.swift in Sources */,
+				C434209DCAFA9B2D3BA91E84 /* DeviceAttributes.swift in Sources */,
 				2C3222CCA8C27C06BBA68F85 /* FailureClassifier.swift in Sources */,
 				3E600B1A4A0F6A075AB8D6E7 /* FailureClassifierTests.swift in Sources */,
+				D222D8CD2611D57559062B89 /* NetworkPathMonitor.swift in Sources */,
 				01C5EA0362C5AAB18ED81859 /* PacketTunnelError.swift in Sources */,
 				39331D5AF76FB94FA1EB09CA /* PacketTunnelProxyEngineError.swift in Sources */,
+				EB4BB9C6B76C65809224DF35 /* RelayDescriptor.swift in Sources */,
 				E6799BE42347DC306ADF2213 /* RelayReachabilityError.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -631,7 +543,6 @@
 /* Begin XCBuildConfiguration section */
 		0D953B3D127C0BB08E644293 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 75EA37B450C63159CA5C16FA /* Pods-OpenRung.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = OpenRung/OpenRung.entitlements;
@@ -738,14 +649,10 @@
 					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
 					"\"$(inherited)\"",
 				);
-				MARKETING_VERSION = 0.2.5;
+				MARKETING_VERSION = "${APP_VERSION}";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-DRCT_REMOVE_LEGACY_ARCH=1",
-				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"$(OTHER_CFLAGS)",
 					"-DFOLLY_NO_CONFIG",
@@ -753,23 +660,17 @@
 					"-DFOLLY_USE_LIBCPP=1",
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
-					"-DRCT_REMOVE_LEGACY_ARCH=1",
 				);
-				PODFILE_DIR = "$(SRCROOT)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
-				SWIFT_ENABLE_EXPLICIT_MODULES = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
-				USE_HERMES = true;
 			};
 			name = Debug;
 		};
 		73BE8C16CB91640112F4357A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C0B991DD5EDE0739BE56D2A4 /* Pods-OpenRung.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = OpenRung/OpenRung.entitlements;
@@ -890,13 +791,9 @@
 					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
 					"\"$(inherited)\"",
 				);
-				MARKETING_VERSION = 0.2.5;
+				MARKETING_VERSION = "${APP_VERSION}";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-DRCT_REMOVE_LEGACY_ARCH=1",
-				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"$(OTHER_CFLAGS)",
 					"-DFOLLY_NO_CONFIG",
@@ -904,17 +801,12 @@
 					"-DFOLLY_USE_LIBCPP=1",
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
-					"-DRCT_REMOVE_LEGACY_ARCH=1",
 				);
-				PODFILE_DIR = "$(SRCROOT)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_ENABLE_EXPLICIT_MODULES = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 5.0;
-				USE_HERMES = true;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -980,25 +872,6 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
-
-/* Begin XCRemoteSwiftPackageReference section */
-		DF1A68EFD7AE0666ED66EEAF /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/maplibre/maplibre-gl-native-distribution";
-			requirement = {
-				kind = exactVersion;
-				version = 6.26.0;
-			};
-		};
-/* End XCRemoteSwiftPackageReference section */
-
-/* Begin XCSwiftPackageProductDependency section */
-		54789229C997837AEFCB20DF /* MapLibre */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = DF1A68EFD7AE0666ED66EEAF /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */;
-			productName = MapLibre;
-		};
-/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 146F6B38E4A347A28C649EC1 /* Project object */;
 }

--- a/ios/OpenRungTests/BrokerClientTests.swift
+++ b/ios/OpenRungTests/BrokerClientTests.swift
@@ -1,0 +1,287 @@
+import Foundation
+import XCTest
+
+/// Tests for the override-first / staggered-race discovery in `BrokerClient.firstReachable`,
+/// driven through the internal fetch-injectable overload with a shortened stagger so no real
+/// sockets (or real 2.5 s staggers) are involved. Mirrors the reference TypeScript suite
+/// (`__tests__/core/brokerClient.test.ts`) and the Kotlin `BrokerClientTest` — the override /
+/// race semantics must stay identical across the desktop Go, RN TypeScript, Kotlin and Swift
+/// clients.
+final class BrokerClientTests: XCTestCase {
+    private static let primary = URL(string: "https://primary.example/")!
+    private static let fallback = URL(string: "https://fallback.example/")!
+
+    /// Short enough to keep the suite fast, long enough that ordering assertions are unambiguous
+    /// against real-clock scheduling jitter.
+    private static let staggerMs: UInt64 = 100
+
+    private static let relayList = RelayListResponse(count: 0, serverTime: Date(), relays: [])
+
+    /// Wraps urls as a pure-race candidate list — what `BrokerClient.candidates` builds without
+    /// an override.
+    private static func noOverride(_ urls: URL...) -> BrokerCandidates {
+        BrokerCandidates(urls: urls)
+    }
+
+    /// Wraps urls as a candidate list whose FIRST entry is a genuine user override.
+    private static func withOverride(_ urls: URL...) -> BrokerCandidates {
+        BrokerCandidates(urls: urls, overrideFirst: true)
+    }
+
+    private static func sleep(ms: UInt64) async throws {
+        try await Task.sleep(nanoseconds: ms * 1_000_000)
+    }
+
+    /// Hangs until the surrounding attempt is cancelled — a blackholed/censored endpoint.
+    /// `Task.sleep` rethrows `CancellationError` the moment the attempt is cancelled.
+    private static func hangUntilCancelled() async throws -> Never {
+        while true {
+            try await sleep(ms: 3_600_000)
+        }
+    }
+
+    /// Thread-safe record of which endpoints were attempted, in start order.
+    private actor AttemptLog {
+        private(set) var attempts: [URL] = []
+        func record(_ url: URL) {
+            attempts.append(url)
+        }
+    }
+
+    private struct AttemptError: Error, Equatable {
+        let url: URL
+    }
+
+    // Staggered race (spec points 1–5).
+
+    func testHealthyPrimaryWinsWithoutTheFallbackEverStarting() async throws {
+        let log = AttemptLog()
+        let fetch = try await BrokerClient.firstReachable(
+            candidates: Self.noOverride(Self.primary, Self.fallback),
+            staggerMs: Self.staggerMs
+        ) { url in
+            await log.record(url)
+            try await Self.sleep(ms: 10) // healthy: answers well inside the first stagger window
+            return Self.relayList
+        }
+        XCTAssertEqual(fetch.brokerURL, Self.primary)
+        // Long after the race settled, no leftover stagger sleeper may fire: the fallback front
+        // never sees a request while the primary is healthy.
+        try await Self.sleep(ms: 3 * Self.staggerMs)
+        let attempts = await log.attempts
+        XCTAssertEqual(attempts, [Self.primary])
+    }
+
+    func testFallbackBeatsAHangingPrimaryOneStaggerInAndTheLoserIsCancelled() async throws {
+        let primaryCancelled = expectation(description: "primary attempt cancelled")
+        let fetch = try await BrokerClient.firstReachable(
+            candidates: Self.noOverride(Self.primary, Self.fallback),
+            staggerMs: Self.staggerMs
+        ) { url in
+            if url == Self.primary {
+                do {
+                    try await Self.hangUntilCancelled() // blackholed: never answers, never fails
+                } catch {
+                    primaryCancelled.fulfill()
+                    throw error
+                }
+            }
+            return Self.relayList
+        }
+        // The later candidate that succeeds first wins even though the earlier-priority attempt
+        // is still pending — priority is only a head start (spec point 2)...
+        XCTAssertEqual(fetch.brokerURL, Self.fallback)
+        // ...and the losing attempt was aborted for real, not left running to its timeout.
+        await fulfillment(of: [primaryCancelled], timeout: 5)
+    }
+
+    func testOneCandidateJoinsTheRacePerStaggerAndALateWinnerCancelsEveryLoser() async throws {
+        let a = URL(string: "https://a.example/")!
+        let b = URL(string: "https://b.example/")!
+        let c = URL(string: "https://c.example/")!
+        let log = AttemptLog()
+        let losersCancelled = expectation(description: "both losing attempts cancelled")
+        losersCancelled.expectedFulfillmentCount = 2
+        let fetch = try await BrokerClient.firstReachable(
+            candidates: Self.noOverride(a, b, c),
+            staggerMs: Self.staggerMs
+        ) { url in
+            await log.record(url)
+            if url != c {
+                do {
+                    try await Self.hangUntilCancelled()
+                } catch {
+                    losersCancelled.fulfill()
+                    throw error
+                }
+            }
+            return Self.relayList
+        }
+        XCTAssertEqual(fetch.brokerURL, c)
+        // One candidate joined per stagger, in list order; the winner cancelled every loser.
+        let attempts = await log.attempts
+        XCTAssertEqual(attempts, [a, b, c])
+        await fulfillment(of: [losersCancelled], timeout: 5)
+    }
+
+    func testAllCandidatesFailingSurfacesThePrimaryError() async {
+        do {
+            _ = try await BrokerClient.firstReachable(
+                candidates: Self.noOverride(Self.primary, Self.fallback),
+                staggerMs: Self.staggerMs
+            ) { url in
+                throw AttemptError(url: url)
+            }
+            XCTFail("expected the race to fail")
+        } catch {
+            // The FIRST candidate's failure is the surfaced diagnostic, not the last-observed
+            // one (spec point 4).
+            XCTAssertEqual(error as? AttemptError, AttemptError(url: Self.primary))
+        }
+    }
+
+    func testASingleCandidateBehavesExactlyLikeOnePlainAttempt() async {
+        let log = AttemptLog()
+        let begun = Date()
+        do {
+            _ = try await BrokerClient.firstReachable(
+                candidates: Self.noOverride(Self.primary),
+                staggerMs: 600_000 // a stagger sleep would be unmissable (spec point 5)
+            ) { url in
+                await log.record(url)
+                throw AttemptError(url: url)
+            }
+            XCTFail("expected the attempt to fail")
+        } catch {
+            // The error propagates unchanged, immediately — no stagger sleeper was scheduled.
+            XCTAssertEqual(error as? AttemptError, AttemptError(url: Self.primary))
+        }
+        XCTAssertLessThan(Date().timeIntervalSince(begun), 60)
+        let attempts = await log.attempts
+        XCTAssertEqual(attempts, [Self.primary])
+    }
+
+    func testAnEmptyCandidateListIsRejectedUpFront() async {
+        do {
+            _ = try await BrokerClient.firstReachable(
+                candidates: BrokerCandidates(urls: []),
+                staggerMs: Self.staggerMs
+            ) { _ in
+                Self.relayList
+            }
+            XCTFail("expected the empty candidate list to be rejected")
+        } catch {
+            XCTAssertEqual(error as? BrokerClientError, .invalidResponse)
+        }
+    }
+
+    // User-override strict phase (spec point 6).
+
+    func testAnOverrideSlowerThanTheStaggerStillWinsAndTheDefaultIsNeverContacted() async throws {
+        // The override answers only after 3 stagger intervals: under pure race semantics the
+        // default front would long since have won; under override-first it must never even start.
+        let log = AttemptLog()
+        let fetch = try await BrokerClient.firstReachable(
+            candidates: Self.withOverride(Self.primary, Self.fallback),
+            staggerMs: Self.staggerMs
+        ) { url in
+            await log.record(url)
+            try await Self.sleep(ms: 3 * Self.staggerMs) // slower than the stagger, inside its timeout
+            return Self.relayList
+        }
+        XCTAssertEqual(fetch.brokerURL, Self.primary)
+        // Long after the override won, no default has been contacted — there was never a race.
+        try await Self.sleep(ms: 3 * Self.staggerMs)
+        let attempts = await log.attempts
+        XCTAssertEqual(attempts, [Self.primary])
+    }
+
+    func testAnOverrideFailureStartsTheRemainingDefaultsOnTheRaceCadence() async throws {
+        let override = URL(string: "https://override.example/")!
+        let a = URL(string: "https://a.example/")!
+        let b = URL(string: "https://b.example/")!
+        let log = AttemptLog()
+        let fetch = try await BrokerClient.firstReachable(
+            candidates: Self.withOverride(override, a, b),
+            staggerMs: Self.staggerMs
+        ) { url in
+            await log.record(url)
+            if url == override {
+                throw AttemptError(url: url)
+            }
+            if url == a {
+                try await Self.hangUntilCancelled() // hangs; loses the remainder race
+            }
+            return Self.relayList
+        }
+        // The override failed, so the remainder raced on the usual cadence and its second
+        // candidate won past the hanging first one.
+        XCTAssertEqual(fetch.brokerURL, b)
+        let attempts = await log.attempts
+        XCTAssertEqual(attempts, [override, a, b])
+    }
+
+    func testTheOverrideErrorIsSurfacedWhenTheRemainderRaceAlsoFails() async {
+        do {
+            _ = try await BrokerClient.firstReachable(
+                candidates: Self.withOverride(Self.primary, Self.fallback),
+                staggerMs: Self.staggerMs
+            ) { url in
+                throw AttemptError(url: url)
+            }
+            XCTFail("expected the override flow to fail")
+        } catch {
+            // The override is candidates[0]: its error stays the surfaced diagnostic (spec
+            // point 4) — the user configured that broker, so its failure is what they need to
+            // see, not a default front's.
+            XCTAssertEqual(error as? AttemptError, AttemptError(url: Self.primary))
+        }
+    }
+
+    func testASingleOverriddenCandidateBehavesExactlyLikeOnePlainAttempt() async {
+        let log = AttemptLog()
+        let begun = Date()
+        do {
+            _ = try await BrokerClient.firstReachable(
+                candidates: Self.withOverride(Self.primary),
+                staggerMs: 600_000 // any remainder race would be unmissable
+            ) { url in
+                await log.record(url)
+                throw AttemptError(url: url)
+            }
+            XCTFail("expected the attempt to fail")
+        } catch {
+            XCTAssertEqual(error as? AttemptError, AttemptError(url: Self.primary))
+        }
+        XCTAssertLessThan(Date().timeIntervalSince(begun), 60)
+        let attempts = await log.attempts
+        XCTAssertEqual(attempts, [Self.primary])
+    }
+
+    func testCancellingTheCallerMidRemainderRacePropagatesTheCancellation() async {
+        // The override fails fast, the remaining default hangs, then the caller cancels. The
+        // surfaced error must be the cancellation — what the caller classifies on — not the
+        // override's stale failure.
+        let defaultStarted = expectation(description: "default attempt started")
+        let task = Task {
+            try await BrokerClient.firstReachable(
+                candidates: Self.withOverride(Self.primary, Self.fallback),
+                staggerMs: Self.staggerMs
+            ) { url in
+                if url == Self.primary {
+                    throw AttemptError(url: url)
+                }
+                defaultStarted.fulfill()
+                try await Self.hangUntilCancelled()
+            }
+        }
+        await fulfillment(of: [defaultStarted], timeout: 5)
+        task.cancel()
+        do {
+            _ = try await task.value
+            XCTFail("expected the cancellation to propagate")
+        } catch {
+            XCTAssertTrue(error is CancellationError, "got \(error)")
+        }
+    }
+}

--- a/ios/PacketTunnel/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider.swift
@@ -93,9 +93,10 @@ final class PacketTunnelProvider: NEPacketTunnelProvider {
             // Resolve our own geo concurrently with the broker fetch (both before the tunnel is up).
             async let geoLookup: ClientGeoInfo? = try? await GeoIpClient().lookup()
             let brokerStartedNs = DispatchTime.now().uptimeNanoseconds
-            // Staggered race across the broker candidates: a blocked primary front costs one
-            // stagger interval of extra latency (not a full request timeout) before a fallback
-            // front is contacted, and never takes discovery offline.
+            // Discovery across the broker candidates: a genuine user override is tried strictly
+            // first with its full attempt timeout; the defaults race with a staggered start, so
+            // a blocked front costs one stagger interval of extra latency (not a full request
+            // timeout) and discovery never goes offline while any candidate answers.
             let fetch = try await BrokerClient.firstReachable(
                 candidates: AppConfig.brokerCandidates(primary: brokerURL),
                 // Targeted connects (country or exact relay) need the full set so the target is present.
@@ -107,12 +108,13 @@ final class PacketTunnelProvider: NEPacketTunnelProvider {
             )
             let response = fetch.response
             let brokerFetchMs = Int64((DispatchTime.now().uptimeNanoseconds - brokerStartedNs) / 1_000_000)
-            // If a fallback front won the discovery race (primary blocked, down, or just slower
-            // than its head start), pin the rest of this session's broker traffic (telemetry,
+            // If a fallback front won discovery — a genuine override is beaten only by FAILING
+            // outright (it is tried strictly first); a default primary also when merely slower
+            // than its head start — pin the rest of this session's broker traffic (telemetry,
             // heartbeats) to the endpoint that worked.
             if fetch.brokerURL != brokerURL {
                 self.brokerURL = fetch.brokerURL
-                SharedConnectionState.appendLog("primary broker lost the discovery race; using fallback \(fetch.brokerURL.absoluteString)")
+                SharedConnectionState.appendLog("configured broker did not win discovery; using fallback \(fetch.brokerURL.absoluteString)")
             }
             if let geo = await geoLookup {
                 TelemetryManager.setGeoInfo(geo)

--- a/ios/Shared/AppConfig.swift
+++ b/ios/Shared/AppConfig.swift
@@ -45,10 +45,13 @@ enum AppConfig {
 
     /// Ordered broker candidates for a connection attempt: the caller-selected `primary` (the provider
     /// configuration's broker, today the default) first, then the built-in `defaultBrokerURLs`,
-    /// de-duplicated while preserving order. The primary is never discarded, so a custom broker always
-    /// starts the discovery race first — in the staggered race, list position is expressed purely as a
-    /// head start of `discoveryStaggerMs` per position — and the defaults act as fallbacks.
-    static func brokerCandidates(primary: URL?) -> [URL] {
+    /// de-duplicated while preserving order. A GENUINE override (a primary that is not one of the
+    /// defaults) is flagged `overrideFirst`: `BrokerClient.firstReachable` tries it strictly first
+    /// with its full per-attempt timeout — a user's custom broker is never silently outrun by a
+    /// default front merely for being slower than the stagger — and the defaults race as fallbacks
+    /// only after it fails. A primary that echoes a default keeps the pure staggered race, where
+    /// list position is just a head start of `discoveryStaggerMs` per position.
+    static func brokerCandidates(primary: URL?) -> BrokerCandidates {
         BrokerClient.candidates(primary: primary, fallbacks: defaultBrokerURLs)
     }
 

--- a/ios/Shared/BrokerClient.swift
+++ b/ios/Shared/BrokerClient.swift
@@ -14,6 +14,24 @@ public struct BrokerFetch: Sendable {
     }
 }
 
+/// The ordered discovery endpoints for one request, plus whether `urls[0]` is a genuine user
+/// override. Built by `BrokerClient.candidates` and consumed by `BrokerClient.firstReachable`;
+/// carrying the flag alongside the list keeps the two from being computed inconsistently.
+public struct BrokerCandidates: Sendable {
+    /// Ordered discovery candidates.
+    public let urls: [URL]
+    /// True when `urls[0]` is a genuine user override — a primary that is not one of the built-in
+    /// defaults. `firstReachable` then tries it strictly first (full per-attempt timeout) and only
+    /// races the remaining defaults after it fails, so a custom broker that is merely slower than
+    /// the stagger is never silently outrun by a default front.
+    public let overrideFirst: Bool
+
+    public init(urls: [URL], overrideFirst: Bool = false) {
+        self.urls = urls
+        self.overrideFirst = overrideFirst
+    }
+}
+
 public struct BrokerClient: Sendable {
     private let baseURL: URL
     private let session: URLSession
@@ -61,18 +79,22 @@ public struct BrokerClient: Sendable {
     }
 
     /// Builds the ordered broker candidate list, de-duplicated while preserving order. `primary` is
-    /// tried FIRST only when it is a genuine override — i.e. not already one of the `fallbacks`. A
-    /// persisted value that merely echoes a built-in default must NOT reorder the defaults' preferred
-    /// (HTTPS-first) ordering. Pure and side-effect free so it is unit-testable.
-    public static func candidates(primary: URL?, fallbacks: [URL]) -> [URL] {
+    /// tried FIRST only when it is a genuine override — i.e. not already one of the `fallbacks` —
+    /// and only such an override sets `overrideFirst`, giving it the strict head phase described on
+    /// `BrokerCandidates`. A persisted value that merely echoes a built-in default must NOT reorder
+    /// the defaults' preferred (HTTPS-first) ordering (or claim the override phase). Pure and
+    /// side-effect free so it is unit-testable.
+    public static func candidates(primary: URL?, fallbacks: [URL]) -> BrokerCandidates {
         var ordered: [URL] = []
+        var overrideFirst = false
         if let primary, fallbacks.contains(primary) == false {
             ordered.append(primary)
+            overrideFirst = true
         }
         for fallback in fallbacks where ordered.contains(fallback) == false {
             ordered.append(fallback)
         }
-        return ordered
+        return BrokerCandidates(urls: ordered, overrideFirst: overrideFirst)
     }
 
     /// Staggered-race discovery (happy-eyeballs style) across the candidate brokers, returning the
@@ -98,22 +120,78 @@ public struct BrokerClient: Sendable {
     ///     primary's failure is the meaningful diagnostic; later fallbacks' errors are secondary.
     ///  5. With a single candidate the observable behavior equals the old sequential loop: one
     ///     attempt, no stagger sleeps, its error propagated unchanged.
+    ///  6. When `candidates.overrideFirst` is set, `urls[0]` is a GENUINE user override and racing
+    ///     it would betray the user's choice: a custom broker that is merely slower than the
+    ///     stagger would silently lose to a default front. The override is therefore attempted
+    ///     strictly first, alone, with its full per-attempt timeout — no default is contacted
+    ///     while it is pending — and it wins on any success, exactly like the old sequential loop.
+    ///     Only when the override FAILS does the race of points 1–5 start over the REMAINING
+    ///     candidates (the first of them immediately, the next one stagger later, and so on). If
+    ///     the override and every remaining candidate fail, the override's error is rethrown — it
+    ///     is `urls[0]`, so point 4's diagnostic is unchanged.
     ///
     /// Honors task cancellation like the old sequential loop: cancelling the surrounding task
     /// cancels every in-flight attempt and rethrows `CancellationError`, never a per-attempt error.
     public static func firstReachable(
-        candidates: [URL],
+        candidates: BrokerCandidates,
         limit: Int = 5,
         clientID: String? = nil,
         sessionID: String? = nil,
         session: URLSession = .shared
     ) async throws -> BrokerFetch {
+        try await firstReachable(candidates: candidates) { url in
+            try await BrokerClient(baseURL: url, session: session)
+                .listRelays(limit: limit, clientID: clientID, sessionID: sessionID)
+        }
+    }
+
+    /// Core behind `firstReachable` with the per-candidate fetch injectable and the stagger
+    /// overridable, so the override / stagger / first-success / all-fail semantics are
+    /// unit-testable (see `BrokerClientTests`) without real sockets or real 2.5 s staggers.
+    static func firstReachable(
+        candidates: BrokerCandidates,
+        staggerMs: UInt64 = AppConfig.discoveryStaggerMs,
+        attempt: @escaping @Sendable (URL) async throws -> RelayListResponse
+    ) async throws -> BrokerFetch {
         try Task.checkCancellation()
-        guard candidates.isEmpty == false else {
+        guard candidates.urls.isEmpty == false else {
             throw BrokerClientError.invalidResponse
         }
 
-        return try await withThrowingTaskGroup(
+        if candidates.overrideFirst {
+            let overrideURL = candidates.urls[0]
+            let overrideError: Error
+            do {
+                // Strict override phase (spec point 6): one plain attempt, full timeout, no race.
+                return BrokerFetch(brokerURL: overrideURL, response: try await attempt(overrideURL))
+            } catch {
+                // The caller went away: rethrow its cancellation, not the override's failure.
+                try Task.checkCancellation()
+                overrideError = error
+            }
+            let remaining = Array(candidates.urls.dropFirst())
+            if remaining.isEmpty {
+                throw overrideError
+            }
+            do {
+                return try await race(remaining, staggerMs: staggerMs, attempt: attempt)
+            } catch is CancellationError {
+                throw CancellationError() // the caller went away mid-race — not a broker diagnostic
+            } catch {
+                // All-fail keeps surfacing candidates[0]'s — the override's — error (spec point 4).
+                throw overrideError
+            }
+        }
+        return try await race(candidates.urls, staggerMs: staggerMs, attempt: attempt)
+    }
+
+    /// The staggered-race core (spec points 1–5), sans override handling.
+    private static func race(
+        _ candidates: [URL],
+        staggerMs: UInt64,
+        attempt: @escaping @Sendable (URL) async throws -> RelayListResponse
+    ) async throws -> BrokerFetch {
+        try await withThrowingTaskGroup(
             of: (Int, Result<BrokerFetch, Error>).self,
             returning: BrokerFetch.self
         ) { group in
@@ -125,7 +203,7 @@ public struct BrokerClient: Sendable {
                         // candidates only ever start while no attempt has succeeded yet; an early
                         // failure does NOT cut the sleep short (spec point 1).
                         try? await Task.sleep(
-                            nanoseconds: UInt64(index) * AppConfig.discoveryStaggerMs * 1_000_000
+                            nanoseconds: UInt64(index) * staggerMs * 1_000_000
                         )
                     }
                     if Task.isCancelled {
@@ -134,8 +212,7 @@ public struct BrokerClient: Sendable {
                         return (index, .failure(CancellationError()))
                     }
                     do {
-                        let response = try await BrokerClient(baseURL: url, session: session)
-                            .listRelays(limit: limit, clientID: clientID, sessionID: sessionID)
+                        let response = try await attempt(url)
                         return (index, .success(BrokerFetch(brokerURL: url, response: response)))
                     } catch {
                         return (index, .failure(error))

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -112,9 +112,10 @@ targets:
         CODE_SIGN_ENTITLEMENTS: PacketTunnel/PacketTunnel.entitlements
         APPLICATION_EXTENSION_API_ONLY: "YES"
 
-  # Hostless logic-test bundle for the failure classifier. It compiles FailureClassifier and the
-  # small error types it maps directly into the test module (rather than @testable-importing the
-  # extension), so the suite builds and runs without the app, CocoaPods, or Libbox.
+  # Hostless logic-test bundle for the failure classifier and the broker discovery flow. It
+  # compiles the tested sources (and their small dependency closure) directly into the test module
+  # (rather than @testable-importing the extension), so the suite builds and runs without the app,
+  # CocoaPods, or Libbox.
   OpenRungTests:
     type: bundle.unit-test
     platform: iOS
@@ -123,7 +124,13 @@ targets:
       - path: PacketTunnel/FailureClassifier.swift
       - path: PacketTunnel/PacketTunnelError.swift
       - path: PacketTunnel/PacketTunnelProxyEngineError.swift
+      - path: Shared/AppConfig.swift
+      - path: Shared/BrokerClient.swift
       - path: Shared/BrokerClientError.swift
+      - path: Shared/BrokerEndpoint.swift
+      - path: Shared/DeviceAttributes.swift
+      - path: Shared/NetworkPathMonitor.swift
+      - path: Shared/RelayDescriptor.swift
       - path: Shared/RelayReachabilityError.swift
     settings:
       base:

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-import { candidates } from './net/brokerClient';
+import { candidates, type BrokerCandidates } from './net/brokerClient';
 // The app version string lives in exactly ONE place — package.json — and every other
 // surface (Android versionName, iOS MARKETING_VERSION, this constant) derives from it so
 // they cannot drift. scripts/check-versions.mjs enforces this in CI.
@@ -53,11 +53,14 @@ export const AppConfig = {
   /**
    * Ordered discovery candidates for a connection attempt: the caller-selected `primary` (a user
    * override or the persisted choice) first, then the built-in DEFAULT_BROKER_URLS, de-duplicated
-   * while preserving order. The primary is never discarded, so a user's custom broker always
-   * starts the discovery race first — in the staggered race, list position is expressed purely
-   * as a head start of DISCOVERY_STAGGER_MS per position — and the defaults act as fallbacks.
+   * while preserving order. A GENUINE override (a primary that is not one of the defaults) is
+   * flagged `overrideFirst`: `firstReachable` tries it strictly first with its full per-attempt
+   * timeout — a user's custom broker is never silently outrun by a default front merely for being
+   * slower than the stagger — and the defaults race as fallbacks only after it fails. A primary
+   * that echoes a default keeps the pure staggered race, where list position is just a head start
+   * of DISCOVERY_STAGGER_MS per position.
    */
-  brokerCandidates(primary: string | null | undefined): string[] {
+  brokerCandidates(primary: string | null | undefined): BrokerCandidates {
     return candidates(primary, AppConfig.DEFAULT_BROKER_URLS);
   },
 

--- a/src/net/brokerClient.ts
+++ b/src/net/brokerClient.ts
@@ -70,17 +70,34 @@ export function relayListUrl(baseUrl: string, limit: number): string {
 }
 
 /**
+ * The ordered discovery endpoints for one request, plus whether `urls[0]` is a genuine user
+ * override. Built by `candidates` and consumed by `firstReachable`; carrying the flag alongside
+ * the list keeps the two from being computed inconsistently.
+ */
+export interface BrokerCandidates {
+  urls: string[];
+  /**
+   * True when `urls[0]` is a genuine user override — a non-blank primary that is not one of the
+   * built-in defaults. `firstReachable` then tries it strictly first (full per-attempt timeout)
+   * and only races the remaining defaults after it fails, so a custom broker that is merely
+   * slower than the stagger is never silently outrun by a default front.
+   */
+  overrideFirst: boolean;
+}
+
+/**
  * Builds the ordered broker candidate list, de-duplicated while preserving order. A non-blank
  * `primary` is tried FIRST only when it is a genuine override — i.e. not already one of the
- * `fallbacks`. A persisted value that merely echoes a built-in default must NOT reorder the
- * defaults' preferred (HTTPS-first) ordering, otherwise an upgrader whose last-used default was
- * the raw IP would keep hitting the IP before the Cloudflare-fronted endpoint. Pure and
- * side-effect free so it is unit-testable.
+ * `fallbacks` — and only such an override sets `overrideFirst`, giving it the strict head phase
+ * described on {@link BrokerCandidates}. A persisted value that merely echoes a built-in default
+ * must NOT reorder the defaults' preferred (HTTPS-first) ordering (or claim the override phase),
+ * otherwise an upgrader whose last-used default was the raw IP would keep hitting the IP before
+ * the Cloudflare-fronted endpoint. Pure and side-effect free so it is unit-testable.
  */
 export function candidates(
   primary: string | null | undefined,
   fallbacks: readonly string[],
-): string[] {
+): BrokerCandidates {
   const ordered: string[] = [];
   const seen = new Set<string>();
   const add = (value: string) => {
@@ -89,9 +106,11 @@ export function candidates(
       ordered.push(value);
     }
   };
+  let overrideFirst = false;
   const trimmedPrimary = primary?.trim() ?? '';
   if (trimmedPrimary.length > 0 && !fallbacks.some(fallback => fallback.trim() === trimmedPrimary)) {
     add(trimmedPrimary);
+    overrideFirst = true;
   }
   for (const fallback of fallbacks) {
     const trimmed = fallback.trim();
@@ -99,7 +118,7 @@ export function candidates(
       add(trimmed);
     }
   }
-  return ordered;
+  return { urls: ordered, overrideFirst };
 }
 
 /**
@@ -278,17 +297,57 @@ export async function listRelays(
  *     primary's failure is the meaningful diagnostic; later fallbacks' errors are secondary.
  *  5. With a single candidate the observable behavior equals the old sequential loop: one
  *     attempt, no timers beyond its own timeout, its error propagated unchanged.
+ *  6. When `candidates.overrideFirst` is set, `urls[0]` is a GENUINE user override and racing it
+ *     would betray the user's choice: a custom broker that is merely slower than the stagger
+ *     would silently lose to a default front. The override is therefore attempted strictly
+ *     first, alone, with its full per-attempt timeout — no default is contacted while it is
+ *     pending — and it wins on any success, exactly like the old sequential loop. Only when the
+ *     override FAILS does the race of points 1–5 start over the REMAINING candidates (the first
+ *     of them immediately, the next one stagger later, and so on). If the override and every
+ *     remaining candidate fail, the override's error is rethrown — it is `urls[0]`, so point 4's
+ *     diagnostic is unchanged.
  *
  * `options` excludes `signal` because the race owns per-attempt cancellation: each attempt gets
  * its own AbortSignal, threaded through listRelays so losing requests are aborted for real.
  */
-export function firstReachable(
+export async function firstReachable(
+  brokerCandidates: BrokerCandidates,
+  options: Omit<ListRelaysOptions, 'signal'> = {},
+): Promise<Fetch> {
+  const { urls, overrideFirst } = brokerCandidates;
+  if (urls.length === 0) {
+    throw new Error('no broker endpoints configured');
+  }
+  if (overrideFirst) {
+    let overrideError: unknown;
+    try {
+      // Strict override phase (spec point 6): one plain attempt, full timeout, no race timers.
+      const response = await listRelays(urls[0], options);
+      return { brokerUrl: urls[0], response };
+    } catch (error: unknown) {
+      overrideError = error;
+    }
+    const surfaced =
+      overrideError instanceof Error ? overrideError : new Error('no broker endpoints reachable');
+    const remaining = urls.slice(1);
+    if (remaining.length === 0) {
+      throw surfaced;
+    }
+    try {
+      return await race(remaining, options);
+    } catch {
+      // All-fail keeps surfacing candidates[0]'s — the override's — error (spec point 4).
+      throw surfaced;
+    }
+  }
+  return race(urls, options);
+}
+
+/** The staggered-race core behind `firstReachable` (spec points 1–5), sans override handling. */
+function race(
   candidateUrls: string[],
   options: Omit<ListRelaysOptions, 'signal'> = {},
 ): Promise<Fetch> {
-  if (candidateUrls.length === 0) {
-    return Promise.reject(new Error('no broker endpoints configured'));
-  }
   return new Promise<Fetch>((resolve, reject) => {
     /** One abort controller per STARTED attempt, index-aligned with candidateUrls. */
     const controllers: AbortController[] = [];


### PR DESCRIPTION
## Problem

The staggered discovery race (PR #35) gave a GENUINE user broker override only a 2.5 s head start: an override merely slower than `DISCOVERY_STAGGER_MS` silently lost to the default Cloudflare front, and the session pinned to a broker the user did not choose. Under the old sequential loop the override won whenever it answered within its 15 s attempt timeout.

## Semantics (uniform across all 4 clients)

- `candidates()` now returns a **`BrokerCandidates`** value — the ordered URL list **plus an `overrideFirst` flag** set only for a genuine override (a non-blank primary that is not one of the built-in defaults). Carrying the flag alongside the list keeps the two from being computed inconsistently, and every production call site keeps its exact shape.
- `firstReachable` consumes it (spec point 6 in the shared docstring):
  - **Override present:** the override is attempted strictly first, alone, with its full per-attempt timeout — no default is contacted while it is pending. Only when it **fails** does the staggered race (points 1–5, unchanged) start over the remaining candidates.
  - **No override** (including a primary that merely echoes a default): pure race, byte-for-byte unchanged.
  - **All fail:** still surfaces `candidates[0]`'s error — now the override's, which is the diagnostic the user needs.
  - **Caller cancellation** mid-race still propagates as cancellation, never as a stale broker error.

Applied identically to the RN TypeScript reference, the Kotlin port, and the Swift port; the desktop Go `FirstReachable` gets the same change in the core repo (openrung/openrung#40).

## iOS finally gets its race test suite

`BrokerClient.firstReachable` gains an internal fetch-injectable, stagger-overridable core (the Swift analog of the Kotlin overload), and the new `BrokerClientTests` mirrors the TS/Kotlin race + override suites (11 tests). The hostless `OpenRungTests` target now compiles the broker-discovery dependency closure directly — still no app, CocoaPods, or Libbox needed.

## Testing

- `npx jest` — 9 suites / 103 tests pass (brokerClient suite: 24, incl. 4 new override tests); `tsc --noEmit` and `eslint` clean.
- `./gradlew :app:testDebugUnitTest` — full suite green (`BrokerClientTest`: 11 tests, incl. 5 new override tests, virtual time).
- `xcodebuild test -scheme OpenRungTests` (iPhone 17 Pro sim) — 11 `BrokerClientTests` + 15 `FailureClassifierTests` pass; `PacketTunnel` extension target builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)