### PR TITLE
Bump version to 0.2.6

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -90,7 +90,7 @@ android {
         applicationId "com.openrung.mobile"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 6
+        versionCode 7
         versionName appVersionName
     }
     signingConfigs {

--- a/ios/OpenRung.xcodeproj/project.pbxproj
+++ b/ios/OpenRung.xcodeproj/project.pbxproj
@@ -661,7 +661,7 @@
 					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
 					"\"$(inherited)\"",
 				);
-				MARKETING_VERSION = 0.2.5;
+				MARKETING_VERSION = 0.2.6;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -803,7 +803,7 @@
 					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
 					"\"$(inherited)\"",
 				);
-				MARKETING_VERSION = 0.2.5;
+				MARKETING_VERSION = 0.2.6;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				OTHER_CPLUSPLUSFLAGS = (

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openrung-mobile-app",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
Bumps the app version 0.2.5 → **0.2.6** to cut a new Android release.

- `package.json` `version` → 0.2.6 (the single source; Android `versionName` and iOS `MARKETING_VERSION` derive from it)
- Android `versionCode` 6 → **7** (manual monotonic build number, required by Play Store)
- iOS `project.pbxproj` regenerated via `xcodegen` so `MARKETING_VERSION` = 0.2.6 (diff is exactly the two version lines — no project drift)
- `scripts/check-versions.mjs` passes (all surfaces single-sourced)

**Merging this to main triggers the version-gated `release.yml`** — it detects the `package.json` version change and builds + publishes the signed 0.2.6 APK as a GitHub Release.

**What ships in 0.2.6** (merged to main earlier today): the broker discovery-resilience work — multi-front candidate list (Cloudflare + AWS CloudFront), staggered-race failover, override-first discovery, and Ed25519 relay-list signature verification across the RN/Android/iOS clients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)