### PR TITLE
Verify relay-list signatures in the three mobile clients (SPEC v1)

### DIFF
--- a/__tests__/core/brokerClient.test.ts
+++ b/__tests__/core/brokerClient.test.ts
@@ -4,7 +4,9 @@ import {
   decodeRelayListResponse,
   firstReachable,
   relayListUrl,
+  setRelaySigningKeysForTests,
 } from '../../src/net/brokerClient';
+import { TEST_SIGNING_KEY, signedApiBody, signedResponse } from '../helpers/signing';
 
 describe('relayListUrl', () => {
   it('builds the relay list URL from a bare base', () => {
@@ -159,16 +161,19 @@ describe('firstReachable (staggered discovery race)', () => {
   const SECONDARY = 'https://secondary.example/';
   const TERTIARY = 'https://tertiary.example/';
 
-  const EMPTY_LIST = JSON.stringify({ count: 0, server_time: '2026-01-01T00:00:00Z', relays: [] });
-
   /** The init the client passes to fetch — always carries the merged per-attempt AbortSignal. */
   interface FetchInit {
     signal: AbortSignal;
   }
   type FetchStub = jest.Mock<Promise<unknown>, [string, FetchInit]>;
 
-  function okResponse(): { status: number; text: () => Promise<string> } {
-    return { status: 200, text: async () => EMPTY_LIST };
+  /**
+   * An empty relay list exactly as a production broker serves it: Ed25519-signed (with the
+   * public §2.3 test key, pinned below) and echoing the default request limit of 5. The race
+   * candidates are non-loopback, so every winning response must pass signature verification.
+   */
+  function okResponse(): unknown {
+    return signedResponse(signedApiBody({ limit: 5 }));
   }
 
   /** A fetch that never responds but honours its AbortSignal — a blackholed/censored endpoint. */
@@ -188,10 +193,12 @@ describe('firstReachable (staggered discovery race)', () => {
 
   beforeEach(() => {
     jest.useFakeTimers();
+    setRelaySigningKeysForTests([TEST_SIGNING_KEY]);
   });
 
   afterEach(() => {
     jest.useRealTimers();
+    setRelaySigningKeysForTests(null);
     (globalThis as Record<string, unknown>).fetch = originalFetch;
   });
 

--- a/__tests__/core/relaySigning.test.ts
+++ b/__tests__/core/relaySigning.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Relay-list signature verification (SPEC v1 §5.2 / test plan §12): the shared §2.3 vector plus
+ * its negative variants, the loopback dev exemption, the pinned-key CI guard (§11), and the
+ * text()+TextEncoder byte-identity fallback. Bodies for the constructed cases are signed with the
+ * PUBLIC test seed from testdata/signing_vectors.json — the production seeds stay offline.
+ */
+import * as ed from '@noble/ed25519';
+
+import { AppConfig } from '../../src/config';
+import {
+  RELAYS_SIGNATURE_HEADER,
+  firstReachable,
+  listRelays,
+  setRelaySigningKeysForTests,
+  verifySignedRelayList,
+} from '../../src/net/brokerClient';
+import {
+  TEST_SIGNING_KEY,
+  base64ToBytes,
+  deriveKeyId,
+  signRelayListBody,
+  signedApiBody,
+  signedResponse,
+  signingVectors,
+  utf8Bytes,
+} from '../helpers/signing';
+
+const VECTOR = signingVectors.spec_vector;
+// The vector's not_after is 2026-07-10T00:30:00Z; "now" is 10 min after server_time.
+const VECTOR_NOW_MS = Date.parse('2026-07-10T00:10:00Z');
+// A second PUBLIC test seed (32 bytes of 0x43) whose key is never pinned anywhere.
+const UNPINNED_SEED_B64 = 'Q0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0M=';
+
+beforeEach(() => {
+  setRelaySigningKeysForTests([TEST_SIGNING_KEY]);
+});
+
+afterEach(() => {
+  setRelaySigningKeysForTests(null);
+});
+
+describe('verifySignedRelayList (§2.3 vector and variants)', () => {
+  const verify = (header: string | null, body: string = VECTOR.body, limit = 1, nowMs = VECTOR_NOW_MS) =>
+    verifySignedRelayList(utf8Bytes(body), header, limit, nowMs);
+
+  it('accepts the shared vector verbatim and parses the SAME buffer', () => {
+    const { response, keyIdUsed } = verify(VECTOR.header_value);
+    expect(keyIdUsed).toBe(VECTOR.key_id);
+    expect(response.count).toBe(1);
+    expect(response.server_time).toBe('2026-07-10T00:00:00Z');
+    expect(response.not_after).toBe('2026-07-10T00:30:00Z');
+    expect(response.channel).toBe('api');
+    expect(response.limit).toBe(1);
+    expect(response.relays).toEqual([]);
+  });
+
+  it('accepts a response past not_after but inside the 5-min skew allowance', () => {
+    // not_after 00:30 with skew 5 min: acceptance boundary is now = 00:35:00 exactly.
+    expect(() => verify(VECTOR.header_value, VECTOR.body, 1, Date.parse('2026-07-10T00:35:00Z'))).not.toThrow();
+    expect(() => verify(VECTOR.header_value, VECTOR.body, 1, Date.parse('2026-07-10T00:35:01Z'))).toThrow(
+      'unsigned/invalid relay list',
+    );
+  });
+
+  it('accepts a wrong advisory key_id when the signature verifies under a pinned key (§4.2)', () => {
+    // Same 64-byte signature, but the header routes to a key_id no pinned key has: the verifier
+    // must fall back to trying every pinned key rather than rejecting.
+    const signature = VECTOR.header_value.split(';')[2];
+    const { keyIdUsed } = verify(`ed25519;ffffffffffffffff;${signature}`);
+    expect(keyIdUsed).toBe(VECTOR.key_id); // reports the PINNED key that verified, not the header's claim
+  });
+
+  it('rejects a flipped body byte', () => {
+    const tampered = VECTOR.body.replace('"count":1', '"count":2');
+    expect(() => verify(VECTOR.header_value, tampered)).toThrow('unsigned/invalid relay list');
+  });
+
+  it('rejects a flipped signature byte', () => {
+    // First base64 char K -> L still decodes to 64 bytes but is no longer the vector signature.
+    const flipped = VECTOR.header_value.replace(/;K/, ';L');
+    expect(flipped).not.toBe(VECTOR.header_value);
+    expect(() => verify(flipped)).toThrow('unsigned/invalid relay list');
+  });
+
+  it('rejects a valid signature under an unpinned key', () => {
+    const header = signRelayListBody(VECTOR.body, UNPINNED_SEED_B64);
+    expect(() => verify(header)).toThrow('signature does not verify against any pinned key');
+  });
+
+  it('rejects a missing header', () => {
+    expect(() => verify(null)).toThrow('missing signature header');
+    expect(() => verify('')).toThrow('missing signature header');
+  });
+
+  it.each([
+    ['two fields only', `ed25519;${VECTOR.key_id}`],
+    ['four fields', `${VECTOR.header_value};extra`],
+    ['wrong algorithm', VECTOR.header_value.replace('ed25519;', 'rsa;')],
+    ['bad base64', `ed25519;${VECTOR.key_id};!!!not-base64!!!`],
+    // Valid base64 of the first 63 signature bytes — an Ed25519 signature is exactly 64.
+    ['truncated signature', `ed25519;${VECTOR.key_id};K5UmJWzoEZ1YHOqZFf5E+ocNOITSe3WPvOo0GuyCRoiAxUk4eo/jcfqiuaPhrNeYrK3i8QcYI3LIv+zbVYq9`],
+  ])('rejects a malformed header: %s', (_name, header) => {
+    expect(() => verify(header)).toThrow('unsigned/invalid relay list');
+  });
+
+  it('rejects an expired not_after on a fresh fetch', () => {
+    expect(() => verify(VECTOR.header_value, VECTOR.body, 1, Date.parse('2026-07-10T01:00:00Z'))).toThrow(
+      'response expired',
+    );
+  });
+
+  it('rejects a signed body without not_after', () => {
+    const body = signedApiBody({ limit: 1, not_after: undefined }, VECTOR_NOW_MS);
+    expect(() => verify(signRelayListBody(body), body, 1)).toThrow('response expired');
+  });
+
+  it('rejects a limit-echo mismatch (§2.2 variant-steering defence)', () => {
+    expect(() => verify(VECTOR.header_value, VECTOR.body, 2)).toThrow('unsigned/invalid relay list');
+  });
+
+  it('rejects a validly signed mirror-channel body cross-fed into the API slot', () => {
+    const mirrorBody =
+      '{"count":1,"server_time":"2026-07-10T00:00:00Z","not_after":"2026-07-11T00:00:00Z",' +
+      `"key_id":"${VECTOR.key_id}","channel":"mirror","relays":[]}`;
+    expect(() => verify(signRelayListBody(mirrorBody), mirrorBody)).toThrow('is not "api"');
+  });
+});
+
+describe('pinned-key CI guard (§11)', () => {
+  // A truncated/typo'd pinned constant must fail HERE, not on key-promotion day: each AppConfig
+  // key must derive its own key_id and verify the committed promotion vector for that key.
+  it('AppConfig.RELAY_SIGNING_KEYS carries exactly the shared active+standby keys, active first', () => {
+    expect(AppConfig.RELAY_SIGNING_KEYS.map(key => key.keyId)).toEqual(
+      signingVectors.pinned_keys.map(key => key.key_id),
+    );
+    expect(AppConfig.RELAY_SIGNING_KEYS.map(key => key.publicKeyHex)).toEqual(
+      signingVectors.pinned_keys.map(key => key.public_key_hex),
+    );
+    expect(signingVectors.pinned_keys[0].name).toBe('active');
+    expect(signingVectors.pinned_keys[1].name).toBe('standby');
+  });
+
+  it.each(AppConfig.RELAY_SIGNING_KEYS.map(key => [key.keyId, key.publicKeyHex]))(
+    'pinned key %s: key_id derivation and promotion vector verify against the CONFIG constant',
+    (keyId, publicKeyHex) => {
+      const publicKey = ed.etc.hexToBytes(publicKeyHex);
+      expect(publicKey).toHaveLength(32);
+      expect(deriveKeyId(publicKey)).toBe(keyId);
+      const vector = signingVectors.pinned_keys.find(key => key.key_id === keyId);
+      expect(vector).toBeDefined();
+      const verifies = ed.verify(
+        base64ToBytes((vector as { vector_signature_b64: string }).vector_signature_b64),
+        utf8Bytes((vector as { vector_message: string }).vector_message),
+        publicKey,
+      );
+      expect(verifies).toBe(true);
+    },
+  );
+
+  it('the §2.3 test key matches its committed derivations', () => {
+    const publicKey = ed.getPublicKey(base64ToBytes(VECTOR.seed_b64));
+    expect(ed.etc.bytesToHex(publicKey)).toBe(VECTOR.public_key_hex);
+    expect(deriveKeyId(publicKey)).toBe(VECTOR.key_id);
+    expect(signRelayListBody(VECTOR.body)).toBe(VECTOR.header_value);
+  });
+});
+
+describe('listRelays verification shim (fetch level)', () => {
+  const originalFetch = (globalThis as Record<string, unknown>).fetch;
+
+  function installFetch(impl: (url: string) => Promise<unknown>): jest.Mock {
+    const stub = jest.fn(impl);
+    (globalThis as Record<string, unknown>).fetch = stub;
+    return stub;
+  }
+
+  afterEach(() => {
+    (globalThis as Record<string, unknown>).fetch = originalFetch;
+    jest.useRealTimers();
+  });
+
+  it('accepts a correctly signed response from a non-loopback broker', async () => {
+    installFetch(async () => signedResponse(signedApiBody({ limit: 5 })));
+    const response = await listRelays('https://broker.example/');
+    expect(response.channel).toBe('api');
+    expect(response.limit).toBe(5);
+  });
+
+  it('fails an unsigned 2xx response from a non-loopback broker with the mandated message', async () => {
+    installFetch(async () => signedResponse(signedApiBody({ limit: 5 }), { header: null }));
+    await expect(listRelays('https://broker.example/')).rejects.toThrow(
+      'unsigned/invalid relay list (missing signature header)',
+    );
+  });
+
+  it('fails a signed response whose echoed limit differs from the request', async () => {
+    installFetch(async () => signedResponse(signedApiBody({ limit: 5 })));
+    await expect(listRelays('https://broker.example/', { limit: 20 })).rejects.toThrow(
+      'unsigned/invalid relay list',
+    );
+  });
+
+  it.each([
+    ['http://127.0.0.1:8080/'],
+    ['http://localhost:8080/'],
+    ['http://[::1]:8080/'],
+  ])('loopback dev broker %s skips verification entirely (unsigned, text-only response)', async url => {
+    // Pre-signing stub shape: no signature header, no arrayBuffer, no headers at all — exactly
+    // what a local dev broker without a signing key serves.
+    installFetch(async () => ({
+      status: 200,
+      text: async () => JSON.stringify({ count: 0, server_time: '2026-07-10T00:00:00Z', relays: [] }),
+    }));
+    await expect(listRelays(url)).resolves.toMatchObject({ count: 0 });
+  });
+
+  it('a non-loopback plain-IP override still requires a valid signature', async () => {
+    installFetch(async () => ({
+      status: 200,
+      headers: { get: () => null },
+      text: async () => JSON.stringify({ count: 0, server_time: '2026-07-10T00:00:00Z', relays: [] }),
+    }));
+    await expect(listRelays('http://54.238.185.205:8080/')).rejects.toThrow(
+      'unsigned/invalid relay list',
+    );
+  });
+
+  it('text()+TextEncoder fallback is byte-identical to the binary read for the broker output', async () => {
+    const body = signedApiBody({ limit: 5 });
+    // Byte identity: re-encoding the decoded text equals the raw wire bytes for valid UTF-8.
+    // (Jest's Node environment provides the same TextEncoder Hermes ships.)
+    const { TextEncoder: NodeTextEncoder } = globalThis as unknown as {
+      TextEncoder: new () => { encode(input: string): Uint8Array };
+    };
+    const viaText = new NodeTextEncoder().encode(body);
+    expect(Array.from(viaText)).toEqual(Array.from(utf8Bytes(body)));
+
+    // End to end: a Response WITHOUT arrayBuffer() (RN fallback path) must still verify.
+    const full = signedResponse(body);
+    installFetch(async () => ({
+      status: full.status,
+      headers: full.headers,
+      text: full.text,
+    }));
+    await expect(listRelays('https://broker.example/')).resolves.toMatchObject({ limit: 5 });
+  });
+
+  it('a verification failure makes the discovery race fall through to the next candidate', async () => {
+    jest.useFakeTimers();
+    const good = 'https://good.example/';
+    installFetch(async (url: string) =>
+      url.startsWith(good)
+        ? signedResponse(signedApiBody({ limit: 5 }))
+        : signedResponse(signedApiBody({ limit: 5 }), { header: null }), // unsigned primary
+    );
+    const race = firstReachable(['https://stripped.example/', good]);
+    await jest.advanceTimersByTimeAsync(AppConfig.DISCOVERY_STAGGER_MS);
+    await expect(race).resolves.toMatchObject({ brokerUrl: good });
+  });
+
+  it('reads the signature header case-insensitively (HTTP/2 lowercases it)', async () => {
+    const body = signedApiBody({ limit: 5 });
+    const header = signRelayListBody(body);
+    installFetch(async () => ({
+      status: 200,
+      // A lowercase-only header map: listRelays must still find the value via its Headers.get
+      // contract (our mock mirrors Headers' case-insensitive lookup, as fetch guarantees).
+      headers: {
+        get: (name: string) => (name.toLowerCase() === RELAYS_SIGNATURE_HEADER.toLowerCase() ? header : null),
+      },
+      arrayBuffer: async () => {
+        const bytes = utf8Bytes(body);
+        return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+      },
+      text: async () => body,
+    }));
+    await expect(listRelays('https://broker.example/')).resolves.toMatchObject({ limit: 5 });
+  });
+});

--- a/__tests__/core/store.test.ts
+++ b/__tests__/core/store.test.ts
@@ -21,6 +21,8 @@ jest.mock('@react-native-async-storage/async-storage', () => {
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
+import { AppConfig } from '../../src/config';
+import { setRelaySigningKeysForTests } from '../../src/net/brokerClient';
 import {
   HOME_VIEW_MODE_STORAGE_KEY,
   applyNativeState,
@@ -31,14 +33,21 @@ import {
   setHomeViewMode,
 } from '../../src/state/store';
 import type { NativeVpnState } from '../../src/native/types';
+import { TEST_SIGNING_KEY, signedApiBody, signedResponse } from '../helpers/signing';
 
-interface MockResponse {
-  status: number;
-  text: () => Promise<string>;
-}
-
-function jsonResponse(payload: unknown): MockResponse {
-  return { status: 200, text: async () => JSON.stringify(payload) };
+/**
+ * A relay-list response as the production broker serves it: Ed25519-signed (with the public
+ * §2.3 test key, pinned in beforeEach) and echoing the directory request's
+ * DIRECTORY_RELAY_LIMIT — the default broker candidates are non-loopback, so refreshDirectory
+ * only ever accepts verified lists.
+ */
+function jsonResponse(payload: unknown): unknown {
+  return signedResponse(
+    signedApiBody({
+      ...(payload as Record<string, unknown>),
+      limit: AppConfig.DIRECTORY_RELAY_LIMIT,
+    }),
+  );
 }
 
 const RELAY_LIST = {
@@ -88,7 +97,12 @@ function installFetch(relayPayload: unknown = RELAY_LIST): void {
 
 beforeEach(() => {
   resetStoreForTests();
+  setRelaySigningKeysForTests([TEST_SIGNING_KEY]);
   installFetch();
+});
+
+afterEach(() => {
+  setRelaySigningKeysForTests(null);
 });
 
 describe('refreshDirectory', () => {

--- a/__tests__/helpers/signing.ts
+++ b/__tests__/helpers/signing.ts
@@ -1,0 +1,160 @@
+/**
+ * Relay-list signing fixtures shared across suites (NOT a test file — excluded via
+ * `testPathIgnorePatterns`). Bodies are signed with the PUBLIC SPEC v1 §2.3 test seed from
+ * testdata/signing_vectors.json, so suites exercise the full verification path without touching
+ * any production private key. Self-contained base64/UTF-8 codecs because the RN type surface
+ * declares neither `Buffer` nor `TextEncoder`.
+ */
+/* eslint-disable no-bitwise -- the base64/UTF-8 codecs below are inherently byte-twiddling */
+import * as ed from '@noble/ed25519';
+import { sha256, sha512 } from '@noble/hashes/sha2.js';
+
+import type { RelaySigningKey } from '../../src/net/brokerClient';
+import vectors from '../../testdata/signing_vectors.json';
+
+// Same wiring as brokerClient.ts — @noble/ed25519's sync API needs an explicit SHA-512.
+ed.etc.sha512Sync = (...messages: Uint8Array[]) => sha512(ed.etc.concatBytes(...messages));
+
+/** The whole shared-vector file, typed structurally via resolveJsonModule. */
+export const signingVectors = vectors;
+
+/** The §2.3 test key in pinned-key shape, for `setRelaySigningKeysForTests`. */
+export const TEST_SIGNING_KEY: RelaySigningKey = {
+  keyId: vectors.spec_vector.key_id,
+  publicKeyHex: vectors.spec_vector.public_key_hex,
+};
+
+const BASE64_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+
+export function base64ToBytes(encoded: string): Uint8Array {
+  if (encoded.length % 4 !== 0) {
+    throw new Error(`bad test base64: ${encoded}`);
+  }
+  const padding = encoded.endsWith('==') ? 2 : encoded.endsWith('=') ? 1 : 0;
+  const out = new Uint8Array((encoded.length / 4) * 3 - padding);
+  let buffer = 0;
+  let bits = 0;
+  let outIndex = 0;
+  for (let i = 0; i < encoded.length - padding; i++) {
+    const value = BASE64_ALPHABET.indexOf(encoded[i]);
+    if (value < 0) {
+      throw new Error(`bad test base64: ${encoded}`);
+    }
+    buffer = (buffer << 6) | value;
+    bits += 6;
+    if (bits >= 8) {
+      bits -= 8;
+      out[outIndex++] = (buffer >> bits) & 0xff;
+    }
+  }
+  return out;
+}
+
+export function bytesToBase64(bytes: Uint8Array): string {
+  let out = '';
+  for (let i = 0; i < bytes.length; i += 3) {
+    const chunk = [bytes[i], bytes[i + 1], bytes[i + 2]];
+    out += BASE64_ALPHABET[chunk[0] >> 2];
+    out += BASE64_ALPHABET[((chunk[0] & 0x03) << 4) | ((chunk[1] ?? 0) >> 4)];
+    out += i + 1 < bytes.length ? BASE64_ALPHABET[((chunk[1] & 0x0f) << 2) | ((chunk[2] ?? 0) >> 6)] : '=';
+    out += i + 2 < bytes.length ? BASE64_ALPHABET[chunk[2] & 0x3f] : '=';
+  }
+  return out;
+}
+
+/** UTF-8 encode without ambient TextEncoder (test bodies are well-formed strings). */
+export function utf8Bytes(text: string): Uint8Array {
+  const out: number[] = [];
+  for (let i = 0; i < text.length; i++) {
+    const code = text.codePointAt(i) as number;
+    if (code > 0xffff) {
+      i++;
+    }
+    if (code < 0x80) {
+      out.push(code);
+    } else if (code < 0x800) {
+      out.push(0xc0 | (code >> 6), 0x80 | (code & 0x3f));
+    } else if (code < 0x10000) {
+      out.push(0xe0 | (code >> 12), 0x80 | ((code >> 6) & 0x3f), 0x80 | (code & 0x3f));
+    } else {
+      out.push(
+        0xf0 | (code >> 18),
+        0x80 | ((code >> 12) & 0x3f),
+        0x80 | ((code >> 6) & 0x3f),
+        0x80 | (code & 0x3f),
+      );
+    }
+  }
+  return Uint8Array.from(out);
+}
+
+/**
+ * Signs `body` with a base64 seed (default: the §2.3 test seed) and returns the full
+ * `X-OpenRung-Relays-Signature` header value, with the signer's real key_id unless overridden.
+ */
+export function signRelayListBody(
+  body: string,
+  seedB64: string = vectors.spec_vector.seed_b64,
+  keyId?: string,
+): string {
+  const seed = base64ToBytes(seedB64);
+  const headerKeyId = keyId ?? deriveKeyId(ed.getPublicKey(seed));
+  const signature = ed.sign(utf8Bytes(body), seed);
+  return `ed25519;${headerKeyId};${bytesToBase64(signature)}`;
+}
+
+/** key_id derivation (§2.2): lowercase hex of the first 8 bytes of SHA-256 over the raw pubkey. */
+export function deriveKeyId(publicKey: Uint8Array): string {
+  return ed.etc.bytesToHex(sha256(publicKey).slice(0, 8));
+}
+
+/**
+ * A signed relay-list body in broker wire shape: the standard fields plus the §2.2 signing
+ * fields. `not_after` defaults to `now + 30 min` like the API channel; `limit` must echo what
+ * the client under test requested.
+ */
+export function signedApiBody(
+  overrides: Record<string, unknown> & { limit: number },
+  nowMs: number = Date.now(),
+): string {
+  const iso = (ms: number) => new Date(ms).toISOString().replace(/\.\d{3}Z$/, 'Z');
+  return JSON.stringify({
+    count: 0,
+    server_time: iso(nowMs),
+    not_after: iso(nowMs + 30 * 60_000),
+    key_id: vectors.spec_vector.key_id,
+    channel: 'api',
+    relays: [],
+    ...overrides,
+  });
+}
+
+/** The Response surface listRelays actually touches, with a case-insensitive header lookup. */
+export interface MockSignedResponse {
+  status: number;
+  headers: { get(name: string): string | null };
+  arrayBuffer(): Promise<ArrayBuffer>;
+  text(): Promise<string>;
+}
+
+/**
+ * A 2xx broker response carrying `body` and its signature header (pass `header: null` to model
+ * a pre-signing broker / header-stripping front). Exposes BOTH arrayBuffer() and text() so the
+ * client's preferred binary path is what gets exercised.
+ */
+export function signedResponse(
+  body: string,
+  options: { header?: string | null; status?: number } = {},
+): MockSignedResponse {
+  const header = options.header !== undefined ? options.header : signRelayListBody(body);
+  const bytes = utf8Bytes(body);
+  return {
+    status: options.status ?? 200,
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === 'x-openrung-relays-signature' ? header : null,
+    },
+    arrayBuffer: async () => bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer,
+    text: async () => body,
+  };
+}

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -186,6 +186,12 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
 
+    // Relay-list signature verification (net/RelayListVerifier): Ed25519 over the raw response
+    // bytes against the operator keys pinned in AppConfig. Tink's pure-Java Ed25519Verify is used
+    // because minSdk 26 predates the platform Ed25519 provider (API 33+); Tink shrinks under R8
+    // and avoids the crippled-bundled-BouncyCastle provider-registration footgun.
+    implementation("com.google.crypto.tink:tink-android:1.23.0")
+
     if (hermesEnabled.toBoolean()) {
         implementation("com.facebook.react:hermes-android")
     } else {

--- a/android/app/src/main/java/com/openrung/config/AppConfig.kt
+++ b/android/app/src/main/java/com/openrung/config/AppConfig.kt
@@ -5,8 +5,10 @@ object AppConfig {
      * Discovery broker (relay-list bootstrap) default, and — since discovery is HTTPS-only — the sole
      * built-in discovery candidate. Discovery is the censorship-critical path: it runs BEFORE the VPN
      * tunnel is up, and the relay list it returns defines which server the client trusts as its exit.
-     * The relay list is NOT signed, so it must only be fetched over a TLS-authenticated channel; the
-     * Cloudflare-fronted HTTPS endpoint (TLS + CDN edge IPs) is both hard to block and unforgeable.
+     * The relay list is Ed25519-signed by the broker and verified against
+     * [RELAY_SIGNING_PUBLIC_KEYS_HEX], so its authenticity no longer rests on the transport; the
+     * Cloudflare-fronted HTTPS endpoint stays the default because it is hard to block and keeps the
+     * client identity headers off the wire in cleartext.
      */
     const val DEFAULT_BROKER_URL = "https://broker.openrung.org/"
 
@@ -26,15 +28,16 @@ object AppConfig {
      * Ordered discovery candidates, raced with a staggered start: the first entry starts
      * immediately, each later entry joins [DISCOVERY_STAGGER_MS] after the previous one, and the
      * first candidate to return relays wins (see [com.openrung.net.BrokerClient.firstReachable]).
-     * Every entry MUST be HTTPS: the relay list is not yet signed, so it is authenticated only by
-     * the TLS cert of the serving host — a cleartext/bare-IP entry would let an on-path censor
-     * inject a malicious relay set.
+     * Every response is Ed25519-verified against [RELAY_SIGNING_PUBLIC_KEYS_HEX] (see
+     * [com.openrung.net.RelayListVerifier]), so a candidate's TLS cert is no longer what
+     * authenticates the list — an entry that fails verification is simply a failed candidate.
      *
      * Only one front is deployed today, so a censor who blocks it fails discovery CLOSED (offline).
-     * Closing that single point of failure is the front-diversity layer: adding more *HTTPS* fronts on
-     * independent CDNs/domains is safe now (still TLS-authenticated) and just needs the extra fronts
-     * deployed. Non-TLS / out-of-band channels (raw IP, cached blobs) stay off this list until the
-     * broker signs the relay list. Keep this in sync with the other clients' AppConfig.
+     * Closing that single point of failure is the front-diversity layer: additional fronts on
+     * independent CDNs/domains, and — now that the relay list is signed — non-TLS channels (direct
+     * IP, signed mirrors) in later phases. Entries stay HTTPS for now because the discovery request
+     * carries the client identity headers, which must not travel in cleartext. Keep this in sync
+     * with the other clients' AppConfig.
      */
     val DEFAULT_BROKER_URLS: List<String> = listOf(
         DEFAULT_BROKER_URL,
@@ -63,6 +66,27 @@ object AppConfig {
      * four clients.
      */
     const val DISCOVERY_STAGGER_MS = 2_500L
+
+    /**
+     * Ordered Ed25519 public keys (raw 32-byte keys as lowercase hex) trusted to sign the relay
+     * list (SPEC v1 §4.2): the active broker key first, then the offline standby that a routine
+     * rotation promotes. Signing detaches relay-list authenticity from the transport — a valid
+     * signature from one of these keys, not the TLS cert of whichever front answered, is what
+     * lets discovery trust a response (see [com.openrung.net.RelayListVerifier]). The `key_id`
+     * in the signature header is advisory routing only: on mismatch every key here is tried, so
+     * a broker-side key_id bug costs one wasted verify, not an outage. MUST stay in sync with
+     * the desktop Go, RN and iOS pinned lists; the pinned-key CI guard in RelayListVerifierTest
+     * verifies each entry against its committed rotation vector, so a truncated or typo'd
+     * constant fails the build instead of being discovered on promotion day. A key may be
+     * dropped only per the rotation runbook (broker no longer signs with it AND key_id
+     * telemetry shows zero verifications under it).
+     */
+    val RELAY_SIGNING_PUBLIC_KEYS_HEX: List<String> = listOf(
+        // Active broker signing key (key_id 627405615601c589).
+        "176c03cbc70833285abcea75f2a0e137bd687629142408c22806a86308bd4974",
+        // Offline standby, promoted on rotation or key loss (key_id 672f79aa99a573cd).
+        "5b2698cfa7a796c671a30aabd5475d55095b91464221f051837eb8fe01f36ea2",
+    )
 
     const val RELAY_LIMIT = 5
     const val VPN_SESSION_NAME = "OpenRung Volunteer VPN"

--- a/android/app/src/main/java/com/openrung/model/RelayDescriptor.kt
+++ b/android/app/src/main/java/com/openrung/model/RelayDescriptor.kt
@@ -78,6 +78,20 @@ data class RelayListResponse(
     @SerialName("server_time")
     val serverTime: String,
     val relays: List<RelayDescriptor>,
+    // Relay-list signing fields (SPEC v1 §2.2). They live inside the signed body — not in
+    // headers — so an attacker cannot rewrite freshness or channel binding without breaking the
+    // signature. Defaults cover pre-signing brokers, which only ever reach the parser on the
+    // signature-exempt loopback dev path (see com.openrung.net.RelayListVerifier).
+    /** RFC3339 expiry of this snapshot: `server_time` + 30 min on the API channel. */
+    @SerialName("not_after")
+    val notAfter: String = "",
+    /** Advisory id (first 8 SHA-256 bytes of the signing pubkey, hex) — routing hint only. */
+    @SerialName("key_id")
+    val keyId: String = "",
+    /** "api" or "mirror"; verified to match the channel the response was fetched from. */
+    val channel: String = "",
+    /** API channel: echo of the requested `limit`, verified to kill variant steering. */
+    val limit: Int? = null,
 ) {
     val serverInstant: Instant
         get() = Instant.parse(serverTime)

--- a/android/app/src/main/java/com/openrung/net/BrokerClient.kt
+++ b/android/app/src/main/java/com/openrung/net/BrokerClient.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import java.io.IOException
 import java.net.HttpURLConnection
+import java.net.InetAddress
 import java.net.URI
 import java.net.URL
 import java.net.URLEncoder
@@ -34,12 +35,23 @@ class BrokerHttpException(val status: Int, message: String) : IOException(messag
 class BrokerClient(
     private val baseUrl: String,
     private val json: Json = Json { ignoreUnknownKeys = true },
+    private val verifier: RelayListVerifier = RelayListVerifier(),
+    /**
+     * When true, loopback brokers are signature-verified like any other candidate. Production
+     * leaves this false: loopback (the adb-reverse dev flow) is the ONE signature-exempt channel,
+     * mirroring the desktop client's `EnforceSecureBrokerURL` loopback-http allowance (SPEC v1
+     * §5.2). Internal so the HTTP-level signing tests can force verification against a 127.0.0.1
+     * fixture server.
+     */
+    internal val requireSignatureOnLoopback: Boolean = false,
 ) {
     suspend fun listRelays(
         limit: Int = 5,
         clientId: String? = null,
         sessionId: String? = null,
     ): RelayListResponse = withContext(Dispatchers.IO) {
+        // What the query string will actually ask for — a signed response must echo it (§2.2).
+        val requestedLimit = effectiveLimit(limit)
         val url = URL(relayListUrl(baseUrl, limit))
         val connection = (url.openConnection() as HttpURLConnection).apply {
             requestMethod = "GET"
@@ -49,6 +61,15 @@ class BrokerClient(
             // installed HTTP response cache replay a stale relay list.
             useCaches = false
             setRequestProperty("Cache-Control", "no-cache, no-store")
+            if (!url.protocol.equals("https", ignoreCase = true)) {
+                // Non-TLS candidate discipline (SPEC v1 §5.2/§6): no transparent gzip —
+                // HttpURLConnection silently adds it otherwise, and a middlebox recompressing
+                // cleartext would change the exact bytes the relay-list signature covers — and
+                // no redirect-following, so an on-path attacker's 3xx is just a failed candidate.
+                // TLS candidates are untouched: edge compression decodes back to origin bytes.
+                setRequestProperty("Accept-Encoding", "identity")
+                instanceFollowRedirects = false
+            }
             clientId?.let { setRequestProperty("X-OpenRung-Client-ID", it) }
             sessionId?.let { setRequestProperty("X-OpenRung-Session-ID", it) }
             setRequestProperty("X-OpenRung-App-Version", BuildConfig.VERSION_NAME)
@@ -76,15 +97,31 @@ class BrokerClient(
             } else {
                 connection.errorStream ?: connection.inputStream
             }
-            val body = stream.bufferedReader().use { it.readText() }
+            // Raw bytes straight off the connection stream, BEFORE any charset decoding: the
+            // relay-list signature covers the exact bytes the broker sent (SPEC v1 §5.1), so a
+            // readText() decode + re-encode has no place on this path.
+            val bodyBytes = stream.use { it.readBytes() }
             if (status !in 200..299) {
+                // Non-2xx responses are unsigned by design and always mean "candidate failed" —
+                // never authenticated broker state (SPEC v1 §5.2 step 1).
+                val body = String(bodyBytes, Charsets.UTF_8)
                 val apiError = runCatching { json.decodeFromString<ErrorResponse>(body).error }.getOrNull()
                 throw BrokerHttpException(
                     status,
                     "broker list relays: ${apiError?.ifBlank { null } ?: body.ifBlank { connection.responseMessage }}",
                 )
             }
-            json.decodeFromString<RelayListResponse>(body)
+            if (requireSignatureOnLoopback || !hostIsLoopback(url.host)) {
+                verifier.verifyAndDecode(
+                    bodyBytes = bodyBytes,
+                    signatureHeader = RelayListVerifier.signatureHeader(connection.headerFields),
+                    requestedLimit = requestedLimit,
+                    json = json,
+                ).response
+            } else {
+                // Loopback dev brokers (adb reverse) stay usable unsigned — the one exemption.
+                json.decodeFromString<RelayListResponse>(String(bodyBytes, Charsets.UTF_8))
+            }
         } finally {
             disconnectOnCancel.cancel()
             connection.disconnect()
@@ -212,6 +249,28 @@ class BrokerClient(
             }
         }
 
+        /**
+         * The limit actually requested from the broker: non-positive values fall back to the
+         * broker's default page size of 5. This is also the value a signed response must echo
+         * back in its `limit` field (SPEC v1 §2.2), so [listRelays] and [relayListUrl] MUST
+         * derive it identically — hence the shared helper.
+         */
+        internal fun effectiveLimit(limit: Int): Int = if (limit < 1) 5 else limit
+
+        /**
+         * Whether [host] (as returned by [URL.getHost], so IPv6 literals keep their brackets) is
+         * localhost or a loopback IP literal — the one signature-exempt broker channel, mirroring
+         * the desktop client's `hostIsLoopback` (internal/client/broker.go). The literal check
+         * gates the [InetAddress] call so a plain hostname never triggers a DNS lookup here (a
+         * DNS answer must never decide whether verification is skipped).
+         */
+        internal fun hostIsLoopback(host: String): Boolean {
+            val bare = host.trim().removePrefix("[").removeSuffix("]")
+            if (bare.equals("localhost", ignoreCase = true)) return true
+            val isLiteral = bare.isNotEmpty() && (bare.all { it.isDigit() || it == '.' } || bare.contains(':'))
+            return isLiteral && runCatching { InetAddress.getByName(bare).isLoopbackAddress }.getOrDefault(false)
+        }
+
         fun relayListUrl(baseUrl: String, limit: Int): String {
             val trimmed = baseUrl.trim()
             require(trimmed.isNotBlank()) { "broker URL is required" }
@@ -225,8 +284,7 @@ class BrokerClient(
             val relayPath = listOf(basePath, "api/v1/relays")
                 .filter { it.isNotBlank() }
                 .joinToString(separator = "/", prefix = "/")
-            val safeLimit = if (limit < 1) 5 else limit
-            val query = appendLimit(uri.rawQuery, safeLimit)
+            val query = appendLimit(uri.rawQuery, effectiveLimit(limit))
             return URI(uri.scheme, uri.userInfo, uri.host, uri.port, relayPath, query, null).toString()
         }
 

--- a/android/app/src/main/java/com/openrung/net/RelayListVerifier.kt
+++ b/android/app/src/main/java/com/openrung/net/RelayListVerifier.kt
@@ -1,0 +1,181 @@
+package com.openrung.net
+
+import com.google.crypto.tink.subtle.Ed25519Verify
+import com.openrung.config.AppConfig
+import com.openrung.model.RelayListResponse
+import kotlinx.serialization.json.Json
+import java.io.IOException
+import java.security.GeneralSecurityException
+import java.security.MessageDigest
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.util.Base64
+
+/**
+ * A relay-list response that is unsigned or fails verification (SPEC v1 §5.2). Extends
+ * [IOException] so every existing caller treats it exactly like any other candidate failure —
+ * fall through to the next broker in the discovery race, never accept the data. The message
+ * deliberately leads with "unsigned/invalid relay list" (a spec requirement) so the surfaced
+ * error cannot be mistaken for a generic network failure.
+ */
+class RelayListVerificationException(detail: String) :
+    IOException("unsigned/invalid relay list: $detail")
+
+/**
+ * Verifies broker relay-list responses per SPEC v1 §5.2: an Ed25519 signature (carried in the
+ * [SIGNATURE_HEADER] response header) over the EXACT raw body bytes, checked against the operator
+ * keys pinned in [AppConfig.RELAY_SIGNING_PUBLIC_KEYS_HEX], followed by the in-body binding and
+ * freshness checks (channel, limit echo, not_after).
+ *
+ * Signing defends channel integrity only: it detaches list authenticity from the transport so
+ * discovery can later use non-TLS channels (direct-IP fallback, signed mirrors) without trusting
+ * whoever carried the bytes. Out of scope by design: a compromised broker signs whatever it
+ * likes, and a censor can still block, strip the header, or inject non-2xx responses — all of
+ * which degrade to "candidate failed, fall through", never to accepting forged data.
+ *
+ * Tink's pure-Java [Ed25519Verify] is used because minSdk 26 predates the platform Ed25519
+ * provider (API 33+); a verify costs well under a millisecond.
+ */
+class RelayListVerifier(
+    pinnedPublicKeysHex: List<String> = AppConfig.RELAY_SIGNING_PUBLIC_KEYS_HEX,
+    private val clock: Clock = Clock.systemUTC(),
+) {
+
+    private class PinnedKey(val keyId: String, val verifier: Ed25519Verify)
+
+    private val pinnedKeys: List<PinnedKey> = pinnedPublicKeysHex.map { hex ->
+        val raw = decodeHex(hex)
+        require(raw.size == Ed25519Verify.PUBLIC_KEY_LEN) {
+            "pinned Ed25519 public key must be ${Ed25519Verify.PUBLIC_KEY_LEN} bytes"
+        }
+        PinnedKey(keyId(raw), Ed25519Verify(raw))
+    }
+
+    init {
+        require(pinnedKeys.isNotEmpty()) { "at least one pinned signing key is required" }
+    }
+
+    /** A verified relay list plus the pinned key that verified it (the §5.2 telemetry signal). */
+    data class Verified(val response: RelayListResponse, val keyIdUsed: String)
+
+    /**
+     * Runs the full §5.2 verification over [bodyBytes] exactly as read off the wire — BEFORE any
+     * charset decoding, because the signature covers the precise bytes the broker sent — and
+     * returns the parsed response. [requestedLimit] is the limit the client put in the query
+     * string; the signed body must echo it, which turns a replayed variant (a `limit=1` body
+     * answering a `limit=20` request) into a verification failure. Every rejection throws
+     * [RelayListVerificationException]: "candidate failed", nothing more.
+     */
+    fun verifyAndDecode(
+        bodyBytes: ByteArray,
+        signatureHeader: String?,
+        requestedLimit: Int,
+        json: Json,
+    ): Verified {
+        // §5.2 step 2: the signature header is required; missing or malformed fails the candidate.
+        val header = signatureHeader?.trim() ?: fail("missing $SIGNATURE_HEADER header")
+        val (advisoryKeyId, signature) = parseHeader(header)
+        // §5.2 step 3: the signature must verify over the raw bytes under a pinned key.
+        val keyIdUsed = verifySignature(bodyBytes, signature, advisoryKeyId)
+        // §5.2 step 4: parse the SAME buffer the signature covered, then run the in-body checks.
+        val response = try {
+            json.decodeFromString<RelayListResponse>(String(bodyBytes, Charsets.UTF_8))
+        } catch (error: Exception) {
+            fail("signed body is not a relay list (${error.message})")
+        }
+        // `channel` binds the body to the channel it was fetched from: a (validly signed) mirror
+        // artifact must never be accepted in an API-channel slot, and vice versa.
+        if (response.channel != EXPECTED_CHANNEL) {
+            fail("channel \"${response.channel}\" is not \"$EXPECTED_CHANNEL\"")
+        }
+        if (response.limit != requestedLimit) {
+            fail("echoed limit ${response.limit} does not match requested $requestedLimit")
+        }
+        // Freshness: not_after (server_time + 30 min on the API channel) against the device
+        // clock, with the 5-min slow-clock allowance. Bounds replay of a captured signed body.
+        val notAfter = runCatching { Instant.parse(response.notAfter) }.getOrNull()
+            ?: fail("not_after \"${response.notAfter}\" is not a valid RFC3339 timestamp")
+        if (notAfter < clock.instant().minus(CLOCK_SKEW_ALLOWANCE)) {
+            fail("response expired at ${response.notAfter}")
+        }
+        return Verified(response, keyIdUsed)
+    }
+
+    /**
+     * §4.2: the header's key_id is ADVISORY routing only — the matching pinned key is tried
+     * first, but on mismatch or failure every pinned key is tried, so a broker-side key_id bug
+     * costs one wasted ~50 µs verify instead of a discovery outage.
+     */
+    private fun verifySignature(body: ByteArray, signature: ByteArray, advisoryKeyId: String): String {
+        // Stable sort: the advisory match moves to the front, pinned order is kept otherwise.
+        val routed = pinnedKeys.sortedByDescending { it.keyId == advisoryKeyId }
+        for (pinned in routed) {
+            try {
+                pinned.verifier.verify(signature, body)
+                return pinned.keyId
+            } catch (_: GeneralSecurityException) {
+                // Not this key — fall through to the next pinned key.
+            }
+        }
+        fail("signature does not verify under any pinned key")
+    }
+
+    /**
+     * §2.1: exactly three `;`-separated fields — the literal algorithm string "ed25519", the
+     * advisory key_id, and the standard-base64 64-byte signature.
+     */
+    private fun parseHeader(header: String): Pair<String, ByteArray> {
+        val fields = header.split(";")
+        if (fields.size != 3 || fields[0] != ALGORITHM) {
+            fail("malformed signature header")
+        }
+        val signature = runCatching { Base64.getDecoder().decode(fields[2]) }.getOrNull()
+            ?: fail("signature is not valid base64")
+        if (signature.size != Ed25519Verify.SIGNATURE_LEN) {
+            fail("signature is ${signature.size} bytes, expected ${Ed25519Verify.SIGNATURE_LEN}")
+        }
+        return fields[1] to signature
+    }
+
+    private fun fail(detail: String): Nothing = throw RelayListVerificationException(detail)
+
+    companion object {
+        /** Signature response header (§2.1). Matched case-insensitively — HTTP/2 lowercases it. */
+        const val SIGNATURE_HEADER = "X-OpenRung-Relays-Signature"
+
+        private const val ALGORITHM = "ed25519"
+
+        /**
+         * Every Android candidate today belongs to the API channel; mirror artifacts (channel
+         * "mirror", 24 h not_after, no limit echo) join the candidate list in a later phase.
+         */
+        private const val EXPECTED_CHANNEL = "api"
+
+        /** §5.2: allowance for a slow device clock when checking not_after (resolved at 5 min). */
+        private val CLOCK_SKEW_ALLOWANCE: Duration = Duration.ofMinutes(5)
+
+        /**
+         * Extracts the signature header from [java.net.HttpURLConnection.getHeaderFields],
+         * matching the name case-insensitively: HTTP/2/3 lowercase header names on the wire, and
+         * intermediaries may re-case them (§2.1). The map's null key (the status line) is skipped.
+         */
+        fun signatureHeader(headers: Map<String?, List<String>>): String? = headers.entries
+            .firstOrNull { it.key?.equals(SIGNATURE_HEADER, ignoreCase = true) == true }
+            ?.value
+            ?.firstOrNull()
+
+        /** key_id derivation (§2.2): lowercase hex of the first 8 bytes of SHA-256(raw pubkey). */
+        internal fun keyId(publicKey: ByteArray): String =
+            MessageDigest.getInstance("SHA-256").digest(publicKey)
+                .take(8)
+                .joinToString("") { "%02x".format(it) }
+
+        internal fun decodeHex(hex: String): ByteArray {
+            require(hex.length % 2 == 0) { "hex string must have even length" }
+            return ByteArray(hex.length / 2) { index ->
+                hex.substring(2 * index, 2 * index + 2).toInt(16).toByte()
+            }
+        }
+    }
+}

--- a/android/app/src/test/java/com/openrung/net/BrokerClientSigningTest.kt
+++ b/android/app/src/test/java/com/openrung/net/BrokerClientSigningTest.kt
@@ -1,0 +1,236 @@
+package com.openrung.net
+
+import com.google.crypto.tink.subtle.Ed25519Sign
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.IOException
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.Base64
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.concurrent.thread
+
+// Shared signing test vector (SPEC v1 §2.3) — TEST-ONLY key, duplicated per file because the
+// constants are file-private (see RelayListVerifierTest for the verifier-level suite).
+private const val TEST_SEED_B64 = "QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI="
+private const val TEST_PUBKEY_HEX = "2152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db12"
+private const val TEST_KEY_ID = "3097e2dee2cb4a34"
+private const val VECTOR_BODY =
+    """{"count":1,"server_time":"2026-07-10T00:00:00Z","not_after":"2026-07-10T00:30:00Z","key_id":"3097e2dee2cb4a34","channel":"api","limit":1,"relays":[]}"""
+private const val VECTOR_HEADER =
+    "ed25519;$TEST_KEY_ID;K5UmJWzoEZ1YHOqZFf5E+ocNOITSe3WPvOo0GuyCRoiAxUk4eo/jcfqiuaPhrNeYrK3i8QcYI3LIv+zbVYq9Bw=="
+
+/**
+ * One-shot raw-socket HTTP/1.1 fixture: unlike com.sun.net.httpserver it gives full control over
+ * the header NAME CASE and the exact body bytes on the wire — precisely the two things these
+ * tests must pin down. Every accepted connection gets the same canned response; request heads
+ * are recorded for assertions.
+ */
+private class FixtureServer(
+    private val status: String = "200 OK",
+    private val headers: List<String> = emptyList(),
+    private val body: ByteArray,
+) : AutoCloseable {
+    private val socket = ServerSocket(0, 4, InetAddress.getLoopbackAddress())
+    val requests = CopyOnWriteArrayList<String>()
+
+    init {
+        thread(isDaemon = true, name = "signing-fixture-server") {
+            while (!socket.isClosed) {
+                val client = try {
+                    socket.accept()
+                } catch (_: IOException) {
+                    break // socket closed — test is done
+                }
+                client.use { connection ->
+                    val head = StringBuilder()
+                    val input = connection.getInputStream()
+                    // The client never sends a body: the request ends at the blank line.
+                    while (!head.endsWith("\r\n\r\n")) {
+                        val byte = input.read()
+                        if (byte < 0) break
+                        head.append(byte.toInt().toChar())
+                    }
+                    requests += head.toString()
+                    val responseHead = buildString {
+                        append("HTTP/1.1 $status\r\n")
+                        headers.forEach { header -> append("$header\r\n") }
+                        append("Content-Length: ${body.size}\r\n")
+                        append("Connection: close\r\n")
+                        append("\r\n")
+                    }.toByteArray(Charsets.ISO_8859_1)
+                    connection.getOutputStream().apply {
+                        write(responseHead)
+                        write(body)
+                        flush()
+                    }
+                }
+            }
+        }
+    }
+
+    val baseUrl: String get() = "http://127.0.0.1:${socket.localPort}/"
+
+    override fun close() {
+        socket.close()
+    }
+}
+
+/**
+ * Wire-level tests of the signing integration in [BrokerClient.listRelays] (SPEC v1 §5.2):
+ * bytes discipline (the signature is checked over the raw stream bytes, before any charset
+ * decoding), case-insensitive header matching, the non-TLS transport discipline (§6), the
+ * loopback dev exemption, and the unsigned non-2xx path. The fixture listens on 127.0.0.1, so
+ * verification is forced with the internal [BrokerClient.requireSignatureOnLoopback] switch.
+ */
+class BrokerClientSigningTest {
+
+    /** Fixed at the vector's server_time, well inside its 30-minute not_after window. */
+    private val vectorClock = Clock.fixed(Instant.parse("2026-07-10T00:00:00Z"), ZoneOffset.UTC)
+
+    private fun verifyingClient(baseUrl: String) = BrokerClient(
+        baseUrl,
+        verifier = RelayListVerifier(listOf(TEST_PUBKEY_HEX), vectorClock),
+        requireSignatureOnLoopback = true,
+    )
+
+    @Test
+    fun `signed response verifies end-to-end over the wire`() {
+        FixtureServer(
+            headers = listOf(
+                "Content-Type: application/json",
+                // Lowercase on purpose: HTTP/2/3 lowercase header names, so the client-side
+                // match must be case-insensitive (§2.1).
+                "x-openrung-relays-signature: $VECTOR_HEADER",
+            ),
+            body = VECTOR_BODY.toByteArray(),
+        ).use { server ->
+            val response = runBlocking { verifyingClient(server.baseUrl).listRelays(limit = 1) }
+            assertEquals(1, response.count)
+            assertEquals("api", response.channel)
+            // §6: non-TLS candidates must ask for identity encoding, so no hop recompresses the
+            // exact bytes the signature covers (HttpURLConnection adds gzip silently otherwise).
+            assertTrue(server.requests.single().contains("Accept-Encoding: identity"))
+        }
+    }
+
+    @Test
+    fun `multibyte body verifies against the exact wire bytes`() {
+        // Byte-count != char-count here, so any decode-to-text-and-re-encode with the wrong
+        // charset (e.g. Latin-1) breaks the signature — pinning the raw-InputStream discipline.
+        // The unknown "fixture_note" key also re-checks the tolerant parser.
+        val body =
+            """{"count":0,"server_time":"2026-07-10T00:00:00Z","not_after":"2026-07-10T00:30:00Z","key_id":"$TEST_KEY_ID","channel":"api","limit":1,"relays":[],"fixture_note":"日本 – ヘルシンキ"}"""
+        val bodyBytes = body.toByteArray()
+        val signer = Ed25519Sign(Base64.getDecoder().decode(TEST_SEED_B64))
+        val header = "ed25519;$TEST_KEY_ID;" + Base64.getEncoder().encodeToString(signer.sign(bodyBytes))
+        FixtureServer(
+            headers = listOf(
+                "Content-Type: application/json; charset=utf-8",
+                "X-OpenRung-Relays-Signature: $header",
+            ),
+            body = bodyBytes,
+        ).use { server ->
+            val response = runBlocking { verifyingClient(server.baseUrl).listRelays(limit = 1) }
+            assertEquals(0, response.count)
+        }
+    }
+
+    @Test
+    fun `tampered body fails closed as unsigned-invalid`() {
+        FixtureServer(
+            headers = listOf("Content-Type: application/json", "X-OpenRung-Relays-Signature: $VECTOR_HEADER"),
+            // Same length, one flipped digit: the signature no longer covers these bytes.
+            body = VECTOR_BODY.replace("\"count\":1", "\"count\":2").toByteArray(),
+        ).use { server ->
+            val thrown = runCatching {
+                runBlocking { verifyingClient(server.baseUrl).listRelays(limit = 1) }
+            }.exceptionOrNull()
+            assertTrue("expected verification failure, got $thrown", thrown is RelayListVerificationException)
+            // §5.2: the surfaced failure names the real problem, not a generic network error.
+            assertTrue(thrown?.message.orEmpty().startsWith("unsigned/invalid relay list"))
+        }
+    }
+
+    @Test
+    fun `response without a signature header is a failed candidate`() {
+        FixtureServer(
+            headers = listOf("Content-Type: application/json"),
+            body = VECTOR_BODY.toByteArray(),
+        ).use { server ->
+            val thrown = runCatching {
+                runBlocking { verifyingClient(server.baseUrl).listRelays(limit = 1) }
+            }.exceptionOrNull()
+            assertTrue("expected verification failure, got $thrown", thrown is RelayListVerificationException)
+        }
+    }
+
+    @Test
+    fun `limit echo mismatch fails over the wire`() {
+        // The served body echoes limit=1; asking for 5 must reject it even though the signature
+        // itself is valid — the §2.2 variant-steering defence, end to end.
+        FixtureServer(
+            headers = listOf("Content-Type: application/json", "X-OpenRung-Relays-Signature: $VECTOR_HEADER"),
+            body = VECTOR_BODY.toByteArray(),
+        ).use { server ->
+            val thrown = runCatching {
+                runBlocking { verifyingClient(server.baseUrl).listRelays(limit = 5) }
+            }.exceptionOrNull()
+            assertTrue("expected verification failure, got $thrown", thrown is RelayListVerificationException)
+        }
+    }
+
+    @Test
+    fun `loopback dev brokers stay usable unsigned by default`() {
+        // The one signature exemption (§5.2): a loopback broker (adb-reverse dev flow) is served
+        // unverified — with the production default requireSignatureOnLoopback=false.
+        FixtureServer(
+            headers = listOf("Content-Type: application/json"),
+            body = VECTOR_BODY.toByteArray(),
+        ).use { server ->
+            val response = runBlocking { BrokerClient(server.baseUrl).listRelays(limit = 1) }
+            assertEquals(1, response.count)
+        }
+    }
+
+    @Test
+    fun `non-2xx responses surface their status and stay unsigned`() {
+        // §5.2 step 1: error responses are unsigned by design; they must classify as candidate
+        // failures with their HTTP status (429 → rate_limited), never reach the verifier.
+        FixtureServer(
+            status = "429 Too Many Requests",
+            headers = listOf("Content-Type: application/json"),
+            body = """{"error":"slow down"}""".toByteArray(),
+        ).use { server ->
+            val thrown = runCatching {
+                runBlocking { verifyingClient(server.baseUrl).listRelays(limit = 1) }
+            }.exceptionOrNull()
+            assertTrue("expected BrokerHttpException, got $thrown", thrown is BrokerHttpException)
+            assertEquals(429, (thrown as BrokerHttpException).status)
+            assertTrue(thrown.message.orEmpty().contains("slow down"))
+        }
+    }
+
+    @Test
+    fun `hostIsLoopback exempts loopback literals and localhost only`() {
+        assertTrue(BrokerClient.hostIsLoopback("localhost"))
+        assertTrue(BrokerClient.hostIsLoopback("LOCALHOST"))
+        assertTrue(BrokerClient.hostIsLoopback("127.0.0.1"))
+        assertTrue(BrokerClient.hostIsLoopback("127.42.0.7"))
+        assertTrue(BrokerClient.hostIsLoopback("[::1]")) // URL.getHost keeps the brackets
+        assertFalse(BrokerClient.hostIsLoopback("broker.openrung.org"))
+        assertFalse(BrokerClient.hostIsLoopback("54.238.185.205"))
+        assertFalse(BrokerClient.hostIsLoopback("[2406:da14:16a4:8400::1]"))
+        // Never decided via DNS: a hostname that (maliciously) resolves to 127.0.0.1 is still
+        // not loopback — only literals and "localhost" pass, without any lookup.
+        assertFalse(BrokerClient.hostIsLoopback("localtest.me"))
+        assertFalse(BrokerClient.hostIsLoopback(""))
+    }
+}

--- a/android/app/src/test/java/com/openrung/net/RelayListVerifierTest.kt
+++ b/android/app/src/test/java/com/openrung/net/RelayListVerifierTest.kt
@@ -1,0 +1,242 @@
+package com.openrung.net
+
+import com.google.crypto.tink.subtle.Ed25519Sign
+import com.google.crypto.tink.subtle.Ed25519Verify
+import com.openrung.config.AppConfig
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.Base64
+
+// Shared signing test vector (SPEC v1 §2.3) — the seed is 32 bytes of 0x42, TEST ONLY. The same
+// vector is committed in every client repo (testdata/signing_vectors.json) so all four verifiers
+// are pinned to identical bytes.
+private const val TEST_SEED_B64 = "QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI="
+private const val TEST_PUBKEY_HEX = "2152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db12"
+private const val TEST_KEY_ID = "3097e2dee2cb4a34"
+private const val VECTOR_BODY =
+    """{"count":1,"server_time":"2026-07-10T00:00:00Z","not_after":"2026-07-10T00:30:00Z","key_id":"3097e2dee2cb4a34","channel":"api","limit":1,"relays":[]}"""
+private const val VECTOR_SIG_B64 =
+    "K5UmJWzoEZ1YHOqZFf5E+ocNOITSe3WPvOo0GuyCRoiAxUk4eo/jcfqiuaPhrNeYrK3i8QcYI3LIv+zbVYq9Bw=="
+private const val VECTOR_HEADER = "ed25519;$TEST_KEY_ID;$VECTOR_SIG_B64"
+
+/**
+ * The SPEC v1 §5.2 verification algorithm against the shared §2.3 test vector: the positive case,
+ * every §12 negative (each must reject as "candidate failed", i.e. throw
+ * [RelayListVerificationException]), the §4.2 advisory key_id routing, and the §11 pinned-key CI
+ * guard over the production constants in [AppConfig.RELAY_SIGNING_PUBLIC_KEYS_HEX]. Plain JVM —
+ * no sockets, no Robolectric; the wire-level path is covered by [BrokerClientSigningTest].
+ */
+class RelayListVerifierTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    /** Fixed at the vector's server_time, well inside its 30-minute not_after window. */
+    private val vectorClock = Clock.fixed(Instant.parse("2026-07-10T00:00:00Z"), ZoneOffset.UTC)
+    private val verifier = RelayListVerifier(listOf(TEST_PUBKEY_HEX), vectorClock)
+
+    /** Signs variant bodies under the TEST-ONLY seed for the dynamic negative cases. */
+    private val signer = Ed25519Sign(Base64.getDecoder().decode(TEST_SEED_B64))
+
+    private fun sign(body: String, keyId: String = TEST_KEY_ID): String =
+        "ed25519;$keyId;" + Base64.getEncoder().encodeToString(signer.sign(body.toByteArray()))
+
+    private fun assertRejected(
+        body: ByteArray = VECTOR_BODY.toByteArray(),
+        header: String? = VECTOR_HEADER,
+        requestedLimit: Int = 1,
+        verifier: RelayListVerifier = this.verifier,
+    ): RelayListVerificationException {
+        try {
+            verifier.verifyAndDecode(body, header, requestedLimit, json)
+        } catch (rejection: RelayListVerificationException) {
+            // §5.2: the surfaced failure must say "unsigned/invalid relay list", never read as a
+            // generic network error.
+            assertTrue(
+                "unexpected message: ${rejection.message}",
+                rejection.message.orEmpty().startsWith("unsigned/invalid relay list"),
+            )
+            return rejection
+        }
+        fail("verification unexpectedly succeeded")
+        throw AssertionError("unreachable")
+    }
+
+    @Test
+    fun `shared vector verifies and decodes`() {
+        val verified = verifier.verifyAndDecode(VECTOR_BODY.toByteArray(), VECTOR_HEADER, 1, json)
+        assertEquals(TEST_KEY_ID, verified.keyIdUsed)
+        assertEquals(1, verified.response.count)
+        assertEquals("api", verified.response.channel)
+        assertEquals(1, verified.response.limit)
+        assertEquals("2026-07-10T00:30:00Z", verified.response.notAfter)
+        // key_id derivation (§2.2): first 8 SHA-256 bytes of the raw pubkey, lowercase hex.
+        assertEquals(TEST_KEY_ID, RelayListVerifier.keyId(RelayListVerifier.decodeHex(TEST_PUBKEY_HEX)))
+    }
+
+    @Test
+    fun `pinned production keys match their committed rotation vectors`() {
+        // §11 CI guard: each pinned constant must verify the vector produced at key-generation
+        // time, so a truncated or typo'd pinned key fails CI here — not on promotion day. The
+        // vectors are index-aligned with the ordered ≥2-key pin (active first, then standby).
+        val rotationVectors = listOf(
+            Triple(
+                "openrung-signing-key-vector:active",
+                "627405615601c589",
+                "mELBVRsBe2+aeKYMniZ2F0HEV7n+8VcokBgailoLQW7JAleX6q8RQypVOO0y0p0+g/u89Uu+aaYpVfvpIAMRBQ==",
+            ),
+            Triple(
+                "openrung-signing-key-vector:standby",
+                "672f79aa99a573cd",
+                "KyYhv/R46Wmi1M4y+KPT4CUz40mVXzwG3hYG5U22v7qpxri0pj4wYCgxqjrGmh2hlFNcx8gZpIBFO1PhD7xABw==",
+            ),
+        )
+        assertEquals(rotationVectors.size, AppConfig.RELAY_SIGNING_PUBLIC_KEYS_HEX.size)
+        rotationVectors.forEachIndexed { index, (message, expectedKeyId, signatureB64) ->
+            val publicKey = RelayListVerifier.decodeHex(AppConfig.RELAY_SIGNING_PUBLIC_KEYS_HEX[index])
+            assertEquals(expectedKeyId, RelayListVerifier.keyId(publicKey))
+            // Throws GeneralSecurityException — failing the test — if the pinned key is wrong.
+            Ed25519Verify(publicKey).verify(Base64.getDecoder().decode(signatureB64), message.toByteArray())
+        }
+    }
+
+    @Test
+    fun `flipped body byte is rejected`() {
+        val tampered = VECTOR_BODY.toByteArray().also { it[10] = (it[10].toInt() xor 0x01).toByte() }
+        assertRejected(body = tampered)
+    }
+
+    @Test
+    fun `flipped signature byte is rejected`() {
+        val signature = Base64.getDecoder().decode(VECTOR_SIG_B64)
+            .also { it[3] = (it[3].toInt() xor 0x01).toByte() }
+        assertRejected(header = "ed25519;$TEST_KEY_ID;" + Base64.getEncoder().encodeToString(signature))
+    }
+
+    @Test
+    fun `signature under an unpinned key is rejected`() {
+        // The production pin does not contain the TEST key, so the (valid) vector signature must
+        // not verify — falling through every pinned key first (§4.2).
+        val productionPinned = RelayListVerifier(AppConfig.RELAY_SIGNING_PUBLIC_KEYS_HEX, vectorClock)
+        assertRejected(verifier = productionPinned)
+    }
+
+    @Test
+    fun `missing header is rejected`() {
+        val rejection = assertRejected(header = null)
+        assertTrue(rejection.message.orEmpty().contains(RelayListVerifier.SIGNATURE_HEADER))
+    }
+
+    @Test
+    fun `malformed headers are rejected`() {
+        val malformed = listOf(
+            "", // empty
+            "ed25519;$TEST_KEY_ID", // truncated: two fields
+            "$VECTOR_HEADER;extra", // four fields
+            "rsa;$TEST_KEY_ID;$VECTOR_SIG_B64", // wrong algorithm string
+            "ED25519;$TEST_KEY_ID;$VECTOR_SIG_B64", // the algorithm literal is exact (§2.1)
+            "ed25519;$TEST_KEY_ID;%%%not-base64%%%", // undecodable signature
+            "ed25519;$TEST_KEY_ID;" + Base64.getEncoder().encodeToString(ByteArray(63)), // short sig
+        )
+        malformed.forEach { header -> assertRejected(header = header) }
+    }
+
+    @Test
+    fun `not_after is enforced with the 5-minute slow-clock allowance`() {
+        // Vector not_after is 00:30:00Z; the §5.2 rule is not_after >= now - 5 min.
+        val justInside = RelayListVerifier(
+            listOf(TEST_PUBKEY_HEX),
+            Clock.fixed(Instant.parse("2026-07-10T00:34:59Z"), ZoneOffset.UTC),
+        )
+        justInside.verifyAndDecode(VECTOR_BODY.toByteArray(), VECTOR_HEADER, 1, json)
+        val justPast = RelayListVerifier(
+            listOf(TEST_PUBKEY_HEX),
+            Clock.fixed(Instant.parse("2026-07-10T00:35:01Z"), ZoneOffset.UTC),
+        )
+        val rejection = assertRejected(verifier = justPast)
+        assertTrue(rejection.message.orEmpty().contains("expired"))
+    }
+
+    @Test
+    fun `limit echo mismatch is rejected`() {
+        // The vector body echoes limit=1; a client that asked for 5 must not accept it — this is
+        // what turns a replayed same-URL variant into a verification failure (§2.2).
+        assertRejected(requestedLimit = 5)
+    }
+
+    @Test
+    fun `missing limit echo is rejected on the api channel`() {
+        val body =
+            """{"count":0,"server_time":"2026-07-10T00:00:00Z","not_after":"2026-07-10T00:30:00Z","key_id":"$TEST_KEY_ID","channel":"api","relays":[]}"""
+        assertRejected(body = body.toByteArray(), header = sign(body))
+    }
+
+    @Test
+    fun `channel mismatch is rejected`() {
+        // A validly signed MIRROR artifact must never be accepted in an API-channel slot (§2.2).
+        val body =
+            """{"count":0,"server_time":"2026-07-10T00:00:00Z","not_after":"2026-07-10T00:30:00Z","key_id":"$TEST_KEY_ID","channel":"mirror","limit":1,"relays":[]}"""
+        assertRejected(body = body.toByteArray(), header = sign(body))
+    }
+
+    @Test
+    fun `unparseable not_after is rejected`() {
+        val body =
+            """{"count":0,"server_time":"2026-07-10T00:00:00Z","not_after":"soonish","key_id":"$TEST_KEY_ID","channel":"api","limit":1,"relays":[]}"""
+        assertRejected(body = body.toByteArray(), header = sign(body))
+    }
+
+    @Test
+    fun `signed body that is not a relay list is rejected`() {
+        val body = """{"ok":true}"""
+        assertRejected(body = body.toByteArray(), header = sign(body))
+    }
+
+    @Test
+    fun `wrong advisory key_id still verifies via pinned-key fallback`() {
+        // §4.2: key_id is routing only — a broker-side key_id bug must cost one wasted verify,
+        // not an outage. The signature is valid under the pinned TEST key.
+        val verified = verifier.verifyAndDecode(
+            VECTOR_BODY.toByteArray(),
+            sign(VECTOR_BODY, keyId = "ffffffffffffffff"),
+            1,
+            json,
+        )
+        assertEquals(TEST_KEY_ID, verified.keyIdUsed)
+    }
+
+    @Test
+    fun `advisory routing works with multiple pinned keys`() {
+        // Active production key pinned first, TEST key second: the advisory key_id routes to the
+        // matching second slot and reports it as the key that verified.
+        val multiKey = RelayListVerifier(
+            listOf(AppConfig.RELAY_SIGNING_PUBLIC_KEYS_HEX.first(), TEST_PUBKEY_HEX),
+            vectorClock,
+        )
+        val verified = multiKey.verifyAndDecode(VECTOR_BODY.toByteArray(), VECTOR_HEADER, 1, json)
+        assertEquals(TEST_KEY_ID, verified.keyIdUsed)
+    }
+
+    @Test
+    fun `signature header lookup is case-insensitive`() {
+        // HTTP/2/3 lowercase header names on the wire (§2.1); HttpURLConnection also maps the
+        // status line under a null key, which must be skipped, not crash the scan.
+        val headers = mapOf<String?, List<String>>(
+            null to listOf("HTTP/1.1 200 OK"),
+            "content-type" to listOf("application/json"),
+            "x-openrung-relays-signature" to listOf(VECTOR_HEADER),
+        )
+        assertEquals(VECTOR_HEADER, RelayListVerifier.signatureHeader(headers))
+        assertNull(
+            RelayListVerifier.signatureHeader(
+                mapOf<String?, List<String>>("Content-Type" to listOf("application/json")),
+            ),
+        )
+    }
+}

--- a/ios/OpenRung.xcodeproj/project.pbxproj
+++ b/ios/OpenRung.xcodeproj/project.pbxproj
@@ -14,10 +14,12 @@
 		02E9AD5F4252406BE29B4B5D /* BrokerClientError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683F07997A392045B7540E47 /* BrokerClientError.swift */; };
 		0483F1444764AB1812DC4A79 /* GeoIpClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 135777353E0B842A0E8E1A49 /* GeoIpClient.swift */; };
 		0B37B967668B130238C8E4EF /* BrokerEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF772A16497903CC49D1F76D /* BrokerEndpoint.swift */; };
+		0FECF7EABB4F538A378ECDFF /* RelayListVerifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B42983C9E84DBA57FA9C2AA4 /* RelayListVerifier.swift */; };
 		1001D8102F7EA1A694366DFF /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A9B3E3F0BA7E28C5D05A1731 /* Images.xcassets */; };
 		101812ACF2D87E69B666B516 /* DeviceAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E77D10C22E8939116D44BD /* DeviceAttributes.swift */; };
 		160F427AA318BEC6A772654F /* SpeedTestClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A57C8F876ACF0B8B9BC73749 /* SpeedTestClient.swift */; };
 		1688E26406D6F8E93575AFCA /* CountryGeo.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2570C01745DA49558877810 /* CountryGeo.swift */; };
+		16BA73EAD541069CDA90AB8B /* libPods-OpenRung.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9299D579D5E1F2472125EF1F /* libPods-OpenRung.a */; };
 		2226FA02DA3CF06280AA3D27 /* CountryGeo.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2570C01745DA49558877810 /* CountryGeo.swift */; };
 		2367D4EBC8213B6D57E65A0E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A07146C137269D283F062DB /* AppDelegate.swift */; };
 		27BE72CA10A4E0EC9A5643FB /* BrokerClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0CE1F672D5FAD1FBB511D5B /* BrokerClient.swift */; };
@@ -25,7 +27,6 @@
 		293B5AB965931E683887D8F4 /* TelemetryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA18FA5754E54F0ADC5189F0 /* TelemetryManager.swift */; };
 		2C3222CCA8C27C06BBA68F85 /* FailureClassifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F3B6378B98E464A9F306E7 /* FailureClassifier.swift */; };
 		2E0156D4F82558FA780E5EFD /* ClientIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD4088394FB9EBCF808F81C2 /* ClientIdentity.swift */; };
-		2F51432049497BF9149B2181 /* libPods-OpenRung.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 739B4A424248AA70C895A125 /* libPods-OpenRung.a */; };
 		352F6CA320938DBB039664C2 /* GeoIpClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 135777353E0B842A0E8E1A49 /* GeoIpClient.swift */; };
 		37B87770F048737201BAE35F /* TelemetryOutbox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BFFA22BC1A97C70EF5F275D /* TelemetryOutbox.swift */; };
 		39331D5AF76FB94FA1EB09CA /* PacketTunnelProxyEngineError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A0014BD8DAE8D1AB0AA819 /* PacketTunnelProxyEngineError.swift */; };
@@ -34,6 +35,14 @@
 		3CF707854EB1FBBCFC3E354F /* ConnectionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 584A04475F28B3CAC39B501E /* ConnectionStatus.swift */; };
 		3D8CFD33EED8FE7AE1FB3299 /* TelemetryEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C9C9695B7E93F7A4F5460B /* TelemetryEvent.swift */; };
 		3E600B1A4A0F6A075AB8D6E7 /* FailureClassifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E89C58EA730C659109459911 /* FailureClassifierTests.swift */; };
+		53204CFF683E4D2D962D0329 /* RelayListVerifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 527B63C692D7446893956A81 /* RelayListVerifierTests.swift */; };
+		1825743E08434381BBDFB6D7 /* RelayListVerifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B42983C9E84DBA57FA9C2AA4 /* RelayListVerifier.swift */; };
+		D5B80B30B308406A90AE3F95 /* AppConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4783169BE46FEE9B0472504 /* AppConfig.swift */; };
+		5167DB5F4AB641C3AE2CB4E5 /* BrokerClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0CE1F672D5FAD1FBB511D5B /* BrokerClient.swift */; };
+		10B4D20F23884CFD9193535C /* RelayDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC6AEF8D510DD407C368119F /* RelayDescriptor.swift */; };
+		049E100990EA4824ACFC0A58 /* DeviceAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E77D10C22E8939116D44BD /* DeviceAttributes.swift */; };
+		DD7E75C3FB7640BB941321D0 /* NetworkPathMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C127CAD14278743A1BD298 /* NetworkPathMonitor.swift */; };
+		6B9BD82BB88D4A799C2A3604 /* BrokerEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF772A16497903CC49D1F76D /* BrokerEndpoint.swift */; };
 		4AF8C7F150317AC00E8B27FA /* PacketTunnel.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 1EAA8B2F5746A87534F0C87B /* PacketTunnel.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		4F5E5D33E5E0532AB1153B1C /* PacketTunnelProxyEngineError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A0014BD8DAE8D1AB0AA819 /* PacketTunnelProxyEngineError.swift */; };
 		523936029217C10BD01D40DC /* ActivityLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C27022D3D9D7FEEC839F406 /* ActivityLog.swift */; };
@@ -64,6 +73,7 @@
 		ADCA603D15EE662D1B0A279C /* RelayReachabilityError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FF4517B34B4819F6DCD4D1 /* RelayReachabilityError.swift */; };
 		B466AFF5D620F556EA05524F /* RelaySelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD9B5CA88D770C6F0A9597FE /* RelaySelector.swift */; };
 		B6964681672D4F326B16F976 /* TunnelDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B9BA54065E95B7262DA7A95 /* TunnelDiagnostics.swift */; };
+		BAF6846398D40CC0F5AB1023 /* RelayListVerifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B42983C9E84DBA57FA9C2AA4 /* RelayListVerifier.swift */; };
 		BB0CE4474A9BF517F57AA4E8 /* BrokerClientError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683F07997A392045B7540E47 /* BrokerClientError.swift */; };
 		BB4F499FD2BC0AAC963D515B /* Libbox.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F19AE6300C331CB6C7B2B9E8 /* Libbox.xcframework */; };
 		BF55D9C9334181B84F1D36EC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 83209B5DF847F742A280CD21 /* LaunchScreen.storyboard */; };
@@ -115,6 +125,7 @@
 		005F1F59591EC44366AC6B21 /* InternetProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternetProbe.swift; sourceTree = "<group>"; };
 		03703C68A02344020716751A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		135777353E0B842A0E8E1A49 /* GeoIpClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeoIpClient.swift; sourceTree = "<group>"; };
+		1636791DD574F337EA4FBFE9 /* Pods-OpenRung.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OpenRung.release.xcconfig"; path = "Target Support Files/Pods-OpenRung/Pods-OpenRung.release.xcconfig"; sourceTree = "<group>"; };
 		174E944F053F54F691E59C74 /* OpenRungTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = OpenRungTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		1EAA8B2F5746A87534F0C87B /* PacketTunnel.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = PacketTunnel.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		25CB8E64CF645C0DD1375294 /* EngineDirectories.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EngineDirectories.swift; sourceTree = "<group>"; };
@@ -126,13 +137,13 @@
 		584A04475F28B3CAC39B501E /* ConnectionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionStatus.swift; sourceTree = "<group>"; };
 		683F07997A392045B7540E47 /* BrokerClientError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrokerClientError.swift; sourceTree = "<group>"; };
 		6A5299A99DA8ED8C75B1E25B /* TelemetrySession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetrySession.swift; sourceTree = "<group>"; };
+		6B00053ED698F1318995849A /* Pods-OpenRung.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OpenRung.debug.xcconfig"; path = "Target Support Files/Pods-OpenRung/Pods-OpenRung.debug.xcconfig"; sourceTree = "<group>"; };
 		719ACF45718CBF52773FCD6C /* OpenRungVpnModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenRungVpnModule.swift; sourceTree = "<group>"; };
-		739B4A424248AA70C895A125 /* libPods-OpenRung.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-OpenRung.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		75EA37B450C63159CA5C16FA /* Pods-OpenRung.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OpenRung.release.xcconfig"; path = "Target Support Files/Pods-OpenRung/Pods-OpenRung.release.xcconfig"; sourceTree = "<group>"; };
 		7A07146C137269D283F062DB /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		81B10868A3F7FA99A84696A4 /* OpenRung.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = OpenRung.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		81CC00C2F7324111F25D07A0 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		83209B5DF847F742A280CD21 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
+		9299D579D5E1F2472125EF1F /* libPods-OpenRung.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-OpenRung.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		97D23B885595CDD6DD259A85 /* LibboxPacketTunnelPlatformInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibboxPacketTunnelPlatformInterface.swift; sourceTree = "<group>"; };
 		9C27022D3D9D7FEEC839F406 /* ActivityLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityLog.swift; sourceTree = "<group>"; };
 		9C3C1158F41CEF59BEB36FEB /* PacketTunnelError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PacketTunnelError.swift; sourceTree = "<group>"; };
@@ -142,9 +153,9 @@
 		AB117725DF8A60D9A23412CC /* PacketTunnel.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PacketTunnel.entitlements; sourceTree = "<group>"; };
 		B0C127CAD14278743A1BD298 /* NetworkPathMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkPathMonitor.swift; sourceTree = "<group>"; };
 		B3A0014BD8DAE8D1AB0AA819 /* PacketTunnelProxyEngineError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PacketTunnelProxyEngineError.swift; sourceTree = "<group>"; };
+		B42983C9E84DBA57FA9C2AA4 /* RelayListVerifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayListVerifier.swift; sourceTree = "<group>"; };
 		B9D3B66E26E617B7B00140A4 /* PacketTunnelProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PacketTunnelProvider.swift; sourceTree = "<group>"; };
 		BA18FA5754E54F0ADC5189F0 /* TelemetryManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryManager.swift; sourceTree = "<group>"; };
-		C0B991DD5EDE0739BE56D2A4 /* Pods-OpenRung.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OpenRung.debug.xcconfig"; path = "Target Support Files/Pods-OpenRung/Pods-OpenRung.debug.xcconfig"; sourceTree = "<group>"; };
 		C28E2B488D1B810BD0BB8AA1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		C4E77D10C22E8939116D44BD /* DeviceAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceAttributes.swift; sourceTree = "<group>"; };
 		C9F3B6378B98E464A9F306E7 /* FailureClassifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FailureClassifier.swift; sourceTree = "<group>"; };
@@ -160,6 +171,7 @@
 		E2570C01745DA49558877810 /* CountryGeo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountryGeo.swift; sourceTree = "<group>"; };
 		E4783169BE46FEE9B0472504 /* AppConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfig.swift; sourceTree = "<group>"; };
 		E89C58EA730C659109459911 /* FailureClassifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FailureClassifierTests.swift; sourceTree = "<group>"; };
+		527B63C692D7446893956A81 /* RelayListVerifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayListVerifierTests.swift; sourceTree = "<group>"; };
 		EC15DA1827B19848080D3452 /* libresolv.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libresolv.tbd; path = usr/lib/libresolv.tbd; sourceTree = SDKROOT; };
 		ED28831CA960E8B89D5D7D04 /* OpenRungVpnModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OpenRungVpnModule.m; sourceTree = "<group>"; };
 		EF772A16497903CC49D1F76D /* BrokerEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrokerEndpoint.swift; sourceTree = "<group>"; };
@@ -179,11 +191,11 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		F6A66E991A4B9EA0848A72AC /* Frameworks */ = {
+		CD0600673757DF977C6D5BA8 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2F51432049497BF9149B2181 /* libPods-OpenRung.a in Frameworks */,
+				16BA73EAD541069CDA90AB8B /* libPods-OpenRung.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -221,6 +233,7 @@
 				005F1F59591EC44366AC6B21 /* InternetProbe.swift */,
 				B0C127CAD14278743A1BD298 /* NetworkPathMonitor.swift */,
 				DC6AEF8D510DD407C368119F /* RelayDescriptor.swift */,
+				B42983C9E84DBA57FA9C2AA4 /* RelayListVerifier.swift */,
 				D5AFE2F1F1556F9E70F0AC99 /* RelayReachability.swift */,
 				D8FF4517B34B4819F6DCD4D1 /* RelayReachabilityError.swift */,
 				FD9B5CA88D770C6F0A9597FE /* RelaySelector.swift */,
@@ -243,18 +256,9 @@
 			isa = PBXGroup;
 			children = (
 				E89C58EA730C659109459911 /* FailureClassifierTests.swift */,
+				527B63C692D7446893956A81 /* RelayListVerifierTests.swift */,
 			);
 			path = OpenRungTests;
-			sourceTree = "<group>";
-		};
-		9FE6AFBA8B6C120542269256 /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				C0B991DD5EDE0739BE56D2A4 /* Pods-OpenRung.debug.xcconfig */,
-				75EA37B450C63159CA5C16FA /* Pods-OpenRung.release.xcconfig */,
-			);
-			name = Pods;
-			path = Pods;
 			sourceTree = "<group>";
 		};
 		A1C815B9A63C637692C1C541 /* Frameworks */ = {
@@ -263,7 +267,7 @@
 				F19AE6300C331CB6C7B2B9E8 /* Libbox.xcframework */,
 				EC15DA1827B19848080D3452 /* libresolv.tbd */,
 				81CC00C2F7324111F25D07A0 /* UIKit.framework */,
-				739B4A424248AA70C895A125 /* libPods-OpenRung.a */,
+				9299D579D5E1F2472125EF1F /* libPods-OpenRung.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -282,6 +286,16 @@
 				B3A0014BD8DAE8D1AB0AA819 /* PacketTunnelProxyEngineError.swift */,
 			);
 			path = PacketTunnel;
+			sourceTree = "<group>";
+		};
+		C215C92524EDF6E02C9893AE /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				6B00053ED698F1318995849A /* Pods-OpenRung.debug.xcconfig */,
+				1636791DD574F337EA4FBFE9 /* Pods-OpenRung.release.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
 			sourceTree = "<group>";
 		};
 		E73A5155909F9EFE9F13A6A1 /* Products */ = {
@@ -303,7 +317,7 @@
 				3F24A472F75132572E2891A1 /* Shared */,
 				A1C815B9A63C637692C1C541 /* Frameworks */,
 				E73A5155909F9EFE9F13A6A1 /* Products */,
-				9FE6AFBA8B6C120542269256 /* Pods */,
+				C215C92524EDF6E02C9893AE /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -330,15 +344,15 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F19D0D1C8CB7FB1B6B178E82 /* Build configuration list for PBXNativeTarget "OpenRung" */;
 			buildPhases = (
-				88F41DF9A85053D4E116BDF2 /* [CP] Check Pods Manifest.lock */,
+				B9D296CFF897350C982FB6BE /* [CP] Check Pods Manifest.lock */,
 				BC3282E3662088C7CF8F8BC7 /* Sources */,
 				7272F5C7D4F2765DAB69942D /* Resources */,
 				141D130B421160859A220937 /* Embed Foundation Extensions */,
 				7645E65DA025354651549041 /* Bundle React Native code and images */,
-				E14B0AF1D929D24368D45514 /* [MapLibre React Native] Remove MapLibre.xcframework-ios.signature */,
-				F6A66E991A4B9EA0848A72AC /* Frameworks */,
-				23F6B208A008DEB0E6791759 /* [CP] Embed Pods Frameworks */,
-				5870AD9C69E407AC5CF86CA3 /* [CP] Copy Pods Resources */,
+				DBC8727E11CF68DBE9C457F6 /* [MapLibre React Native] Remove MapLibre.xcframework-ios.signature */,
+				CD0600673757DF977C6D5BA8 /* Frameworks */,
+				56D49AC4F94A5B7EB4ACD104 /* [CP] Embed Pods Frameworks */,
+				94E100682F0FBB9F01E593A8 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -347,7 +361,7 @@
 			);
 			name = OpenRung;
 			packageProductDependencies = (
-				54789229C997837AEFCB20DF /* MapLibre */,
+				27E595FF40673ADA19724433 /* MapLibre */,
 			);
 			productName = OpenRung;
 			productReference = 81B10868A3F7FA99A84696A4 /* OpenRung.app */;
@@ -401,7 +415,7 @@
 			mainGroup = F4646C7E57CBAA9E0DF5661F;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
-				DF1A68EFD7AE0666ED66EEAF /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */,
+				18DC1EC9AF2327B5DD11BE7D /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = E73A5155909F9EFE9F13A6A1 /* Products */;
@@ -429,7 +443,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		23F6B208A008DEB0E6791759 /* [CP] Embed Pods Frameworks */ = {
+		56D49AC4F94A5B7EB4ACD104 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -444,23 +458,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-OpenRung/Pods-OpenRung-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		5870AD9C69E407AC5CF86CA3 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-OpenRung/Pods-OpenRung-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-OpenRung/Pods-OpenRung-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-OpenRung/Pods-OpenRung-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		7645E65DA025354651549041 /* Bundle React Native code and images */ = {
@@ -483,7 +480,24 @@
 			shellPath = /bin/sh;
 			shellScript = "set -e\n\nWITH_ENVIRONMENT=\"$REACT_NATIVE_PATH/scripts/xcode/with-environment.sh\"\nREACT_NATIVE_XCODE=\"$REACT_NATIVE_PATH/scripts/react-native-xcode.sh\"\n\n/bin/sh -c \"\\\"$WITH_ENVIRONMENT\\\" \\\"$REACT_NATIVE_XCODE\\\"\"\n";
 		};
-		88F41DF9A85053D4E116BDF2 /* [CP] Check Pods Manifest.lock */ = {
+		94E100682F0FBB9F01E593A8 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-OpenRung/Pods-OpenRung-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-OpenRung/Pods-OpenRung-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-OpenRung/Pods-OpenRung-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		B9D296CFF897350C982FB6BE /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -505,7 +519,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		E14B0AF1D929D24368D45514 /* [MapLibre React Native] Remove MapLibre.xcframework-ios.signature */ = {
+		DBC8727E11CF68DBE9C457F6 /* [MapLibre React Native] Remove MapLibre.xcframework-ios.signature */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
@@ -551,6 +565,7 @@
 				E23AB43D1F262132DECB88F3 /* PacketTunnelProxyEngine.swift in Sources */,
 				4F5E5D33E5E0532AB1153B1C /* PacketTunnelProxyEngineError.swift in Sources */,
 				D095482C735B4750F9AC99BB /* RelayDescriptor.swift in Sources */,
+				0FECF7EABB4F538A378ECDFF /* RelayListVerifier.swift in Sources */,
 				C1A6F6AC896E2EE68FCD7AC9 /* RelayReachability.swift in Sources */,
 				CE5FF08F60EA9B59A3FAD581 /* RelayReachabilityError.swift in Sources */,
 				024B9A8C62881E530EB591B4 /* RelaySelector.swift in Sources */,
@@ -572,11 +587,19 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D5B80B30B308406A90AE3F95 /* AppConfig.swift in Sources */,
+				5167DB5F4AB641C3AE2CB4E5 /* BrokerClient.swift in Sources */,
 				3CCF2F1EFD201AD5A17B3998 /* BrokerClientError.swift in Sources */,
+				6B9BD82BB88D4A799C2A3604 /* BrokerEndpoint.swift in Sources */,
+				049E100990EA4824ACFC0A58 /* DeviceAttributes.swift in Sources */,
 				2C3222CCA8C27C06BBA68F85 /* FailureClassifier.swift in Sources */,
 				3E600B1A4A0F6A075AB8D6E7 /* FailureClassifierTests.swift in Sources */,
+				DD7E75C3FB7640BB941321D0 /* NetworkPathMonitor.swift in Sources */,
 				01C5EA0362C5AAB18ED81859 /* PacketTunnelError.swift in Sources */,
 				39331D5AF76FB94FA1EB09CA /* PacketTunnelProxyEngineError.swift in Sources */,
+				10B4D20F23884CFD9193535C /* RelayDescriptor.swift in Sources */,
+				1825743E08434381BBDFB6D7 /* RelayListVerifier.swift in Sources */,
+				53204CFF683E4D2D962D0329 /* RelayListVerifierTests.swift in Sources */,
 				E6799BE42347DC306ADF2213 /* RelayReachabilityError.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -601,6 +624,7 @@
 				E2C945F0A942AE0E937369EC /* OpenRungVpnModule.m in Sources */,
 				F82F4E03FAD0D3DFDB106718 /* OpenRungVpnModule.swift in Sources */,
 				7AD3CF8197D457CDDC3CCBCE /* RelayDescriptor.swift in Sources */,
+				BAF6846398D40CC0F5AB1023 /* RelayListVerifier.swift in Sources */,
 				A47671E4D8F1625738EA3742 /* RelayReachability.swift in Sources */,
 				ADCA603D15EE662D1B0A279C /* RelayReachabilityError.swift in Sources */,
 				B466AFF5D620F556EA05524F /* RelaySelector.swift in Sources */,
@@ -631,7 +655,7 @@
 /* Begin XCBuildConfiguration section */
 		0D953B3D127C0BB08E644293 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 75EA37B450C63159CA5C16FA /* Pods-OpenRung.release.xcconfig */;
+			baseConfigurationReference = 1636791DD574F337EA4FBFE9 /* Pods-OpenRung.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = OpenRung/OpenRung.entitlements;
@@ -769,7 +793,7 @@
 		};
 		73BE8C16CB91640112F4357A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C0B991DD5EDE0739BE56D2A4 /* Pods-OpenRung.debug.xcconfig */;
+			baseConfigurationReference = 6B00053ED698F1318995849A /* Pods-OpenRung.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = OpenRung/OpenRung.entitlements;
@@ -982,7 +1006,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		DF1A68EFD7AE0666ED66EEAF /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */ = {
+		18DC1EC9AF2327B5DD11BE7D /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/maplibre/maplibre-gl-native-distribution";
 			requirement = {
@@ -993,9 +1017,9 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		54789229C997837AEFCB20DF /* MapLibre */ = {
+		27E595FF40673ADA19724433 /* MapLibre */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = DF1A68EFD7AE0666ED66EEAF /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */;
+			package = 18DC1EC9AF2327B5DD11BE7D /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */;
 			productName = MapLibre;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/ios/OpenRungTests/RelayListVerifierTests.swift
+++ b/ios/OpenRungTests/RelayListVerifierTests.swift
@@ -1,0 +1,276 @@
+import CryptoKit
+import Foundation
+import XCTest
+
+// Shared signing test vector (SPEC v1 §2.3): the seed is 32 bytes of 0x42 — TEST ONLY, never a
+// production key. These literals are copied verbatim from testdata/signing_vectors.json (`spec_vector`),
+// mirroring how the Kotlin suite (RelayListVerifierTest.kt) embeds the vector as constants so all
+// four clients are pinned to identical bytes. RelayListVerifier and its RelaySigningKey/
+// RelayListVerificationError types are compiled directly into this test target (see the
+// OpenRungTests target in project.yml / project.pbxproj), so no import of the app or extension is
+// needed — the FailureClassifierTests isolation pattern.
+private let VECTOR_PUBKEY_HEX = "2152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db12"
+private let VECTOR_KEY_ID = "3097e2dee2cb4a34"
+private let VECTOR_BODY =
+    "{\"count\":1,\"server_time\":\"2026-07-10T00:00:00Z\",\"not_after\":\"2026-07-10T00:30:00Z\"," +
+    "\"key_id\":\"3097e2dee2cb4a34\",\"channel\":\"api\",\"limit\":1,\"relays\":[]}"
+private let VECTOR_SIG_B64 =
+    "K5UmJWzoEZ1YHOqZFf5E+ocNOITSe3WPvOo0GuyCRoiAxUk4eo/jcfqiuaPhrNeYrK3i8QcYI3LIv+zbVYq9Bw=="
+private let VECTOR_HEADER = "ed25519;\(VECTOR_KEY_ID);\(VECTOR_SIG_B64)"
+
+/// The vector's `not_after` is 2026-07-10T00:30:00Z; "now" sits 10 min after `server_time`, well
+/// inside the signed freshness window.
+private let VECTOR_NOW = isoDate("2026-07-10T00:10:00Z")
+
+/// The SPEC v1 §5.2 verification algorithm against the shared §2.3 vector: the positive case, the
+/// §12 negatives (each must reject as "candidate failed", i.e. throw `RelayListVerificationError`
+/// whose message begins with the mandated "unsigned/invalid relay list"), the §4.2 advisory key_id
+/// routing, and the §11 pinned-key CI guard over the production constants in
+/// `AppConfig.relaySigningKeys`. Pure logic — no sockets, no app host.
+final class RelayListVerifierTests: XCTestCase {
+
+    /// Verifier pinned with ONLY the §2.3 test key, for the positive/negative body-and-header cases.
+    private let testKeyVerifier = RelayListVerifier(
+        keys: [RelaySigningKey(keyID: VECTOR_KEY_ID, publicKeyHex: VECTOR_PUBKEY_HEX)]
+    )
+
+    // MARK: - Positive
+
+    func testSharedVectorVerifies() throws {
+        let verified = try testKeyVerifier.verify(
+            body: Data(VECTOR_BODY.utf8),
+            signatureHeader: VECTOR_HEADER,
+            channel: .api,
+            requestedLimit: 1,
+            now: VECTOR_NOW
+        )
+        XCTAssertEqual(verified.keyID, VECTOR_KEY_ID)
+        // key_id derivation (§2.2): first 8 SHA-256 bytes of the raw pubkey, lowercase hex.
+        XCTAssertEqual(deriveKeyID(try XCTUnwrap(hexToData(VECTOR_PUBKEY_HEX))), VECTOR_KEY_ID)
+    }
+
+    func testAcceptsInsideFiveMinuteSkewAllowance() throws {
+        // not_after 00:30:00Z, skew 5 min → acceptance boundary is now = 00:35:00Z exactly.
+        _ = try testKeyVerifier.verify(
+            body: Data(VECTOR_BODY.utf8),
+            signatureHeader: VECTOR_HEADER,
+            channel: .api,
+            requestedLimit: 1,
+            now: isoDate("2026-07-10T00:34:59Z")
+        )
+    }
+
+    // MARK: - §4.2 advisory key_id routing
+
+    func testWrongAdvisoryKeyIdStillVerifiesUnderPinnedKey() throws {
+        // The header routes to a key_id no pinned key has; the verifier must fall back to trying
+        // every pinned key rather than reject, and report the PINNED key that actually verified.
+        let header = "ed25519;ffffffffffffffff;\(VECTOR_SIG_B64)"
+        let verified = try testKeyVerifier.verify(
+            body: Data(VECTOR_BODY.utf8),
+            signatureHeader: header,
+            channel: .api,
+            requestedLimit: 1,
+            now: VECTOR_NOW
+        )
+        XCTAssertEqual(verified.keyID, VECTOR_KEY_ID)
+    }
+
+    // MARK: - Negatives (each rejects as a failed candidate)
+
+    func testFlippedBodyByteIsRejected() {
+        var body = Array(VECTOR_BODY.utf8)
+        body[10] ^= 0x01
+        let error = assertRejected(testKeyVerifier, body: Data(body))
+        XCTAssertEqual(error, .signatureMismatch)
+    }
+
+    func testFlippedSignatureByteIsRejected() {
+        // First base64 char K -> L still decodes to 64 bytes but is no longer the vector signature.
+        let flipped = "L" + VECTOR_SIG_B64.dropFirst()
+        XCTAssertNotEqual(flipped, VECTOR_SIG_B64)
+        let error = assertRejected(testKeyVerifier, header: "ed25519;\(VECTOR_KEY_ID);\(flipped)")
+        XCTAssertEqual(error, .signatureMismatch)
+    }
+
+    func testValidSignatureUnderUnpinnedKeyIsRejected() {
+        // The production pin does not contain the §2.3 TEST key, so the (valid) vector signature
+        // must not verify — the verifier falls through every pinned key first (§4.2).
+        let productionPinned = RelayListVerifier(keys: AppConfig.relaySigningKeys)
+        let error = assertRejected(productionPinned)
+        XCTAssertEqual(error, .signatureMismatch)
+    }
+
+    func testMissingHeaderIsRejected() {
+        let error = assertRejected(testKeyVerifier, header: nil)
+        XCTAssertEqual(error, .missingSignatureHeader)
+    }
+
+    func testMalformedHeadersAreRejected() {
+        let shortSignature = Data(count: 63).base64EncodedString()
+        let malformed: [String] = [
+            "",                                             // empty (present but unparseable)
+            "ed25519;\(VECTOR_KEY_ID)",                     // two fields
+            "\(VECTOR_HEADER);extra",                       // four fields
+            "rsa;\(VECTOR_KEY_ID);\(VECTOR_SIG_B64)",       // wrong algorithm string
+            "ED25519;\(VECTOR_KEY_ID);\(VECTOR_SIG_B64)",   // the algorithm literal is exact (§2.1)
+            "ed25519;\(VECTOR_KEY_ID);%%%not-base64%%%",    // undecodable signature
+            "ed25519;\(VECTOR_KEY_ID);\(shortSignature)",   // 63-byte signature (must be exactly 64)
+        ]
+        for header in malformed {
+            let error = assertRejected(testKeyVerifier, header: header)
+            XCTAssertEqual(error, .malformedSignatureHeader, "header should be malformed: \(header)")
+        }
+    }
+
+    func testChannelMismatchIsRejected() {
+        // The §2.3 body is signed for the API channel; verifying it on the mirror channel must fail
+        // even though the signature is valid — a validly signed artifact cannot cross channels (§2.2).
+        let error = assertRejected(testKeyVerifier, channel: .mirror, requestedLimit: nil)
+        guard case .channelMismatch(let expected, let received)? = error else {
+            return XCTFail("expected channelMismatch, got \(String(describing: error))")
+        }
+        XCTAssertEqual(expected, "mirror")
+        XCTAssertEqual(received, "api")
+    }
+
+    func testLimitEchoMismatchIsRejected() {
+        // The vector body echoes limit=1; a client that requested 2 must not accept it (§2.2
+        // anti variant-steering).
+        let error = assertRejected(testKeyVerifier, requestedLimit: 2)
+        guard case .limitMismatch(let requested, let received)? = error else {
+            return XCTFail("expected limitMismatch, got \(String(describing: error))")
+        }
+        XCTAssertEqual(requested, 2)
+        XCTAssertEqual(received, 1)
+    }
+
+    func testExpiredNotAfterIsRejected() {
+        // not_after 00:30:00Z; now 01:00:00Z is well past the 5-min slow-clock allowance.
+        let error = assertRejected(testKeyVerifier, now: isoDate("2026-07-10T01:00:00Z"))
+        guard case .expired? = error else {
+            return XCTFail("expected expired, got \(String(describing: error))")
+        }
+    }
+
+    // MARK: - §11 pinned-key CI guard
+
+    func testPinnedProductionKeysMatchCommittedRotationVectors() throws {
+        // A truncated or typo'd pinned constant must fail HERE, not on key-promotion day. Each
+        // production key in AppConfig.relaySigningKeys must derive its committed key_id AND verify
+        // its committed rotation vector — the vectors are index-aligned with the ordered pin (active
+        // first, then standby). Copied verbatim from testdata/signing_vectors.json (`pinned_keys`).
+        let rotationVectors: [(message: String, keyID: String, signatureB64: String)] = [
+            (
+                "openrung-signing-key-vector:active",
+                "627405615601c589",
+                "mELBVRsBe2+aeKYMniZ2F0HEV7n+8VcokBgailoLQW7JAleX6q8RQypVOO0y0p0+g/u89Uu+aaYpVfvpIAMRBQ=="
+            ),
+            (
+                "openrung-signing-key-vector:standby",
+                "672f79aa99a573cd",
+                "KyYhv/R46Wmi1M4y+KPT4CUz40mVXzwG3hYG5U22v7qpxri0pj4wYCgxqjrGmh2hlFNcx8gZpIBFO1PhD7xABw=="
+            ),
+        ]
+
+        XCTAssertEqual(
+            AppConfig.relaySigningKeys.count,
+            rotationVectors.count,
+            "pinned-key count drifted from the committed rotation vectors"
+        )
+
+        for (index, vector) in rotationVectors.enumerated() {
+            let pinned = AppConfig.relaySigningKeys[index]
+            XCTAssertEqual(pinned.keyID, vector.keyID, "pinned key order or key_id drifted at index \(index)")
+
+            let rawKey = try XCTUnwrap(
+                hexToData(pinned.publicKeyHex),
+                "pinned publicKeyHex is not valid hex: \(pinned.publicKeyHex)"
+            )
+            XCTAssertEqual(rawKey.count, 32, "pinned key is not a raw 32-byte Ed25519 key")
+            XCTAssertEqual(
+                deriveKeyID(rawKey),
+                vector.keyID,
+                "key_id derivation mismatch — corrupted pinned key at index \(index)"
+            )
+
+            let publicKey = try Curve25519.Signing.PublicKey(rawRepresentation: rawKey)
+            let signature = try XCTUnwrap(Data(base64Encoded: vector.signatureB64))
+            XCTAssertTrue(
+                publicKey.isValidSignature(signature, for: Data(vector.message.utf8)),
+                "rotation vector failed to verify under pinned key \(vector.keyID) — corrupted pinned constant"
+            )
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Asserts `verify` rejects and, per §5.2, that the surfaced message begins with the mandated
+    /// "unsigned/invalid relay list" (never a generic network-error phrasing). Returns the thrown
+    /// error so callers can additionally assert the specific case.
+    @discardableResult
+    private func assertRejected(
+        _ verifier: RelayListVerifier,
+        body: Data = Data(VECTOR_BODY.utf8),
+        header: String? = VECTOR_HEADER,
+        channel: RelayListVerifier.Channel = .api,
+        requestedLimit: Int? = 1,
+        now: Date = VECTOR_NOW,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> RelayListVerificationError? {
+        do {
+            _ = try verifier.verify(
+                body: body,
+                signatureHeader: header,
+                channel: channel,
+                requestedLimit: requestedLimit,
+                now: now
+            )
+            XCTFail("verification unexpectedly succeeded", file: file, line: line)
+            return nil
+        } catch let error as RelayListVerificationError {
+            XCTAssertTrue(
+                (error.errorDescription ?? "").hasPrefix("unsigned/invalid relay list"),
+                "message must begin with the mandated substring: \(String(describing: error.errorDescription))",
+                file: file,
+                line: line
+            )
+            return error
+        } catch {
+            XCTFail("unexpected error type: \(error)", file: file, line: line)
+            return nil
+        }
+    }
+}
+
+// MARK: - File-local codecs (RelayListVerifier's own hex decoder is private)
+
+/// Strict lowercase/uppercase hex → bytes; nil on odd length or any non-hex character.
+private func hexToData(_ hex: String) -> Data? {
+    guard hex.count % 2 == 0 else { return nil }
+    var data = Data(capacity: hex.count / 2)
+    var index = hex.startIndex
+    while index < hex.endIndex {
+        let next = hex.index(index, offsetBy: 2)
+        guard let byte = UInt8(hex[index..<next], radix: 16) else { return nil }
+        data.append(byte)
+        index = next
+    }
+    return data
+}
+
+/// key_id derivation (§2.2): lowercase hex of the first 8 bytes of SHA-256 over the raw public key.
+private func deriveKeyID(_ publicKey: Data) -> String {
+    SHA256.hash(data: publicKey).prefix(8).map { String(format: "%02x", $0) }.joined()
+}
+
+/// RFC3339 UTC parse for the fixed test clocks.
+private func isoDate(_ value: String) -> Date {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime]
+    guard let date = formatter.date(from: value) else {
+        fatalError("bad ISO8601 test date: \(value)")
+    }
+    return date
+}

--- a/ios/Shared/AppConfig.swift
+++ b/ios/Shared/AppConfig.swift
@@ -11,8 +11,10 @@ enum AppConfig {
     /// Discovery broker (relay-list bootstrap) default, and — since discovery is HTTPS-only — the sole
     /// built-in discovery candidate. Discovery is the censorship-critical path: it runs BEFORE the VPN
     /// tunnel is up, and the relay list it returns defines which server the client trusts as its exit.
-    /// The relay list is NOT signed, so it must only be fetched over a TLS-authenticated channel; the
-    /// Cloudflare-fronted HTTPS endpoint (TLS + CDN edge IPs) is both hard to block and unforgeable.
+    /// The relay list is Ed25519-signed by the broker and verified against `relaySigningKeys` before
+    /// it is decoded (see `RelayListVerifier`), so its authenticity no longer rests on the transport;
+    /// the Cloudflare-fronted HTTPS endpoint stays the default because TLS + CDN edge IPs are hard to
+    /// block and keep the client identity headers off the wire in cleartext.
     static let defaultBrokerURL = URL(string: "https://broker.openrung.org/")!
 
     /// Telemetry / heartbeat / speed-test target. Uses the same Cloudflare-fronted HTTPS broker as
@@ -27,20 +29,40 @@ enum AppConfig {
 
     /// Ordered discovery candidates, raced with a staggered start: the first entry starts
     /// immediately, each later entry joins `discoveryStaggerMs` after the previous one, and the first
-    /// candidate to return relays wins (see `BrokerClient.firstReachable`). Every entry MUST be
-    /// HTTPS: the relay list is not yet signed, so it is authenticated only by the TLS cert of the
-    /// serving host — a cleartext/bare-IP entry would let an on-path censor inject a malicious relay
-    /// set.
+    /// candidate to return relays wins (see `BrokerClient.firstReachable`). Every non-loopback
+    /// candidate's relay list must carry a valid Ed25519 signature under `relaySigningKeys`
+    /// (`RelayListVerifier`), so a censor or on-path attacker controlling a candidate can only fail
+    /// it, never feed a forged relay set. Entries stay HTTPS regardless — TLS keeps the client
+    /// identity headers confidential, which the signature does not.
     ///
     /// Only one front is deployed today, so a censor who blocks it fails discovery CLOSED (offline).
-    /// Closing that single point of failure is the front-diversity layer: adding more *HTTPS* fronts
-    /// on independent CDNs/domains is safe now (still TLS-authenticated) and just needs the extra
-    /// fronts deployed. Non-TLS / out-of-band channels (raw IP, cached blobs) stay off this list until
-    /// the broker signs the relay list. Keep this in sync with the other clients' AppConfig.
+    /// Closing that single point of failure is the front-diversity layer: adding more HTTPS fronts on
+    /// independent CDNs/domains just needs the extra fronts deployed, and with signing in place
+    /// non-TLS / out-of-band channels (direct-IP fallback, signed mirrors, cached lists) become
+    /// possible in later phases. Keep this in sync with the other clients' AppConfig.
     static let defaultBrokerURLs: [URL] = [
         defaultBrokerURL,
         // Additional HTTPS fronts once deployed (second domain / second CDN), e.g.:
         //   URL(string: "https://broker2.openrung.org/")!,
+    ]
+
+    /// Ed25519 public keys trusted to sign the relay list, in pinned order — active key first, then
+    /// the offline standby (a third "previous" slot appears during rotations; signing spec §4.2/§11).
+    /// `keyID` is the lowercase hex of the first 8 bytes of SHA-256 over the raw 32-byte public key;
+    /// it routes verification to the matching key first but is advisory only — on a miss every pinned
+    /// key is tried. These constants MUST stay byte-identical to `testdata/signing_vectors.json`
+    /// (`pinned_keys`), which is what the committed-vector CI guard compares them against, and in
+    /// sync with the other clients' pinned lists. Rotating keys means shipping a release with the
+    /// updated list — see the signing spec's promotion runbook.
+    static let relaySigningKeys: [RelaySigningKey] = [
+        RelaySigningKey(
+            keyID: "627405615601c589",
+            publicKeyHex: "176c03cbc70833285abcea75f2a0e137bd687629142408c22806a86308bd4974"
+        ),
+        RelaySigningKey(
+            keyID: "672f79aa99a573cd",
+            publicKeyHex: "5b2698cfa7a796c671a30aabd5475d55095b91464221f051837eb8fe01f36ea2"
+        ),
     ]
 
     /// Ordered broker candidates for a connection attempt: the caller-selected `primary` (the provider

--- a/ios/Shared/BrokerClient.swift
+++ b/ios/Shared/BrokerClient.swift
@@ -28,8 +28,16 @@ public struct BrokerClient: Sendable {
         self.decoder = decoder
     }
 
+    /// Verifier over the operator keys pinned in AppConfig. Built once — verification itself is
+    /// per-response (`listRelays`), on the raw bytes, before any JSON decode.
+    private static let relayListVerifier = RelayListVerifier(keys: AppConfig.relaySigningKeys)
+
     public func listRelays(limit: Int = 5, clientID: String? = nil, sessionID: String? = nil) async throws -> RelayListResponse {
-        let url = try BrokerClient.relaysURL(brokerURL: baseURL, limit: limit)
+        // The effective limit is what the query carries; the broker echoes it back inside the
+        // signed body and the verifier rejects any mismatch (anti variant-steering, signing spec
+        // §2.2), so it must be computed once and used for both the URL and the check.
+        let effectiveLimit = max(limit, 1)
+        let url = try BrokerClient.relaysURL(brokerURL: baseURL, limit: effectiveLimit)
 
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
@@ -55,6 +63,24 @@ public struct BrokerClient: Sendable {
         }
         guard (200..<300).contains(httpResponse.statusCode) else {
             throw BrokerClientError.httpStatus(httpResponse.statusCode)
+        }
+
+        // Authenticate BEFORE decoding: Ed25519 over the exact raw bytes URLSession handed us
+        // (post transfer-decoding, equal to origin bytes), against the pinned operator keys —
+        // never over re-serialized parsed JSON (signing spec §5.2). The header MUST be read via
+        // value(forHTTPHeaderField:), which matches case-insensitively; allHeaderFields
+        // subscripting is case-sensitive and silently misses the lowercased names HTTP/2+ puts
+        // on the wire. Loopback candidates are the sole exemption (local dev broker, mirroring
+        // the desktop client's EnforceSecureBrokerURL allowance); every other candidate —
+        // including user overrides — fails without a valid signature. The verified key id is
+        // dropped for now: the §5.2 keyIdUsed telemetry ships with the client cache phase.
+        if RelayListVerifier.isLoopbackHost(url.host) == false {
+            _ = try BrokerClient.relayListVerifier.verify(
+                body: data,
+                signatureHeader: httpResponse.value(forHTTPHeaderField: RelayListVerifier.signatureHeaderName),
+                channel: .api,
+                requestedLimit: effectiveLimit
+            )
         }
 
         return try decoder.decode(RelayListResponse.self, from: data)

--- a/ios/Shared/RelayListVerifier.swift
+++ b/ios/Shared/RelayListVerifier.swift
@@ -1,0 +1,269 @@
+import CryptoKit
+import Foundation
+
+/// One Ed25519 public key the client trusts to sign the relay list (signing spec §4.2). Pinned as
+/// raw-key lowercase hex (not SPKI/PEM) so the committed CI vectors (`testdata/signing_vectors.json`)
+/// can be compared byte-for-byte against these constants across all four clients.
+public struct RelaySigningKey: Equatable, Sendable {
+    /// Lowercase hex of the first 8 bytes of SHA-256 over the raw 32-byte public key (spec §2.2).
+    /// Advisory routing only — it picks which pinned key to try first, never a trust decision.
+    public let keyID: String
+    /// The raw 32-byte Ed25519 public key, lowercase hex.
+    public let publicKeyHex: String
+
+    public init(keyID: String, publicKeyHex: String) {
+        self.keyID = keyID
+        self.publicKeyHex = publicKeyHex
+    }
+}
+
+/// Why a relay-list response failed authentication. Every case means "candidate failed — fall
+/// through to the next broker candidate", exactly like a network error; none is retryable against
+/// the same response. Carries enough context for diagnostics, and the user-facing description
+/// deliberately says "unsigned/invalid relay list" (spec §5.2) rather than reading like a
+/// generic network failure.
+public enum RelayListVerificationError: Error, Equatable {
+    /// 2xx response with no `X-OpenRung-Relays-Signature` header — a pre-signing broker, a
+    /// stripped header, or an injected body. All indistinguishable, all rejected.
+    case missingSignatureHeader
+    /// Header present but not `ed25519;<key_id>;<64-byte base64 signature>` (spec §2.1).
+    case malformedSignatureHeader
+    /// The signature does not verify over the raw body bytes under ANY pinned key (§4.2 requires
+    /// trying every key after the advisory key_id route misses).
+    case signatureMismatch
+    /// Signature verified, but the body is not JSON carrying the signed freshness/binding fields
+    /// (`not_after`, `channel`, and `limit` on the API channel) in the expected shapes.
+    case malformedSignedFields
+    /// Signed `channel` differs from the channel this candidate was fetched on — a mirror
+    /// artifact replayed into an API slot, or vice versa (spec §2.2).
+    case channelMismatch(expected: String, received: String?)
+    /// Signed `limit` echo differs from the limit this client requested — a validly signed
+    /// variant of the list steered at us from a different query (spec §2.2).
+    case limitMismatch(requested: Int?, received: Int?)
+    /// Signed and well-formed, but `not_after` is more than the skew allowance in the past:
+    /// a replay of an expired list (or a fast device clock; degraded-UI handling is spec §5.2).
+    case expired(notAfter: Date)
+}
+
+extension RelayListVerificationError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .missingSignatureHeader:
+            return "unsigned/invalid relay list: response carries no signature"
+        case .malformedSignatureHeader:
+            return "unsigned/invalid relay list: malformed signature header"
+        case .signatureMismatch:
+            return "unsigned/invalid relay list: signature does not match any pinned key"
+        case .malformedSignedFields:
+            return "unsigned/invalid relay list: signed freshness fields missing or malformed"
+        case .channelMismatch(let expected, let received):
+            return "unsigned/invalid relay list: signed for channel \(received ?? "<none>"), expected \(expected)"
+        case .limitMismatch(let requested, let received):
+            return "unsigned/invalid relay list: signed limit \(received.map(String.init) ?? "<none>") does not echo requested \(requested.map(String.init) ?? "<none>")"
+        case .expired(let notAfter):
+            return "unsigned/invalid relay list: expired (not_after \(notAfter))"
+        }
+    }
+}
+
+/// Verifies broker relay-list responses per the signing spec §5.2: Ed25519 over the EXACT raw
+/// body bytes as received (never re-serialized JSON), against an ordered list of pinned operator
+/// keys, then freshness/binding checks on fields inside the signed bytes. Detaching authenticity
+/// from the transport is what makes non-TLS discovery channels (direct-IP fallback, mirrors,
+/// cached lists) safe to add later.
+///
+/// Scope (mirrors the spec's threat model): this authenticates the CHANNEL only. A compromised
+/// broker signs whatever it likes; a censor can still block or strip — both degrade to "candidate
+/// failed, fall through", never to accepting forged data.
+///
+/// Foundation + CryptoKit only (both system frameworks, no new dependencies), and deliberately
+/// free of any other Shared-layer type so a logic-test target can compile this file in isolation
+/// (the FailureClassifier test pattern in project.yml).
+public struct RelayListVerifier: Sendable {
+    /// The signed channel a candidate belongs to (spec §2.2): broker API fronts/direct IP vs.
+    /// published mirror artifacts. Checked against the in-body `channel` so a validly signed
+    /// artifact can never be cross-fed between channels with different freshness regimes.
+    public enum Channel: String, Sendable {
+        case api
+        case mirror
+    }
+
+    /// Successful verification result. `keyID` is the pinned key that actually verified (which
+    /// may differ from the advisory key_id in the header) — reported in telemetry as the
+    /// compromise-detection signal (spec §5.2 step 5 / §8).
+    public struct Verified: Equatable, Sendable {
+        public let keyID: String
+    }
+
+    /// Response header carrying `ed25519;<key_id>;<base64 signature>` (spec §2.1). Match it
+    /// case-insensitively: HTTP/2+ lowercases header names on the wire.
+    public static let signatureHeaderName = "X-OpenRung-Relays-Signature"
+
+    /// How far in the past a signed `not_after` may lie and still be accepted — absorbs slow
+    /// device clocks (spec §5.2/§14 resolved this at 5 minutes; it widens the ~30 min API replay
+    /// window to ~35 min, accepted).
+    public static let clockSkewAllowance: TimeInterval = 5 * 60
+
+    private struct ParsedKey {
+        let keyID: String
+        let publicKey: Data
+    }
+
+    private let keys: [ParsedKey]
+
+    /// `keys` in pinned order (active first). Entries whose hex is not exactly 32 raw bytes are
+    /// dropped rather than half-trusted — the committed-vector CI guard (spec §11) is what turns
+    /// a typo'd constant into a test failure instead of a promotion-day outage.
+    public init(keys: [RelaySigningKey]) {
+        self.keys = keys.compactMap { key in
+            guard let raw = Data(hexEncoded: key.publicKeyHex), raw.count == 32 else { return nil }
+            return ParsedKey(keyID: key.keyID.lowercased(), publicKey: raw)
+        }
+    }
+
+    /// Runs the spec §5.2 checks over `body` — the raw response bytes exactly as read off the
+    /// connection, which MUST also be the buffer the caller later decodes. Throws
+    /// `RelayListVerificationError` (candidate failed) or returns the pinned key that verified.
+    ///
+    /// `requestedLimit` is the limit this client put in the query (the API channel's signed body
+    /// echoes it back); pass `nil` on the mirror channel, where the check is skipped.
+    public func verify(
+        body: Data,
+        signatureHeader: String?,
+        channel: Channel,
+        requestedLimit: Int?,
+        now: Date = Date()
+    ) throws -> Verified {
+        // (§5.2 step 2) Require and parse the signature header.
+        guard let signatureHeader else {
+            throw RelayListVerificationError.missingSignatureHeader
+        }
+        guard let (headerKeyID, signature) = Self.parseSignatureHeader(signatureHeader) else {
+            throw RelayListVerificationError.malformedSignatureHeader
+        }
+
+        // (§5.2 step 3) Verify over the raw bytes. The header's key_id routes to the matching
+        // pinned key first but is advisory only (§4.2): on miss or failure every pinned key is
+        // tried, so a broker key_id bug costs one extra ~50 µs verify, not an outage.
+        var candidates = keys.filter { $0.keyID == headerKeyID }
+        candidates.append(contentsOf: keys.filter { $0.keyID != headerKeyID })
+        let verifiedKey = candidates.first { candidate in
+            guard let publicKey = try? Curve25519.Signing.PublicKey(rawRepresentation: candidate.publicKey) else {
+                return false
+            }
+            return publicKey.isValidSignature(signature, for: body)
+        }
+        guard let verifiedKey else {
+            throw RelayListVerificationError.signatureMismatch
+        }
+
+        // (§5.2 step 4) Parse the SAME buffer and check the fields that live inside the signed
+        // bytes — they are what an attacker replaying a stale-but-validly-signed body cannot
+        // rewrite. Unknown extra keys stay ignored for forward compatibility.
+        guard let envelope = try? JSONDecoder().decode(SignedEnvelope.self, from: body) else {
+            throw RelayListVerificationError.malformedSignedFields
+        }
+        guard envelope.channel == channel.rawValue else {
+            throw RelayListVerificationError.channelMismatch(expected: channel.rawValue, received: envelope.channel)
+        }
+        if channel == .api {
+            // Echoed-limit binding: a signed `limit=1` body must never satisfy a `limit=20`
+            // request (anti variant-steering, §2.2). Mirror bodies carry no limit; skipped there.
+            guard let echoed = envelope.limit, echoed == requestedLimit else {
+                throw RelayListVerificationError.limitMismatch(requested: requestedLimit, received: envelope.limit)
+            }
+        }
+        guard let notAfterString = envelope.notAfter, let notAfter = Self.parseRFC3339(notAfterString) else {
+            throw RelayListVerificationError.malformedSignedFields
+        }
+        guard notAfter >= now - Self.clockSkewAllowance else {
+            throw RelayListVerificationError.expired(notAfter: notAfter)
+        }
+
+        return Verified(keyID: verifiedKey.keyID)
+    }
+
+    /// Whether `host` is a loopback destination, for the dev-flow exemption: verification is
+    /// required for ALL candidates except loopback, mirroring the desktop client's
+    /// `EnforceSecureBrokerURL` loopback-http allowance (internal/client/broker.go) and the other
+    /// mobile clients. "localhost", any 127.0.0.0/8 dotted-quad, and the IPv6 loopback (with or
+    /// without URL brackets) qualify; everything else — including user overrides — must verify.
+    public static func isLoopbackHost(_ host: String?) -> Bool {
+        guard var host = host?.lowercased(), host.isEmpty == false else { return false }
+        if host.hasPrefix("["), host.hasSuffix("]") {
+            host = String(host.dropFirst().dropLast())
+        }
+        if host == "localhost" || host == "::1" || host == "0:0:0:0:0:0:0:1" {
+            return true
+        }
+        let octets = host.split(separator: ".", omittingEmptySubsequences: false)
+        return octets.count == 4
+            && octets.allSatisfy { UInt8($0) != nil }
+            && UInt8(octets[0]) == 127
+    }
+
+    // MARK: - Internals
+
+    /// The signed freshness/binding fields (spec §2.2), decoded from the same buffer the
+    /// signature covered. `server_time`/`relays` etc. are left to `RelayListResponse`; this
+    /// struct exists so verification never depends on the full model layer.
+    private struct SignedEnvelope: Decodable {
+        let notAfter: String?
+        let channel: String?
+        let limit: Int?
+
+        enum CodingKeys: String, CodingKey {
+            case notAfter = "not_after"
+            case channel
+            case limit
+        }
+    }
+
+    /// Parses `ed25519;<key_id>;<base64 signature>` (spec §2.1): exactly three `;`-separated
+    /// fields, the literal algorithm string, and a standard-base64 (padded) 64-byte signature.
+    private static func parseSignatureHeader(_ header: String) -> (keyID: String, signature: Data)? {
+        let fields = header
+            .trimmingCharacters(in: .whitespaces)
+            .split(separator: ";", omittingEmptySubsequences: false)
+        guard fields.count == 3, fields[0] == "ed25519" else {
+            return nil
+        }
+        guard let signature = Data(base64Encoded: String(fields[2])), signature.count == 64 else {
+            return nil
+        }
+        return (String(fields[1]).lowercased(), signature)
+    }
+
+    private static let rfc3339 = ISO8601DateFormatter()
+
+    private static let rfc3339Fractional: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    /// RFC3339 UTC parse for `not_after`. The broker emits whole-second timestamps; the
+    /// fractional-second fallback is client-side tolerance only (ISO8601DateFormatter accepts
+    /// exactly one of the two shapes per configuration, and both formatters are thread-safe).
+    private static func parseRFC3339(_ value: String) -> Date? {
+        rfc3339.date(from: value) ?? rfc3339Fractional.date(from: value)
+    }
+}
+
+private extension Data {
+    /// Strict lowercase/uppercase hex → bytes; nil on odd length or any non-hex character.
+    init?(hexEncoded hex: String) {
+        let digits = Array(hex)
+        guard digits.count % 2 == 0 else { return nil }
+        var bytes = Data(capacity: digits.count / 2)
+        var index = 0
+        while index < digits.count {
+            guard let high = digits[index].hexDigitValue, let low = digits[index + 1].hexDigitValue else {
+                return nil
+            }
+            bytes.append(UInt8(high << 4 | low))
+            index += 2
+        }
+        self = bytes
+    }
+}

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -112,9 +112,15 @@ targets:
         CODE_SIGN_ENTITLEMENTS: PacketTunnel/PacketTunnel.entitlements
         APPLICATION_EXTENSION_API_ONLY: "YES"
 
-  # Hostless logic-test bundle for the failure classifier. It compiles FailureClassifier and the
-  # small error types it maps directly into the test module (rather than @testable-importing the
-  # extension), so the suite builds and runs without the app, CocoaPods, or Libbox.
+  # Hostless logic-test bundle. It compiles the units under test and their sources directly into the
+  # test module (rather than @testable-importing the app/extension), so the suite builds and runs
+  # without the app, CocoaPods, or Libbox. Two suites live here:
+  #   - FailureClassifierTests: FailureClassifier + the small error types it maps.
+  #   - RelayListVerifierTests: RelayListVerifier (self-contained), plus AppConfig and its compile
+  #     closure (BrokerClient/RelayDescriptor/DeviceAttributes/NetworkPathMonitor/BrokerEndpoint) so
+  #     the §11 pinned-key CI guard can verify the committed rotation vectors against the REAL
+  #     AppConfig.relaySigningKeys constant — a typo'd pin fails CI here, not on rotation day. All of
+  #     these are Foundation/UIKit/Network/CryptoKit only (no CocoaPods, no Libbox).
   OpenRungTests:
     type: bundle.unit-test
     platform: iOS
@@ -125,6 +131,13 @@ targets:
       - path: PacketTunnel/PacketTunnelProxyEngineError.swift
       - path: Shared/BrokerClientError.swift
       - path: Shared/RelayReachabilityError.swift
+      - path: Shared/RelayListVerifier.swift
+      - path: Shared/AppConfig.swift
+      - path: Shared/BrokerClient.swift
+      - path: Shared/RelayDescriptor.swift
+      - path: Shared/DeviceAttributes.swift
+      - path: Shared/NetworkPathMonitor.swift
+      - path: Shared/BrokerEndpoint.swift
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openrung.mobile.OpenRungTests

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,11 @@
 module.exports = {
   preset: '@react-native/jest-preset',
+  // The preset's pattern plus @noble: @noble/ed25519 and @noble/hashes are ESM-only, so Jest
+  // needs babel-jest to transform them to CJS (Metro consumes their ESM directly).
+  transformIgnorePatterns: [
+    'node_modules/(?!((jest-)?react-native|@react-native(-community)?|@noble)/)',
+  ],
+  // Shared non-test helpers for suites (e.g. relay-list signing fixtures); everything else under
+  // __tests__/ is a test file.
+  testPathIgnorePatterns: ['/node_modules/', '/__tests__/helpers/'],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,16 @@
 {
   "name": "openrung-mobile-app",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openrung-mobile-app",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "dependencies": {
         "@maplibre/maplibre-react-native": "^11.3.6",
+        "@noble/ed25519": "2.3.0",
+        "@noble/hashes": "2.2.0",
         "@react-native-async-storage/async-storage": "^3.1.1",
         "@react-native/new-app-screen": "0.86.0",
         "react": "19.2.3",
@@ -2777,6 +2779,27 @@
       "license": "MIT",
       "dependencies": {
         "eslint-scope": "5.1.1"
+      }
+    },
+    "node_modules/@noble/ed25519": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-2.3.0.tgz",
+      "integrity": "sha512-M7dvXL2B92/M7dw9+gzuydL8qn/jiqNHaoR3Q+cb1q1GHV7uwE17WCyFMG+Y+TZb5izcaXk5TdJRrDUxHXL78A==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
   },
   "dependencies": {
     "@maplibre/maplibre-react-native": "^11.3.6",
+    "@noble/ed25519": "2.3.0",
+    "@noble/hashes": "2.2.0",
     "@react-native-async-storage/async-storage": "^3.1.1",
     "@react-native/new-app-screen": "0.86.0",
     "react": "19.2.3",

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,11 +10,12 @@ import { version } from '../package.json';
  */
 export const AppConfig = {
   /**
-   * Discovery broker (relay-list bootstrap) default, and — since discovery is HTTPS-only — the sole
-   * built-in discovery candidate. Discovery is the censorship-critical path: it runs BEFORE the VPN
-   * tunnel is up, and the relay list it returns defines which server the client trusts as its exit.
-   * The relay list is NOT signed, so it must only be fetched over a TLS-authenticated channel; the
-   * Cloudflare-fronted HTTPS endpoint (TLS + CDN edge IPs) is both hard to block and unforgeable.
+   * Discovery broker (relay-list bootstrap) default. Discovery is the censorship-critical path: it
+   * runs BEFORE the VPN tunnel is up, and the relay list it returns defines which server the client
+   * trusts as its exit. The relay list is Ed25519-signed by the broker (SPEC v1) and verified
+   * against RELAY_SIGNING_KEYS below, so its authenticity no longer depends on the transport; the
+   * Cloudflare-fronted HTTPS endpoint remains the default because TLS + CDN edge IPs are also hard
+   * to block.
    */
   DEFAULT_BROKER_URL: 'https://broker.openrung.org/',
 
@@ -34,15 +35,16 @@ export const AppConfig = {
    * Ordered discovery candidates, raced with a staggered start: the first entry starts
    * immediately, each later entry joins DISCOVERY_STAGGER_MS after the previous one, and the
    * first candidate to return relays wins (see `firstReachable` in `net/brokerClient.ts`).
-   * Every entry MUST be HTTPS: the relay list is not yet signed, so it is
-   * authenticated only by the TLS cert of the serving host — a cleartext/bare-IP entry would let an
-   * on-path censor inject a malicious relay set.
+   * Every candidate's relay list is verified against RELAY_SIGNING_KEYS (loopback dev hosts
+   * excepted), so list authenticity no longer rests on the TLS cert of the serving host —
+   * a forged or tampered response is simply a failed candidate.
    *
    * Only one front is deployed today, so a censor who blocks it fails discovery CLOSED (offline).
-   * Closing that single point of failure is the front-diversity layer: adding more *HTTPS* fronts on
-   * independent CDNs/domains is safe now (still TLS-authenticated) and just needs the extra fronts
-   * deployed. Non-TLS / out-of-band channels (raw IP, cached blobs) stay off this list until the
-   * broker signs the relay list. Keep this in sync with the other clients' AppConfig.
+   * Closing that single point of failure is the front-diversity layer: signature verification
+   * makes non-TLS channels (direct-IP fallback, static mirrors) safe to ADD here once the signing
+   * broker is deployed and the verifying probe is green (SPEC v1 §10.3 sequencing) — signing
+   * defends integrity only, a censor can still block any individual entry. Keep this in sync with
+   * the other clients' AppConfig.
    */
   DEFAULT_BROKER_URLS: [
     'https://broker.openrung.org/',
@@ -71,6 +73,28 @@ export const AppConfig = {
    * AppConfigs — the staggered-race semantics are identical across all four clients.
    */
   DISCOVERY_STAGGER_MS: 2_500,
+
+  /**
+   * Pinned Ed25519 public keys for relay-list signature verification (SPEC v1 §4.2), ordered
+   * active first, offline standby second. `publicKeyHex` is the raw 32-byte key as lowercase hex;
+   * `keyId` is lowercase hex of the first 8 bytes of SHA-256 over that raw key. The key_id in the
+   * broker's signature header is advisory routing only — verification falls back to trying every
+   * pinned key — so a keyId typo here costs one wasted verify, never an outage. MUST stay in sync
+   * with the desktop Go client and the Kotlin/Swift AppConfigs, and with the `pinned_keys` block
+   * of testdata/signing_vectors.json: the CI pinned-key guard (relaySigning.test.ts) verifies a
+   * committed test vector against each constant so a truncated/typo'd key fails CI immediately
+   * instead of being discovered on key-promotion day (SPEC v1 §11).
+   */
+  RELAY_SIGNING_KEYS: [
+    {
+      keyId: '627405615601c589', // active (online, on the broker)
+      publicKeyHex: '176c03cbc70833285abcea75f2a0e137bd687629142408c22806a86308bd4974',
+    },
+    {
+      keyId: '672f79aa99a573cd', // standby (offline, promotable per the rotation runbook)
+      publicKeyHex: '5b2698cfa7a796c671a30aabd5475d55095b91464221f051837eb8fe01f36ea2',
+    },
+  ],
 
   RELAY_LIMIT: 5,
   VPN_SESSION_NAME: 'OpenRung Volunteer VPN',

--- a/src/model/relay.ts
+++ b/src/model/relay.ts
@@ -42,6 +42,13 @@ export interface RelayListResponse {
   count: number;
   server_time: string;
   relays: RelayDescriptor[];
+  // Relay-list signing fields (SPEC v1 §2.2), absent on pre-signing brokers. They live INSIDE the
+  // signed body (never in headers) so an attacker cannot rewrite them; net/brokerClient.ts checks
+  // them after the Ed25519 signature over the raw body bytes has verified.
+  not_after?: string; // RFC3339 freshness bound: server_time + 30 min on the API channel
+  key_id?: string; // advisory id of the signing key (first 8 bytes of SHA-256 over the raw pubkey)
+  channel?: string; // 'api' or 'mirror' — binds the body to the channel it was fetched from
+  limit?: number; // API channel only: echo of the effective request limit
 }
 
 export interface ErrorResponse {

--- a/src/net/brokerClient.ts
+++ b/src/net/brokerClient.ts
@@ -1,8 +1,15 @@
+/* eslint-disable no-bitwise -- the base64/UTF-8 codecs below are inherently byte-twiddling */
+import * as ed from '@noble/ed25519';
+import { sha512 } from '@noble/hashes/sha2.js';
 import { Platform } from 'react-native';
 // AppConfig is only dereferenced at call time (never during module evaluation), which keeps the
 // existing config.ts <-> brokerClient.ts import cycle harmless, same as APP_VERSION below.
 import { APP_VERSION, AppConfig } from '../config';
 import type { RelayDescriptor, RelayListResponse } from '../model/relay';
+
+// Hermes has no SubtleCrypto, so @noble/ed25519's async (WebCrypto-hashed) path is unavailable;
+// wiring the pure-JS SHA-512 enables the sync verify path (SPEC v1 §5.3, React Native row).
+ed.etc.sha512Sync = (...messages: Uint8Array[]) => sha512(ed.etc.concatBytes(...messages));
 
 /**
  * Broker relay-list client, ported from the production `net/BrokerClient.kt`.
@@ -12,6 +19,15 @@ import type { RelayDescriptor, RelayListResponse } from '../model/relay';
  * deadline instead.
  */
 const REQUEST_TIMEOUT_MS = 15_000;
+
+/** Response header carrying `ed25519;<key_id>;<base64_std_signature>` (SPEC v1 §2.1). */
+export const RELAYS_SIGNATURE_HEADER = 'X-OpenRung-Relays-Signature';
+
+/**
+ * How far past `not_after` a response is still accepted, covering slow device clocks
+ * (SPEC v1 §5.2: `not_after` >= now - 5 min).
+ */
+const SIGNATURE_SKEW_MS = 5 * 60_000;
 
 /** A successful relay fetch together with the broker endpoint that served it. */
 export interface Fetch {
@@ -54,13 +70,21 @@ function joinApiPath(basePath: string, apiPath: string): string {
 }
 
 /**
+ * The limit actually sent on the wire: `limit < 1` coerces to the production default of 5.
+ * Shared by `relayListUrl` and the signed `limit`-echo check so they can never disagree.
+ */
+function effectiveLimit(limit: number): number {
+  return limit < 1 ? 5 : limit;
+}
+
+/**
  * `BrokerClient.relayListUrl`: joins any existing base path with `api/v1/relays`, strips/replaces
  * any existing `limit` query param, and coerces `limit < 1` to 5.
  */
 export function relayListUrl(baseUrl: string, limit: number): string {
   const base = parseBase(baseUrl);
   const relayPath = joinApiPath(base.path, 'api/v1/relays');
-  const safeLimit = limit < 1 ? 5 : limit;
+  const safeLimit = effectiveLimit(limit);
   const existing = (base.query ?? '')
     .split('&')
     .filter(part => part.length > 0)
@@ -194,7 +218,322 @@ export function decodeRelayListResponse(body: string): RelayListResponse {
     count: asNumber(record.count),
     server_time: record.server_time,
     relays,
+    not_after: asOptionalString(record.not_after),
+    key_id: asOptionalString(record.key_id),
+    channel: asOptionalString(record.channel),
+    limit: asOptionalNumber(record.limit),
   };
+}
+
+// ---------------------------------------------------------------------------
+// Relay-list signature verification (SPEC v1 §5.2) — the byte-level shim below
+// the discovery layer. Signing defends CHANNEL INTEGRITY only: a compromised
+// broker still signs whatever it likes, and a censor can still block, strip
+// the header, or inject non-2xx responses — all of which degrade to "candidate
+// failed, fall through", never to accepting forged data.
+// ---------------------------------------------------------------------------
+
+/** A pinned Ed25519 verification key (see AppConfig.RELAY_SIGNING_KEYS for the derivations). */
+export interface RelaySigningKey {
+  keyId: string;
+  publicKeyHex: string;
+}
+
+// Pinned-key override for tests only (same convention as store.ts `resetStoreForTests`): the
+// production private keys are offline, so tests verify bodies signed with the public SPEC §2.3
+// test seed against ITS key instead.
+let signingKeysOverride: readonly RelaySigningKey[] | null = null;
+
+export function setRelaySigningKeysForTests(keys: readonly RelaySigningKey[] | null): void {
+  signingKeysOverride = keys;
+}
+
+function pinnedSigningKeys(): readonly RelaySigningKey[] {
+  return signingKeysOverride ?? AppConfig.RELAY_SIGNING_KEYS;
+}
+
+/** Host part of a URL authority: strips userinfo, an IPv6 bracket wrapper, and any port. */
+function hostOfAuthority(authority: string): string {
+  const at = authority.lastIndexOf('@');
+  const hostPort = at >= 0 ? authority.slice(at + 1) : authority;
+  if (hostPort.startsWith('[')) {
+    const end = hostPort.indexOf(']');
+    return end >= 0 ? hostPort.slice(1, end) : hostPort;
+  }
+  const colon = hostPort.indexOf(':');
+  return colon >= 0 ? hostPort.slice(0, colon) : hostPort;
+}
+
+/** `::`-expanded IPv6 loopback (`::1` and equivalents). IPv4-mapped forms deliberately fail. */
+function isIpv6Loopback(host: string): boolean {
+  const halves = host.split('::');
+  if (halves.length > 2) {
+    return false;
+  }
+  const head = halves[0] ? halves[0].split(':') : [];
+  const tail = halves.length === 2 && halves[1] ? halves[1].split(':') : [];
+  const groups =
+    halves.length === 2
+      ? [...head, ...Array<string>(Math.max(0, 8 - head.length - tail.length)).fill('0'), ...tail]
+      : head;
+  if (groups.length !== 8) {
+    return false;
+  }
+  return groups.every(
+    (group, index) =>
+      /^[0-9a-f]{1,4}$/.test(group) && parseInt(group, 16) === (index === 7 ? 1 : 0),
+  );
+}
+
+/**
+ * Mirrors the desktop client's `hostIsLoopback` (internal/client/broker.go): `localhost` or a
+ * loopback IP literal. Loopback brokers are the local dev flow and the ONLY candidates exempt
+ * from signature verification; a non-loopback user override still requires a valid signature
+ * from the pinned operator keys (self-hosted brokers are unsupported in stock builds).
+ */
+function isLoopbackHost(host: string): boolean {
+  const lower = host.toLowerCase();
+  if (lower === 'localhost') {
+    return true;
+  }
+  const v4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(lower);
+  if (v4) {
+    const octets = v4.slice(1).map(Number);
+    return octets[0] === 127 && octets.every(octet => octet <= 255);
+  }
+  return lower.includes(':') && isIpv6Loopback(lower);
+}
+
+/**
+ * The §5.2 rejection: every verification failure throws (candidate failed) so the discovery race
+ * falls through to the next candidate. The message deliberately says "unsigned/invalid relay
+ * list" — not a generic network error — per SPEC v1 §5.2.
+ */
+function signatureFailure(reason: string): Error {
+  return new Error(`broker list relays: unsigned/invalid relay list (${reason})`);
+}
+
+const BASE64_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+
+/**
+ * Strict standard-base64 (padded) decoder. Hand-rolled because Hermes has no `atob`; throws on
+ * any character outside the standard alphabet or a non-4-multiple length.
+ */
+function base64ToBytes(encoded: string): Uint8Array {
+  if (encoded.length === 0 || encoded.length % 4 !== 0) {
+    throw signatureFailure('signature is not valid base64');
+  }
+  const padding = encoded.endsWith('==') ? 2 : encoded.endsWith('=') ? 1 : 0;
+  const out = new Uint8Array((encoded.length / 4) * 3 - padding);
+  let buffer = 0;
+  let bits = 0;
+  let outIndex = 0;
+  for (let i = 0; i < encoded.length - padding; i++) {
+    const value = BASE64_ALPHABET.indexOf(encoded[i]);
+    if (value < 0) {
+      throw signatureFailure('signature is not valid base64');
+    }
+    buffer = (buffer << 6) | value;
+    bits += 6;
+    if (bits >= 8) {
+      bits -= 8;
+      out[outIndex++] = (buffer >> bits) & 0xff;
+    }
+  }
+  return out;
+}
+
+// TextEncoder exists on Hermes (and Node/Jest); TextDecoder may not, so both come with a strict
+// pure-JS fallback. Looked up via globalThis because the RN type surface doesn't declare them.
+type TextCodecGlobals = {
+  TextEncoder?: new () => { encode(input: string): Uint8Array };
+  TextDecoder?: new (label?: string, options?: { fatal?: boolean }) => {
+    decode(input: Uint8Array): string;
+  };
+};
+const textCodecs = globalThis as TextCodecGlobals;
+
+/**
+ * UTF-8 encodes a string. A lone surrogate produces bytes no valid broker body contains, so the
+ * subsequent signature check fails closed — matching TextEncoder's replacement behaviour.
+ */
+function encodeUtf8(text: string): Uint8Array {
+  if (textCodecs.TextEncoder) {
+    return new textCodecs.TextEncoder().encode(text);
+  }
+  const out: number[] = [];
+  for (let i = 0; i < text.length; i++) {
+    const code = text.codePointAt(i) as number;
+    if (code > 0xffff) {
+      i++; // consumed a surrogate pair
+    }
+    if (code < 0x80) {
+      out.push(code);
+    } else if (code < 0x800) {
+      out.push(0xc0 | (code >> 6), 0x80 | (code & 0x3f));
+    } else if (code < 0x10000) {
+      out.push(0xe0 | (code >> 12), 0x80 | ((code >> 6) & 0x3f), 0x80 | (code & 0x3f));
+    } else {
+      out.push(
+        0xf0 | (code >> 18),
+        0x80 | ((code >> 12) & 0x3f),
+        0x80 | ((code >> 6) & 0x3f),
+        0x80 | (code & 0x3f),
+      );
+    }
+  }
+  return Uint8Array.from(out);
+}
+
+/**
+ * Strict UTF-8 decode of the VERIFIED body bytes ("parse the same buffer", §5.2 step 4). Invalid
+ * UTF-8 throws (candidate failed) instead of silently substituting U+FFFD.
+ */
+function decodeUtf8(bytes: Uint8Array): string {
+  if (textCodecs.TextDecoder) {
+    return new textCodecs.TextDecoder('utf-8', { fatal: true }).decode(bytes);
+  }
+  let out = '';
+  let i = 0;
+  const fail = () => signatureFailure('verified body is not valid UTF-8');
+  while (i < bytes.length) {
+    const b0 = bytes[i++];
+    if (b0 < 0x80) {
+      out += String.fromCharCode(b0);
+      continue;
+    }
+    let extra: number;
+    let codePoint: number;
+    let min: number;
+    if (b0 >= 0xc2 && b0 <= 0xdf) {
+      extra = 1;
+      codePoint = b0 & 0x1f;
+      min = 0x80;
+    } else if (b0 >= 0xe0 && b0 <= 0xef) {
+      extra = 2;
+      codePoint = b0 & 0x0f;
+      min = 0x800;
+    } else if (b0 >= 0xf0 && b0 <= 0xf4) {
+      extra = 3;
+      codePoint = b0 & 0x07;
+      min = 0x10000;
+    } else {
+      throw fail(); // 0x80-0xc1 (stray continuation / overlong) and 0xf5-0xff
+    }
+    if (i + extra > bytes.length) {
+      throw fail();
+    }
+    for (let k = 0; k < extra; k++) {
+      const next = bytes[i++];
+      if ((next & 0xc0) !== 0x80) {
+        throw fail();
+      }
+      codePoint = (codePoint << 6) | (next & 0x3f);
+    }
+    if (codePoint < min || codePoint > 0x10ffff || (codePoint >= 0xd800 && codePoint <= 0xdfff)) {
+      throw fail();
+    }
+    out += String.fromCodePoint(codePoint);
+  }
+  return out;
+}
+
+interface ParsedSignatureHeader {
+  keyId: string;
+  signature: Uint8Array;
+}
+
+/** Parses `ed25519;<key_id>;<base64_std_signature>` (§2.1: exactly three `;`-separated fields). */
+function parseSignatureHeader(value: string): ParsedSignatureHeader {
+  const fields = value.split(';');
+  if (fields.length !== 3 || fields[0] !== 'ed25519') {
+    throw signatureFailure('malformed signature header');
+  }
+  const signature = base64ToBytes(fields[2]);
+  if (signature.length !== 64) {
+    throw signatureFailure('signature must be 64 bytes');
+  }
+  return { keyId: fields[1], signature };
+}
+
+/** A verified relay list plus the pinned key that verified it (SPEC v1 §5.1 shim contract). */
+export interface VerifiedRelayList {
+  response: RelayListResponse;
+  /** keyId of the PINNED key that verified — a key_id telemetry signal (§8) in a later phase. */
+  keyIdUsed: string;
+}
+
+/**
+ * The full SPEC v1 §5.2 verification algorithm over the exact raw body bytes of a 2xx API-channel
+ * response. Every failure throws "unsigned/invalid relay list" so the calling candidate fails and
+ * the discovery race falls through. Exported (with injectable `nowMs`) so the shared
+ * testdata/signing_vectors.json cases can drive it directly.
+ */
+export function verifySignedRelayList(
+  bodyBytes: Uint8Array,
+  signatureHeader: string | null,
+  requestedLimit: number,
+  nowMs: number = Date.now(),
+): VerifiedRelayList {
+  // §5.2 step 2: the header is REQUIRED — a pre-signing broker or a front that strips headers is
+  // a failed candidate, never a trusted one.
+  if (signatureHeader === null || signatureHeader.length === 0) {
+    throw signatureFailure('missing signature header');
+  }
+  const header = parseSignatureHeader(signatureHeader);
+
+  // §5.2 step 3: verify over the raw bytes. The header key_id is ADVISORY routing only (§4.2):
+  // a matching pinned key is tried first, but a mismatch or stale key_id just falls back to
+  // trying every pinned key — it costs one wasted verify, not a rejection.
+  const keys = pinnedSigningKeys();
+  const ordered = [
+    ...keys.filter(key => key.keyId === header.keyId),
+    ...keys.filter(key => key.keyId !== header.keyId),
+  ];
+  let keyIdUsed: string | null = null;
+  for (const key of ordered) {
+    try {
+      if (ed.verify(header.signature, bodyBytes, ed.etc.hexToBytes(key.publicKeyHex))) {
+        keyIdUsed = key.keyId;
+        break;
+      }
+    } catch {
+      // Malformed point/scalar encodings throw in @noble/ed25519; same outcome as verify=false.
+    }
+  }
+  if (keyIdUsed === null) {
+    throw signatureFailure('signature does not verify against any pinned key');
+  }
+
+  // §5.2 step 4: parse the SAME buffer the signature covered, then check the signed fields.
+  const response = decodeRelayListResponse(decodeUtf8(bodyBytes));
+  if (response.channel !== 'api') {
+    // In-body channel binding (§2.2): a validly signed MIRROR artifact must never be cross-fed
+    // into an API-channel slot.
+    throw signatureFailure(`channel ${JSON.stringify(response.channel ?? null)} is not "api"`);
+  }
+  if (response.limit !== requestedLimit) {
+    // The signed limit echo kills variant steering: a cached/replayed body for a different
+    // `limit` is same-URL CDN-cache-equivalent or nothing.
+    throw signatureFailure(`signed limit ${response.limit ?? 'absent'} != requested ${requestedLimit}`);
+  }
+  const notAfterMs = Date.parse(response.not_after ?? '');
+  if (Number.isNaN(notAfterMs) || notAfterMs < nowMs - SIGNATURE_SKEW_MS) {
+    throw signatureFailure(`response expired (not_after ${response.not_after ?? 'absent'})`);
+  }
+  return { response, keyIdUsed };
+}
+
+/**
+ * Raw body bytes for signature verification: binary read (`arrayBuffer`) preferred; where RN's
+ * fetch lacks it, `text()` + UTF-8 re-encode is byte-identical for the broker's valid-UTF-8
+ * output and fails closed otherwise (SPEC v1 §5.1 RN exception).
+ */
+async function readBodyBytes(response: Response): Promise<Uint8Array> {
+  if (typeof response.arrayBuffer === 'function') {
+    return new Uint8Array(await response.arrayBuffer());
+  }
+  return encodeUtf8(await response.text());
 }
 
 export interface ListRelaysOptions {
@@ -213,6 +552,10 @@ export interface ListRelaysOptions {
 /**
  * GET {base}/api/v1/relays?limit=N. No auth token — the X-OpenRung-* headers are the only
  * identification, exactly like production (plus X-OpenRung-RN marking the RN prototype platform).
+ *
+ * Every 2xx response from a non-loopback broker must carry a valid Ed25519 relay-list signature
+ * (verifySignedRelayList above); any signing failure throws, i.e. the candidate fails and the
+ * discovery race falls through.
  */
 export async function listRelays(
   baseUrl: string,
@@ -220,6 +563,7 @@ export async function listRelays(
 ): Promise<RelayListResponse> {
   const { limit = 5, clientId = null, sessionId = null, signal } = options;
   const url = relayListUrl(baseUrl, limit);
+  const loopback = isLoopbackHost(hostOfAuthority(parseBase(baseUrl).authority));
   const headers: Record<string, string> = {
     'X-OpenRung-App-Version': APP_VERSION,
     'X-OpenRung-RN': Platform.OS,
@@ -237,8 +581,11 @@ export async function listRelays(
   }
 
   const response = await fetchWithTimeout(url, { method: 'GET', headers }, REQUEST_TIMEOUT_MS, signal);
-  const body = await response.text();
   if (response.status < 200 || response.status > 299) {
+    // §5.2 step 1: non-2xx = candidate failed. Error bodies are unsigned by design (§2.1) and
+    // only ever feed the diagnostic message — never authenticated broker state (a forged 429 is
+    // an availability attack no signature catches).
+    const body = await response.text();
     let apiError: string | null = null;
     try {
       const decoded: unknown = JSON.parse(body);
@@ -254,7 +601,15 @@ export async function listRelays(
     const detail = apiError ?? (body.trim().length > 0 ? body : `HTTP ${response.status}`);
     throw new Error(`broker list relays: ${detail}`);
   }
-  return decodeRelayListResponse(body);
+  if (loopback) {
+    // Local dev broker: the sole signature-exempt flow (see isLoopbackHost).
+    return decodeRelayListResponse(await response.text());
+  }
+  const bodyBytes = await readBodyBytes(response);
+  // Headers.get matches case-insensitively, as §2.1 requires (HTTP/2/3 lowercase header names).
+  const signatureHeader = response.headers.get(RELAYS_SIGNATURE_HEADER);
+  // keyIdUsed is intentionally not surfaced further yet — key_id telemetry (§8) is a later phase.
+  return verifySignedRelayList(bodyBytes, signatureHeader, effectiveLimit(limit)).response;
 }
 
 /**

--- a/testdata/signing_vectors.json
+++ b/testdata/signing_vectors.json
@@ -1,0 +1,29 @@
+{
+  "spec_version": 1,
+  "header_name": "X-OpenRung-Relays-Signature",
+  "spec_vector": {
+    "comment": "SPEC v1 §2.3 shared vector. Seed is 32 bytes of 0x42 — TEST ONLY, never a production key.",
+    "seed_b64": "QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI=",
+    "public_key_hex": "2152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db12",
+    "key_id": "3097e2dee2cb4a34",
+    "body": "{\"count\":1,\"server_time\":\"2026-07-10T00:00:00Z\",\"not_after\":\"2026-07-10T00:30:00Z\",\"key_id\":\"3097e2dee2cb4a34\",\"channel\":\"api\",\"limit\":1,\"relays\":[]}",
+    "signature_b64": "K5UmJWzoEZ1YHOqZFf5E+ocNOITSe3WPvOo0GuyCRoiAxUk4eo/jcfqiuaPhrNeYrK3i8QcYI3LIv+zbVYq9Bw==",
+    "header_value": "ed25519;3097e2dee2cb4a34;K5UmJWzoEZ1YHOqZFf5E+ocNOITSe3WPvOo0GuyCRoiAxUk4eo/jcfqiuaPhrNeYrK3i8QcYI3LIv+zbVYq9Bw=="
+  },
+  "pinned_keys": [
+    {
+      "name": "active",
+      "public_key_hex": "176c03cbc70833285abcea75f2a0e137bd687629142408c22806a86308bd4974",
+      "key_id": "627405615601c589",
+      "vector_message": "openrung-signing-key-vector:active",
+      "vector_signature_b64": "mELBVRsBe2+aeKYMniZ2F0HEV7n+8VcokBgailoLQW7JAleX6q8RQypVOO0y0p0+g/u89Uu+aaYpVfvpIAMRBQ=="
+    },
+    {
+      "name": "standby",
+      "public_key_hex": "5b2698cfa7a796c671a30aabd5475d55095b91464221f051837eb8fe01f36ea2",
+      "key_id": "672f79aa99a573cd",
+      "vector_message": "openrung-signing-key-vector:standby",
+      "vector_signature_b64": "KyYhv/R46Wmi1M4y+KPT4CUz40mVXzwG3hYG5U22v7qpxri0pj4wYCgxqjrGmh2hlFNcx8gZpIBFO1PhD7xABw=="
+    }
+  ]
+}


### PR DESCRIPTION
## What & why

Mobile half of relay-list signing (companion to core [#41](https://github.com/openrung/openrung/pull/41) broker + [#42](https://github.com/openrung/openrung/pull/42) desktop). Each client verifies the broker's **Ed25519 signature over the exact raw response bytes** before trusting a relay list, so the list's authenticity no longer depends on the transport — the groundwork for safely using non-TLS channels (direct-IP fallback, static mirrors, offline cache) later.

Per-platform library choices (spec §5.3):
- **RN (Hermes)**: `@noble/ed25519` 2.3.0 + `@noble/hashes` 2.2.0, exact-pinned (`sha512Sync` wired — Hermes has no SubtleCrypto). Raw bytes via `arrayBuffer()` with the spec's `text()`+`TextEncoder` fallback.
- **Android (minSdk 26)**: Google Tink 1.23.0 (platform Ed25519 needs API 33+). Reads raw `InputStream` bytes before charset decode; sends `Accept-Encoding: identity` on non-TLS candidates.
- **iOS (13+)**: CryptoKit `Curve25519`; header via `value(forHTTPHeaderField:)` (never `allHeaderFields` — HTTP/2 lowercases names).

All four clients (incl. desktop Go) pin the **same two production public keys**; `key_id` is advisory routing only (falls back to every pinned key), so a `key_id` bug costs one wasted verify, not an outage. Every verification failure → candidate-failed, so the staggered race falls through. Enforces `channel=="api"`, `limit` echo, and `not_after ≥ now − 5 min`.

## Verification

- `npx tsc --noEmit` clean; `npx jest` **10 suites / 129 tests** green (new `relaySigning` suite covers all §2.3 positive/negative vectors, key_id-mismatch-but-valid accept, channel/limit/expiry rejects, and the text()+TextEncoder byte-identity test).
- Android `./gradlew :app:testDebugUnitTest` **BUILD SUCCESSFUL** (`RelayListVerifierTest` 16 + `BrokerClientSigningTest` 8).
- iOS: no `xcodebuild` in this env, but `swiftc` compiled the real `RelayListVerifier` + `AppConfig` closure into a standalone driver — **all 24 checks pass** (incl. a negative control proving a corrupted pin fails the guard); `plutil -lint` OK on the pbxproj; typecheck green on device + simulator SDKs.
- **§11 pinned-key CI guard** in all three clients verifies both production rotation vectors against the embedded pinned keys — a typo'd pin fails CI instead of bricking discovery on rotation day.
- Shared `testdata/signing_vectors.json`.

## ⚠️ Merge ordering (hard requirement)

Hard-requires signatures. **Do not merge/ship before the prod broker (core #41) is deployed and verified emitting signatures** — a build against the current unsigned prod broker would fail discovery.

## Reviewer notes

- **Rebase over override-first ([mobile #36](https://github.com/openrung/openrung-mobile-app/pull/36)) expected**: both touch `brokerClient.ts` / `BrokerClient.kt/.swift` / `AppConfig.*` and both wire `ios/OpenRung.xcodeproj/project.pbxproj` for the `OpenRungTests` target. Merge #36 first; I'll rebase this on top.
- iOS test target pulls AppConfig's compile closure so the §11 guard references the *real* pinned keys (true parity with Kotlin/RN). It overlaps #36's `BrokerClientTests` wiring, so the two converge on rebase. A first real `xcodebuild` CI run should confirm XCTest linkage.
- Deferred per phase scope: `key_id` telemetry (§8), fast-clock degraded path (§5.2), last-known-good cache (§5.4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)