### PR TITLE
Add NAT hole punching to the Android client

### DIFF
--- a/OPENRUNG_VERSION
+++ b/OPENRUNG_VERSION
@@ -1,0 +1,13 @@
+# Pinned openrung revision for the NAT hole-punch client (openrung/mobile/orpunch)
+# bound into android/app/libs/libbox.aar. openrung is GPL-3.0, so this commit is
+# the GPL §6 corresponding source for the punch portion of a shipped build — keep
+# it in lockstep with the AAR you distribute (see RELEASE.md §1).
+#
+# The openrung Go module path is "openrung" (no VCS host), so the build wires it in
+# via a go.mod `replace` to a local checkout (android/build-libbox-release.sh,
+# OPENRUNG_SRC). For a reproducible release build, check that local tree out at the
+# commit recorded below before running the build.
+#
+# Until the punch binding lands on openrung's main branch, this points at the
+# feature branch; update to the merged commit SHA at release time.
+branch:claude/mobile-punch-binding

--- a/README.md
+++ b/README.md
@@ -133,8 +133,17 @@ JDK 17, the Android SDK + NDK `29.0.14206865`, and Go on `PATH`. The sing-box
 revision is the GPL §6 corresponding source for the shipped engine; the
 per-release pin procedure is in [`RELEASE.md`](RELEASE.md).
 
+The same AAR also bundles the OpenRung NAT hole-punch client
+(`io.nekohasekai.orpunch`, from the `openrung/mobile/orpunch` Go package) so the
+app can connect directly to a CGNAT volunteer, bypassing the relay hub's data
+path (Android only; iOS still always routes through the hub). The build wires the
+openrung module in from a local checkout via `OPENRUNG_SRC` (default: a sibling
+`openrung/` checkout; the pinned revision lives in `OPENRUNG_VERSION`). Set
+`OPENRUNG_SRC=/path/to/openrung` if your checkout is elsewhere (e.g. a worktree).
+
 Without the AAR the app still compiles; the connect path fails at engine start
-with a clear "engine not linked" error.
+with a clear "engine not linked" error, and NAT punching is silently skipped (the
+app routes through the hub as before).
 
 You also need `android/local.properties` with your SDK path
 (`sdk.dir=/Users/<you>/Library/Android/sdk`), or `ANDROID_HOME` exported. Build

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,13 +1,14 @@
 # Release checklist — license & corresponding-source obligations
 
 The OpenRung mobile app statically links **sing-box / libbox**, which is
-**GPL-3.0-or-later**. That makes the whole app GPL-3.0-or-later and imposes a
-GPL §6 obligation: anyone you distribute a build to (TestFlight, Play, direct
-APK) must be able to obtain the *complete corresponding source* for that exact
-binary. This file is the per-release procedure that keeps that obligation
+**GPL-3.0-or-later**, and (on Android) the **openrung** NAT hole-punch client,
+which is also **GPL-3.0-or-later**. That makes the whole app GPL-3.0-or-later and
+imposes a GPL §6 obligation: anyone you distribute a build to (TestFlight, Play,
+direct APK) must be able to obtain the *complete corresponding source* for that
+exact binary. This file is the per-release procedure that keeps that obligation
 satisfiable. Do all of it before tagging a release.
 
-## 1. Pin the sing-box revision
+## 1. Pin the engine + punch revisions
 
 The engine revision is pinned in [`SINGBOX_VERSION`](SINGBOX_VERSION) as a Go
 pseudo-version (`v0.0.0-<utc>-<12-char-commit>`; the trailing 12 characters are
@@ -18,8 +19,17 @@ the upstream commit SHA). Both build paths consume it:
 - iOS — [`ios/ThirdParty/README.md`](ios/ThirdParty/README.md) checks out that
   commit before building `Libbox.xcframework`.
 
-When you move to a newer sing-box, update `SINGBOX_VERSION` **only**, rebuild
-both artifacts from it, and commit the new pin in the same change.
+On Android the same AAR also embeds the openrung punch client
+(`openrung/mobile/orpunch`), pinned in [`OPENRUNG_VERSION`](OPENRUNG_VERSION).
+Because the openrung module path has no VCS host, the build wires it in from a
+local checkout via a go.mod `replace` (`OPENRUNG_SRC`); check that tree out at the
+`OPENRUNG_VERSION` commit before a release build so the corresponding source
+matches the binary. (iOS has no punch support yet, so `OPENRUNG_VERSION` is
+Android-only.)
+
+When you move to a newer sing-box (or openrung), update `SINGBOX_VERSION` /
+`OPENRUNG_VERSION` **only**, rebuild both artifacts from them, and commit the new
+pins in the same change.
 
 ## 2. Rebuild both engine artifacts from the pin
 

--- a/android/app/src/main/java/com/openrung/config/AppConfig.kt
+++ b/android/app/src/main/java/com/openrung/config/AppConfig.kt
@@ -96,6 +96,23 @@ object AppConfig {
     const val STATUS_PREFS = "openrung_status"
 
     /**
+     * When true, the connect path tries a direct NAT-hole-punched path to a punch-capable
+     * (CGNAT) volunteer before falling back to routing through the relay hub — matching the
+     * desktop client's `-punch` default. On any punch failure the outcome is never worse than
+     * the hub relay path. Set false to force all traffic through the hub.
+     */
+    const val PUNCH_ENABLED = true
+
+    /**
+     * Skip TLS verification of the hub punch coordination HTTP endpoint only (for a volunteer-run
+     * hub serving a self-signed cert on a bare IP). This weakens ONLY the coordination channel: the
+     * punched QUIC data path still pins the volunteer's per-session cert by fingerprint and the
+     * tunnel is VLESS+REALITY, so a hub MITM can at worst force a fallback to the relay path. Keep
+     * false in production; the desktop exposes this as `-punch-insecure` for testing.
+     */
+    const val PUNCH_HUB_INSECURE = false
+
+    /**
      * Relay fetch used to populate the exit-node map directory (the connect path still uses
      * [RELAY_LIMIT]). This is the broker's maximum allowed page size — the broker rejects anything
      * larger with HTTP 400 — so it captures the full set of currently-advertised relays.

--- a/android/app/src/main/java/com/openrung/model/RelayDescriptor.kt
+++ b/android/app/src/main/java/com/openrung/model/RelayDescriptor.kt
@@ -8,6 +8,9 @@ object RelayConstants {
     const val PROTOCOL_VLESS_REALITY_VISION = "vless-reality-vision"
     const val FLOW_VISION = "xtls-rprx-vision"
     const val EXIT_MODE_DIRECT = "direct"
+
+    /** Hub punch coordinator port assumed when a relay advertises no punch_endpoint. */
+    const val DEFAULT_PUNCH_PORT = 9444
 }
 
 @Serializable
@@ -53,6 +56,17 @@ data class RelayDescriptor(
     val countryCode: String = "",
     val latitude: Double? = null,
     val longitude: Double? = null,
+    // NAT hole-punch fields, sent only by punch-capable tunnel (CGNAT) volunteers; absent on
+    // older brokers and on direct relays. They ride inside the Ed25519-signed relay list, so they
+    // cannot be injected on-path. When punchCapable is true the client may try a direct
+    // NAT-punched path to the volunteer (via the hub's punch coordinator) before falling back to
+    // the relay hub — never a usability gate, purely an accelerator (see isUsable).
+    @SerialName("punch_capable")
+    val punchCapable: Boolean = false,
+    // Hub punch coordinator base URL (e.g. http://hub:9444). Empty means derive it from publicHost
+    // and DEFAULT_PUNCH_PORT (mirrors the desktop client's punchBaseURL resolution).
+    @SerialName("punch_endpoint")
+    val punchEndpoint: String = "",
 ) {
     fun isUsable(now: Instant): Boolean {
         val expires = runCatching { Instant.parse(expiresAt) }.getOrNull() ?: return false
@@ -70,6 +84,17 @@ data class RelayDescriptor(
 
     /** Human-readable exit location such as "Tokyo, Japan", or "" while the broker has no geo. */
     fun locationLabel(): String = listOf(city, country).filter { it.isNotBlank() }.joinToString(", ")
+
+    /**
+     * Hub punch coordinator base URL: the advertised [punchEndpoint] verbatim, else a derived
+     * `http://<publicHost>:9444` (IPv6 literals bracketed). Mirrors the desktop client's
+     * punchBaseURL fallback (cmd/client/main.go). Only meaningful when [punchCapable].
+     */
+    fun punchBaseUrl(): String {
+        if (punchEndpoint.isNotBlank()) return punchEndpoint
+        val host = if (publicHost.contains(":") && !publicHost.startsWith("[")) "[$publicHost]" else publicHost
+        return "http://$host:${RelayConstants.DEFAULT_PUNCH_PORT}"
+    }
 }
 
 @Serializable

--- a/android/app/src/main/java/com/openrung/net/SingBoxConfiguration.kt
+++ b/android/app/src/main/java/com/openrung/net/SingBoxConfiguration.kt
@@ -18,6 +18,15 @@ data class SingBoxConfiguration(
     val tunnelIPv6Address: String = "fdfe:dcba:9876::1/126",
     val dnsServers: List<String> = listOf("1.1.1.1", "8.8.8.8"),
     val mtu: Int = 1400,
+    // Punch-mode overrides. When [bridgeHost]/[bridgePort] are set, the VLESS outbound dials the
+    // local punch bridge (127.0.0.1:bridgePort) instead of the relay's public endpoint — the
+    // Reality identity fields are unchanged, so the end-to-end target is still the real volunteer.
+    // [punchPeerExcludeAddress] is the volunteer's reflexive UDP IP, which MUST be excluded from the
+    // TUN routes or the punched QUIC datagrams would be captured by auto_route/strict_route and loop
+    // back into the tunnel. Mirrors the desktop client's BuildSingBoxConfig punch inputs.
+    val bridgeHost: String? = null,
+    val bridgePort: Int? = null,
+    val punchPeerExcludeAddress: String? = null,
 ) {
     fun encodedJsonString(): String {
         validateRelay()
@@ -39,8 +48,15 @@ data class SingBoxConfiguration(
             "dns_mode" to JsonPrimitive("hijack"),
             "endpoint_independent_nat" to JsonPrimitive(true),
         )
-        relayRouteExcludeAddress(relay.publicHost)?.let {
-            tunInbound["route_exclude_address"] = JsonArray(listOf(JsonPrimitive(it)))
+        // Exclude the real transport peers from the TUN so their packets are not captured by
+        // auto_route/strict_route. On the direct path that is the relay hub's public IP; on the
+        // punch path it is additionally the volunteer's reflexive UDP IP the QUIC socket talks to.
+        // Hostnames (non-literal publicHost) yield no exclusion; the loopback bridge needs none.
+        val excludeAddresses = listOfNotNull(relay.publicHost, punchPeerExcludeAddress)
+            .mapNotNull { relayRouteExcludeAddress(it) }
+            .distinct()
+        if (excludeAddresses.isNotEmpty()) {
+            tunInbound["route_exclude_address"] = JsonArray(excludeAddresses.map { JsonPrimitive(it) })
         }
 
         return buildJsonObject {
@@ -66,8 +82,12 @@ data class SingBoxConfiguration(
                 add(buildJsonObject {
                     put("type", "vless")
                     put("tag", "proxy")
-                    put("server", relay.publicHost)
-                    put("server_port", relay.publicPort)
+                    // On the punch path sing-box dials the loopback bridge; TLS/Reality identity
+                    // (server_name, public_key, short_id, uuid) stays the volunteer's, so Reality
+                    // still validates end-to-end and the bridge is a transparent TCP hop.
+                    val usingBridge = bridgeHost != null && (bridgePort ?: 0) > 0
+                    put("server", if (usingBridge) bridgeHost else relay.publicHost)
+                    put("server_port", if (usingBridge) bridgePort!! else relay.publicPort)
                     put("uuid", relay.clientId)
                     put("flow", relay.flow)
                     put("network", "tcp")

--- a/android/app/src/main/java/com/openrung/vpn/OpenRungVpnService.kt
+++ b/android/app/src/main/java/com/openrung/vpn/OpenRungVpnService.kt
@@ -46,6 +46,7 @@ class OpenRungVpnService : VpnService() {
     private var connectJob: Job? = null
     private var heartbeatJob: Job? = null
     private var engine: ProxyEngine? = null
+    private var activePunch: PunchOutcome? = null
     private var brokerUrl: String = AppConfig.DEFAULT_BROKER_URL
     private var activeRelayId: String? = null
 
@@ -238,81 +239,114 @@ class OpenRungVpnService : VpnService() {
     private suspend fun connectFirstAvailable(candidates: List<RelayDescriptor>): ConnectedRelay {
         var lastError: Throwable? = null
         for ((index, relay) in candidates.withIndex()) {
-            try {
-                OpenRungStatusStore.appendLog(
-                    getString(R.string.log_trying_relay, relay.id, relay.publicHost, relay.publicPort),
-                )
-                OpenRungStatusStore.appendLog(getString(R.string.log_checking_relay_reachability))
-                val tcpLatencyMs = try {
-                    RelayReachability.checkTcp(relay)
-                } catch (error: CancellationException) {
-                    // A racing disconnect cancels this coroutine; let cancellation propagate instead
-                    // of masking it as an "unreachable" failure, which would keep trying relays and
-                    // could bring a tunnel up after teardown.
-                    throw error
-                } catch (error: Throwable) {
-                    throw IllegalStateException(
-                        getString(R.string.error_relay_unreachable, relay.publicHost, relay.publicPort),
-                        error,
-                    )
-                }
-                val config = SingBoxConfiguration(relay = relay).encodedJsonString()
-                val proxyEngine = ProxyEngineFactory.create()
-                val tunnelStarted = SystemClock.elapsedRealtime()
-                // Tag an engine start/liveness failure as EngineStartException so it classifies as
-                // process_exited (the embedded-engine analogue of the Go clients' sing-box subprocess
-                // dying). The original error is kept as the cause so a more specific signal in its
-                // chain still wins over process_exited.
+            // Each relay gets at most two attempts: a direct NAT-punched path (for punch-capable
+            // volunteers), then, if that path fails to bring up a working tunnel, the ordinary relay
+            // hub path. This guarantees enabling punch is never worse than not punching — a relay the
+            // hub could have reached is not skipped just because its direct path degraded.
+            var allowPunch = true
+            while (true) {
                 try {
-                    proxyEngine.start(
+                    OpenRungStatusStore.appendLog(
+                        getString(R.string.log_trying_relay, relay.id, relay.publicHost, relay.publicPort),
+                    )
+                    OpenRungStatusStore.appendLog(getString(R.string.log_checking_relay_reachability))
+                    val tcpLatencyMs = try {
+                        RelayReachability.checkTcp(relay)
+                    } catch (error: CancellationException) {
+                        // A racing disconnect cancels this coroutine; let cancellation propagate instead
+                        // of masking it as an "unreachable" failure, which would keep trying relays and
+                        // could bring a tunnel up after teardown.
+                        throw error
+                    } catch (error: Throwable) {
+                        throw IllegalStateException(
+                            getString(R.string.error_relay_unreachable, relay.publicHost, relay.publicPort),
+                            error,
+                        )
+                    }
+                    // Try a direct NAT-punched path to a punch-capable volunteer before falling back to
+                    // routing through the relay hub. On success sing-box dials the loopback bridge and the
+                    // volunteer's reflexive IP is excluded from the TUN; on any failure maybePunch returns
+                    // null and this stays the ordinary hub path. Tracked as a service field so
+                    // cleanupActiveTunnel() releases the punched socket on teardown.
+                    val punch = if (allowPunch) PunchClient.maybePunch(relay, this) else null
+                    activePunch = punch
+                    punch?.let {
+                        OpenRungStatusStore.appendLog(getString(R.string.log_punch_direct, it.peerIp, it.natClass))
+                    }
+                    val config = SingBoxConfiguration(
                         relay = relay,
-                        configJson = config,
-                        vpnService = this,
+                        bridgeHost = punch?.bridgeHost,
+                        bridgePort = punch?.bridgePort,
+                        punchPeerExcludeAddress = punch?.peerIp,
+                    ).encodedJsonString()
+                    val proxyEngine = ProxyEngineFactory.create()
+                    val tunnelStarted = SystemClock.elapsedRealtime()
+                    // Tag an engine start/liveness failure as EngineStartException so it classifies as
+                    // process_exited (the embedded-engine analogue of the Go clients' sing-box subprocess
+                    // dying). The original error is kept as the cause so a more specific signal in its
+                    // chain still wins over process_exited.
+                    try {
+                        proxyEngine.start(
+                            relay = relay,
+                            configJson = config,
+                            vpnService = this,
+                        )
+                    } catch (error: CancellationException) {
+                        throw error
+                    } catch (error: Throwable) {
+                        throw EngineStartException(error.message, error)
+                    }
+                    val tunnelStartMs = SystemClock.elapsedRealtime() - tunnelStarted
+                    engine = proxyEngine
+                    OpenRungStatusStore.appendLog(getString(R.string.log_verifying_internet))
+                    val internetProbe = InternetProbe(applicationContext).verify()
+                    OpenRungStatusStore.appendLog(
+                        getString(R.string.log_internet_verified, internetProbe.durationMs),
+                    )
+                    return ConnectedRelay(
+                        relay = relay,
+                        tcpLatencyMs = tcpLatencyMs,
+                        tunnelStartMs = tunnelStartMs,
+                        internetProbeMs = internetProbe.durationMs,
+                        attempts = index + 1,
                     )
                 } catch (error: CancellationException) {
                     throw error
                 } catch (error: Throwable) {
-                    throw EngineStartException(error.message, error)
+                    // Read before cleanupActiveTunnel(), which nulls activePunch.
+                    val punchWasActive = activePunch != null
+                    lastError = error
+                    val attemptReason = FailureClassifier.classify(error)
+                    val attemptDetail = FailureClassifier.detail(error)
+                    TelemetryManager.record(
+                        event = "relay_attempt_failed",
+                        relayId = relay.id,
+                        attributes = buildMap {
+                            // Kept alongside failure_reason for continuity with older app versions.
+                            put("error_type", error::class.java.simpleName)
+                            if (attemptReason.isNotBlank()) put("failure_reason", attemptReason)
+                            if (attemptDetail.isNotBlank()) put("failure_detail", attemptDetail)
+                            if (punchWasActive) put("path", "punch")
+                        },
+                        measurements = mapOf("attempt" to (index + 1).toLong()),
+                    )
+                    OpenRungStatusStore.appendLog(
+                        getString(
+                            R.string.log_relay_failed,
+                            relay.id,
+                            error.message ?: error::class.java.simpleName,
+                        ),
+                    )
+                    cleanupActiveTunnel()
+                    if (allowPunch && punchWasActive) {
+                        // The punched path came up but failed to carry traffic; retry this same relay
+                        // over the plain hub path before moving on (never worse than not punching).
+                        allowPunch = false
+                        OpenRungStatusStore.appendLog(getString(R.string.log_punch_fallback, relay.id))
+                        continue
+                    }
+                    break
                 }
-                val tunnelStartMs = SystemClock.elapsedRealtime() - tunnelStarted
-                engine = proxyEngine
-                OpenRungStatusStore.appendLog(getString(R.string.log_verifying_internet))
-                val internetProbe = InternetProbe(applicationContext).verify()
-                OpenRungStatusStore.appendLog(
-                    getString(R.string.log_internet_verified, internetProbe.durationMs),
-                )
-                return ConnectedRelay(
-                    relay = relay,
-                    tcpLatencyMs = tcpLatencyMs,
-                    tunnelStartMs = tunnelStartMs,
-                    internetProbeMs = internetProbe.durationMs,
-                    attempts = index + 1,
-                )
-            } catch (error: CancellationException) {
-                throw error
-            } catch (error: Throwable) {
-                lastError = error
-                val attemptReason = FailureClassifier.classify(error)
-                val attemptDetail = FailureClassifier.detail(error)
-                TelemetryManager.record(
-                    event = "relay_attempt_failed",
-                    relayId = relay.id,
-                    attributes = buildMap {
-                        // Kept alongside failure_reason for continuity with older app versions.
-                        put("error_type", error::class.java.simpleName)
-                        if (attemptReason.isNotBlank()) put("failure_reason", attemptReason)
-                        if (attemptDetail.isNotBlank()) put("failure_detail", attemptDetail)
-                    },
-                    measurements = mapOf("attempt" to (index + 1).toLong()),
-                )
-                OpenRungStatusStore.appendLog(
-                    getString(
-                        R.string.log_relay_failed,
-                        relay.id,
-                        error.message ?: error::class.java.simpleName,
-                    ),
-                )
-                cleanupActiveTunnel()
             }
         }
 
@@ -399,6 +433,10 @@ class OpenRungVpnService : VpnService() {
     private fun cleanupActiveTunnel() {
         engine?.stop()
         engine = null
+        // Close the punched path after the engine so sing-box stops dialing the loopback bridge
+        // before its QUIC connection and UDP socket are released.
+        activePunch?.close()
+        activePunch = null
     }
 
     private data class ConnectedRelay(

--- a/android/app/src/main/java/com/openrung/vpn/PunchClient.kt
+++ b/android/app/src/main/java/com/openrung/vpn/PunchClient.kt
@@ -1,0 +1,142 @@
+package com.openrung.vpn
+
+import android.net.VpnService
+import android.util.Log
+import com.openrung.config.AppConfig
+import com.openrung.model.RelayDescriptor
+import com.openrung.telemetry.TelemetryManager
+import io.nekohasekai.orpunch.Config
+import io.nekohasekai.orpunch.Orpunch
+import io.nekohasekai.orpunch.Session
+import io.nekohasekai.orpunch.SocketProtector
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * A live direct NAT-punched path to a volunteer. [session] owns the punched QUIC connection and the
+ * loopback bridge goroutine; sing-box dials [bridgeHost]:[bridgePort] in place of the relay hub, and
+ * [peerIp] must be excluded from the TUN routes. Close it (via [PunchClient] teardown) to release the
+ * socket when the tunnel is torn down.
+ */
+class PunchOutcome(
+    val session: Session,
+    val bridgeHost: String,
+    val bridgePort: Int,
+    val peerIp: String,
+    val natClass: String,
+) {
+    fun close() {
+        runCatching { session.close() }
+    }
+}
+
+/**
+ * Kotlin front door to the gomobile-bound punch client (io.nekohasekai.orpunch, bundled in
+ * libbox.aar). It runs the desktop client's exact punch flow — hub coordination, reflector
+ * discovery, UDP hole punch, QUIC, loopback bridge — and hands back a [PunchOutcome] whose loopback
+ * bridge sing-box uses instead of the relay hub. Any failure (not punch-capable, symmetric NAT, hub
+ * declined, timeout, or the AAR lacking orpunch) resolves to null and the caller falls back to the
+ * relay hub path: the outcome is never worse than not punching.
+ */
+object PunchClient {
+    private const val LOG_TAG = "OpenRungPunch"
+
+    /**
+     * Whether the orpunch classes are actually linked. A checkout or build variant without the AAR
+     * must degrade to the relay path rather than crash, exactly like ProxyEngineFactory guards the
+     * libbox classes.
+     */
+    private val linked: Boolean = try {
+        Orpunch::class.java.name
+        true
+    } catch (error: Throwable) {
+        false
+    }
+
+    /**
+     * Attempts a direct NAT-punched path to [relay]. Returns a live [PunchOutcome] on success or null
+     * on any failure. Records punch telemetry mirroring the desktop client
+     * (punch_skipped/attempted/succeeded/failed). The blocking hub/punch/QUIC work runs on
+     * Dispatchers.IO; cancellation propagates so a racing disconnect tears the attempt down.
+     */
+    suspend fun maybePunch(relay: RelayDescriptor, vpnService: VpnService): PunchOutcome? {
+        if (!relay.punchCapable) return null
+        if (!AppConfig.PUNCH_ENABLED) {
+            TelemetryManager.record("punch_skipped", relayId = relay.id, attributes = mapOf("reason" to "disabled"))
+            return null
+        }
+        if (!linked) return null
+
+        TelemetryManager.record("punch_attempted", relayId = relay.id)
+        // Orpunch.dial is a blocking JNI call that runs to completion even if this coroutine is
+        // cancelled meanwhile — producing a LIVE session (open UDP socket + bridge goroutine + QUIC
+        // conn). If the dispatch back to the caller's context then finds it cancelled, withContext
+        // DISCARDS the returned value and throws CancellationException, so `activePunch = ...` never
+        // runs and nothing closes the session. Capture it in an outer var and close it on
+        // cancellation so a disconnect mid-punch cannot leak the socket/goroutine.
+        var outcome: PunchOutcome? = null
+        try {
+            return withContext(Dispatchers.IO) {
+                val session = try {
+                    val config = Config().apply {
+                        setHubBaseURL(relay.punchBaseUrl())
+                        setRelayID(relay.id)
+                        setInsecure(AppConfig.PUNCH_HUB_INSECURE)
+                    }
+                    Orpunch.dial(config, VpnSocketProtector(vpnService))
+                } catch (error: CancellationException) {
+                    throw error
+                } catch (error: Throwable) {
+                    Log.w(LOG_TAG, "punch dial failed", error)
+                    TelemetryManager.record(
+                        "punch_failed",
+                        relayId = relay.id,
+                        attributes = mapOf("reason" to "wrapper", "nat_class" to ""),
+                    )
+                    return@withContext null
+                }
+
+                if (!session.ok()) {
+                    TelemetryManager.record(
+                        "punch_failed",
+                        relayId = relay.id,
+                        // Both keys always present, matching the desktop client's telemetry shape.
+                        attributes = mapOf("reason" to session.reason(), "nat_class" to session.natClass()),
+                    )
+                    runCatching { session.close() }
+                    return@withContext null
+                }
+
+                TelemetryManager.record(
+                    "punch_succeeded",
+                    relayId = relay.id,
+                    attributes = mapOf("nat_class" to session.natClass()),
+                    measurements = mapOf("punch_rtt_ms" to session.rttMillis()),
+                )
+                PunchOutcome(
+                    session = session,
+                    bridgeHost = session.bridgeHost(),
+                    bridgePort = session.bridgePort().toInt(),
+                    peerIp = session.peerIP(),
+                    natClass = session.natClass(),
+                ).also { outcome = it }
+            }
+        } catch (error: CancellationException) {
+            runCatching { outcome?.close() }
+            throw error
+        }
+    }
+}
+
+/**
+ * Bridges the Go punch socket's fd to VpnService.protect() so the reflector, hole-punch, and QUIC
+ * datagrams reach the underlying network instead of looping back through the app's own TUN — the
+ * same seam libbox uses via PlatformInterface.autoDetectInterfaceControl. gomobile marshals Go's
+ * `int` fd as a Java `long`; VpnService.protect takes an `int`.
+ */
+private class VpnSocketProtector(private val vpn: VpnService) : SocketProtector {
+    override fun protect(fd: Long) {
+        vpn.protect(fd.toInt())
+    }
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -18,6 +18,8 @@
     <string name="log_connecting_relay">connecting to relay %1$s</string>
     <string name="log_trying_relay">trying relay %1$s at %2$s:%3$d</string>
     <string name="log_checking_relay_reachability">checking relay TCP reachability</string>
+    <string name="log_punch_direct">punched a direct path to the volunteer (peer %1$s, NAT %2$s)</string>
+    <string name="log_punch_fallback">direct path to %1$s did not come up; retrying over the relay hub</string>
     <string name="log_verifying_internet">verifying internet access through the VPN</string>
     <string name="log_internet_verified">internet access verified in %1$d ms</string>
     <string name="log_relay_failed">relay %1$s failed: %2$s</string>

--- a/android/app/src/test/java/com/openrung/model/RelayDescriptorPunchTest.kt
+++ b/android/app/src/test/java/com/openrung/model/RelayDescriptorPunchTest.kt
@@ -1,0 +1,89 @@
+package com.openrung.model
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.Instant
+
+/**
+ * Covers the NAT-punch relay fields: they deserialize from the broker's snake_case keys, default
+ * cleanly when a relay/broker omits them, drive [RelayDescriptor.punchBaseUrl] the way the desktop
+ * client resolves the hub URL, and — critically — never gate [RelayDescriptor.isUsable] (punch is an
+ * accelerator, not a usability requirement).
+ */
+class RelayDescriptorPunchTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private fun relayJson(extra: String): String =
+        """
+        {
+          "id": "relay_abc",
+          "public_host": "203.0.113.7",
+          "public_port": 443,
+          "protocol": "vless-reality-vision",
+          "client_id": "11111111-2222-3333-4444-555555555555",
+          "reality_public_key": "pubkey",
+          "short_id": "abcd",
+          "server_name": "www.example.com",
+          "flow": "xtls-rprx-vision",
+          "exit_mode": "direct",
+          "max_sessions": 4,
+          "max_mbps": 100,
+          "volunteer_version": "0.2.6",
+          "registered_at": "2026-07-10T00:00:00Z",
+          "last_heartbeat_at": "2026-07-10T00:00:00Z",
+          "expires_at": "2999-01-01T00:00:00Z"$extra
+        }
+        """.trimIndent()
+
+    @Test
+    fun `deserializes punch fields when present`() {
+        val relay = json.decodeFromString<RelayDescriptor>(
+            relayJson(""","punch_capable": true, "punch_endpoint": "https://hub.example.org:9444""""),
+        )
+        assertTrue(relay.punchCapable)
+        assertEquals("https://hub.example.org:9444", relay.punchEndpoint)
+    }
+
+    @Test
+    fun `defaults punch fields when absent`() {
+        val relay = json.decodeFromString<RelayDescriptor>(relayJson(""))
+        assertFalse(relay.punchCapable)
+        assertEquals("", relay.punchEndpoint)
+    }
+
+    @Test
+    fun `punchBaseUrl uses advertised endpoint verbatim`() {
+        val relay = json.decodeFromString<RelayDescriptor>(
+            relayJson(""","punch_endpoint": "https://hub.example.org:9444""""),
+        )
+        assertEquals("https://hub.example.org:9444", relay.punchBaseUrl())
+    }
+
+    @Test
+    fun `punchBaseUrl derives from public host when endpoint blank`() {
+        val relay = json.decodeFromString<RelayDescriptor>(relayJson(""))
+        assertEquals("http://203.0.113.7:9444", relay.punchBaseUrl())
+    }
+
+    @Test
+    fun `punchBaseUrl brackets bare IPv6 public host`() {
+        val relay = json.decodeFromString<RelayDescriptor>(
+            relayJson(""","public_host": "2001:db8::1""""),
+        )
+        assertEquals("http://[2001:db8::1]:9444", relay.punchBaseUrl())
+    }
+
+    @Test
+    fun `isUsable ignores punch capability`() {
+        val now = Instant.parse("2026-07-10T00:00:00Z")
+        val punchable = json.decodeFromString<RelayDescriptor>(relayJson(""","punch_capable": true"""))
+        val plain = json.decodeFromString<RelayDescriptor>(relayJson(""))
+        // Both are usable; punch_capable neither grants nor revokes usability.
+        assertTrue(punchable.isUsable(now))
+        assertTrue(plain.isUsable(now))
+    }
+}

--- a/android/app/src/test/java/com/openrung/net/SingBoxConfigurationPunchTest.kt
+++ b/android/app/src/test/java/com/openrung/net/SingBoxConfigurationPunchTest.kt
@@ -1,0 +1,120 @@
+package com.openrung.net
+
+import com.openrung.model.RelayDescriptor
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Covers the punch-mode sing-box config deltas versus the relay (direct) path: the VLESS outbound is
+ * redirected to the loopback bridge while the Reality identity is preserved, and the volunteer's
+ * reflexive IP joins the relay hub in route_exclude_address. Without punch params the config must be
+ * byte-identical to today.
+ */
+class SingBoxConfigurationPunchTest {
+
+    private fun relay(publicHost: String = "203.0.113.7"): RelayDescriptor =
+        RelayDescriptor(
+            id = "relay_abc",
+            publicHost = publicHost,
+            publicPort = 443,
+            relayProtocol = "vless-reality-vision",
+            clientId = "11111111-2222-3333-4444-555555555555",
+            realityPublicKey = "pubkey",
+            shortId = "abcd",
+            serverName = "www.example.com",
+            flow = "xtls-rprx-vision",
+            exitMode = "direct",
+            maxSessions = 4,
+            maxMbps = 100,
+            volunteerVersion = "0.2.6",
+            registeredAt = "2026-07-10T00:00:00Z",
+            lastHeartbeatAt = "2026-07-10T00:00:00Z",
+            expiresAt = "2999-01-01T00:00:00Z",
+        )
+
+    private fun proxyOutbound(config: JsonObject): JsonObject =
+        config["outbounds"]!!.jsonArray
+            .map { it.jsonObject }
+            .first { it["tag"]?.jsonPrimitive?.content == "proxy" }
+
+    private fun routeExclude(config: JsonObject): List<String> {
+        val tun = config["inbounds"]!!.jsonArray[0].jsonObject
+        val excl = tun["route_exclude_address"] as? JsonArray ?: return emptyList()
+        return excl.map { it.jsonPrimitive.content }
+    }
+
+    @Test
+    fun `direct path dials the relay public endpoint and excludes only the hub`() {
+        val config = SingBoxConfiguration(relay = relay()).makeJsonObject()
+        val proxy = proxyOutbound(config)
+        assertEquals(JsonPrimitive("203.0.113.7"), proxy["server"])
+        assertEquals(JsonPrimitive(443), proxy["server_port"])
+        assertEquals(listOf("203.0.113.7/32"), routeExclude(config))
+    }
+
+    @Test
+    fun `punch path dials the loopback bridge`() {
+        val config = SingBoxConfiguration(
+            relay = relay(),
+            bridgeHost = "127.0.0.1",
+            bridgePort = 51820,
+            punchPeerExcludeAddress = "198.51.100.9",
+        ).makeJsonObject()
+        val proxy = proxyOutbound(config)
+        assertEquals(JsonPrimitive("127.0.0.1"), proxy["server"])
+        assertEquals(JsonPrimitive(51820), proxy["server_port"])
+    }
+
+    @Test
+    fun `punch path preserves the Reality identity`() {
+        val config = SingBoxConfiguration(
+            relay = relay(),
+            bridgeHost = "127.0.0.1",
+            bridgePort = 51820,
+            punchPeerExcludeAddress = "198.51.100.9",
+        ).makeJsonObject()
+        val tls = proxyOutbound(config)["tls"]!!.jsonObject
+        // Identity fields still target the real volunteer, so Reality validates end-to-end.
+        assertEquals(JsonPrimitive("www.example.com"), tls["server_name"])
+        assertEquals(JsonPrimitive("pubkey"), tls["reality"]!!.jsonObject["public_key"])
+        assertEquals(JsonPrimitive("abcd"), tls["reality"]!!.jsonObject["short_id"])
+        assertEquals(
+            JsonPrimitive("11111111-2222-3333-4444-555555555555"),
+            proxyOutbound(config)["uuid"],
+        )
+    }
+
+    @Test
+    fun `punch path excludes both the hub and the volunteer reflexive IP`() {
+        val config = SingBoxConfiguration(
+            relay = relay(),
+            bridgeHost = "127.0.0.1",
+            bridgePort = 51820,
+            punchPeerExcludeAddress = "198.51.100.9",
+        ).makeJsonObject()
+        val excludes = routeExclude(config)
+        assertTrue("hub excluded", excludes.contains("203.0.113.7/32"))
+        assertTrue("peer excluded", excludes.contains("198.51.100.9/32"))
+        assertEquals(2, excludes.size)
+    }
+
+    @Test
+    fun `punch peer exclude only applies when the peer IP is a literal`() {
+        // A blank peer IP must not add a stray exclusion (defensive: maybePunch always sets one on
+        // success, but the config layer must not choke on a hostname or null).
+        val config = SingBoxConfiguration(
+            relay = relay(),
+            bridgeHost = "127.0.0.1",
+            bridgePort = 51820,
+            punchPeerExcludeAddress = null,
+        ).makeJsonObject()
+        assertEquals(listOf("203.0.113.7/32"), routeExclude(config))
+    }
+}

--- a/android/build-libbox-release.sh
+++ b/android/build-libbox-release.sh
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
 # Builds the Android sing-box/libbox AAR (android/app/libs/libbox.aar) from the
-# exact sing-box revision pinned in ../SINGBOX_VERSION. libbox is GPL-3.0, so
-# the pinned revision here is the GPL §6 corresponding source for the sing-box
-# portion of any released APK — keep ../SINGBOX_VERSION in lockstep with the
-# shipped binary (see ../RELEASE.md).
+# exact sing-box revision pinned in ../SINGBOX_VERSION, with the OpenRung NAT
+# hole-punch client (openrung/mobile/orpunch, pinned in ../OPENRUNG_VERSION)
+# bound into the SAME AAR. Both run under one Go runtime: gomobile binds the
+# io.nekohasekai.libbox.* and io.nekohasekai.orpunch.* packages together, so
+# there is a single go/Seq JNI bridge and a single libbox.so (a second, separate
+# AAR would collide on go/Seq and run two Go runtimes — unsupported).
+#
+# libbox is GPL-3.0 (pinned rev = ../SINGBOX_VERSION) and openrung is GPL-3.0
+# (pinned rev = ../OPENRUNG_VERSION); together they are the GPL §6 corresponding
+# source for the shipped APK's native engine — keep both pins in lockstep with the
+# released binary (see ../RELEASE.md).
 set -euo pipefail
 
 script_dir="$(cd "$(dirname "$0")" && pwd)"
@@ -17,7 +24,28 @@ export ANDROID_NDK_HOME="${ANDROID_NDK_HOME:-$ANDROID_HOME/ndk/29.0.14206865}"
 export JAVA_HOME="${JAVA_HOME:-/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home}"
 export PATH="$HOME/go/bin:/opt/homebrew/bin:/opt/homebrew/opt/openjdk@17/bin:$PATH"
 
-echo "Building libbox.aar from sing-box $sing_box_version"
+# OPENRUNG_SRC is a local checkout of the openrung Go module (module path
+# "openrung"). It is a private module path with no VCS host, so it can only be
+# wired in via a go.mod `replace` to a local path — check it out at the
+# ../OPENRUNG_VERSION commit for a reproducible, GPL-corresponding build. Default
+# to a sibling of the app repo; override for worktrees or other layouts.
+resolve_openrung_src() {
+  if [[ -n "${OPENRUNG_SRC:-}" ]]; then
+    printf '%s' "$OPENRUNG_SRC"
+    return
+  fi
+  local candidate
+  for candidate in "$repo_root/../openrung" "$repo_root/../../openrung" "/opt/projects/openrung"; do
+    if [[ -f "$candidate/go.mod" ]] && grep -qx 'module openrung' "$candidate/go.mod" 2>/dev/null; then
+      (cd "$candidate" && pwd)
+      return
+    fi
+  done
+  echo "error: could not locate the openrung Go module; set OPENRUNG_SRC to its checkout" >&2
+  exit 1
+}
+openrung_src="$(resolve_openrung_src)"
+echo "Building libbox.aar from sing-box $sing_box_version + openrung punch ($openrung_src)"
 
 cd "$script_dir"
 
@@ -30,11 +58,52 @@ chmod -R u+w "$work_dir/source"
 
 (
   cd "$work_dir/source"
-  GOMODCACHE="$module_cache" go run ./cmd/internal/build_libbox \
+
+  # Wire the openrung punch wrapper into the sing-box module's build graph. The
+  # keep-file forces `go mod tidy` to retain the (otherwise unimported) require and
+  # pull openrung's transitive deps (mainline quic-go v0.60.0, which coexists with
+  # sagernet's fork — different module paths). The require is added explicitly so
+  # tidy resolves it even before the bind arg references it.
+  {
+    echo ''
+    echo 'require openrung v0.0.0-00010101000000-000000000000'
+    echo "replace openrung => $openrung_src"
+  } >> go.mod
+  mkdir -p orpunchkeep
+  printf 'package orpunchkeep\n\nimport _ "openrung/mobile/orpunch"\n' > orpunchkeep/keep.go
+  GOFLAGS=-mod=mod GOMODCACHE="$module_cache" GOWORK=off go mod tidy
+
+  # Append the wrapper to build_libbox's single bind package arg so both packages
+  # land in one AAR / one Go runtime. Every gomobile flag, build tag, and ldflag
+  # (-checklinkname=0, badlinkname, tfogo_checklinkname0, with_quic, ...) stays
+  # sourced from build_libbox, so the libbox half is byte-for-byte the stock build.
+  perl -0pi -e 's{args = append\(args, "\./experimental/libbox"\)}{args = append(args, "./experimental/libbox", "openrung/mobile/orpunch")}' \
+    cmd/internal/build_libbox/main.go
+  if ! grep -q 'openrung/mobile/orpunch' cmd/internal/build_libbox/main.go; then
+    echo "error: failed to inject the orpunch bind package into build_libbox" >&2
+    exit 1
+  fi
+
+  GOFLAGS=-mod=mod GOMODCACHE="$module_cache" GOWORK=off go run ./cmd/internal/build_libbox \
     -target android \
     -platform android/arm64
 )
 
 mkdir -p "$script_dir/app/libs"
 cp "$work_dir/source/libbox.aar" "$script_dir/app/libs/libbox.aar"
-echo "Release libbox AAR: $script_dir/app/libs/libbox.aar"
+
+# Sanity-check that both halves made it into the single AAR. gomobile nests the
+# Java classes inside classes.jar, so extract that and inspect it, not the AAR's
+# top level.
+check_dir="$work_dir/aar-check"
+mkdir -p "$check_dir"
+unzip -o -q "$script_dir/app/libs/libbox.aar" classes.jar -d "$check_dir"
+if ! unzip -l "$check_dir/classes.jar" | grep -q 'io/nekohasekai/orpunch/Session.class'; then
+  echo "error: the built AAR is missing io.nekohasekai.orpunch classes" >&2
+  exit 1
+fi
+if ! unzip -l "$check_dir/classes.jar" | grep -q 'io/nekohasekai/libbox/Libbox.class'; then
+  echo "error: the built AAR is missing io.nekohasekai.libbox classes" >&2
+  exit 1
+fi
+echo "Release libbox+punch AAR: $script_dir/app/libs/libbox.aar"


### PR DESCRIPTION
## What & why

Android now attempts a **direct NAT-punched path** to a punch-capable (CGNAT) volunteer before falling back to routing through the relay hub — matching the desktop client. Volunteers behind CGNAT no longer force all of a client's traffic through the hub's data plane.

## Approach

Rather than reimplement QUIC + the punch protocol in Kotlin (interop risk against the exact `quic-go` server, plus a permanent parallel codebase), this **reuses the desktop's proven Go punch client by binding it into the same `libbox.aar` via gomobile** (`io.nekohasekai.orpunch`). A second AAR isn't viable — two gomobile AARs collide on the shared `go/Seq` JNI classes and run two Go runtimes in one process — so both packages share one bind → one `libbox.so` → one runtime.

The Go side (the `openrung/mobile/orpunch` wrapper + an optional `Dialer.Control` socket-protection hook in `internal/punch`) lives in the **openrung** repo on branch `claude/mobile-punch-binding` and ships as a **separate PR**. This PR is the Android integration + build wiring.

## Changes
- **`android/build-libbox-release.sh`** — binds `openrung/mobile/orpunch` into the same AAR by injecting a go.mod `replace` for the openrung module and appending the package to `build_libbox`'s bind args (all sing-box build tags stay sourced from `build_libbox`). New `OPENRUNG_VERSION` pin; `README`/`RELEASE.md` document the `OPENRUNG_SRC` local checkout and the GPL §6 corresponding-source obligation.
- **`PunchClient.kt`** (new) — `maybePunch()` gated on `relay.punch_capable` + `PUNCH_ENABLED` + orpunch-linked; bridges `VpnService.protect()` to the Go socket via a `SocketProtector`; desktop-parity telemetry (`punch_attempted/succeeded/failed/skipped`). Closes the session on a cancelled `withContext` dispatch-back so a disconnect mid-punch can't leak the socket/goroutine.
- **`OpenRungVpnService.kt`** — punch attempted per candidate before engine start; `activePunch` released in `cleanupActiveTunnel()`; **per-relay retry over the plain hub path** if a punched path establishes but fails to carry traffic (guarantees enabling punch is never worse than not punching).
- **`RelayDescriptor.kt`** — `punch_capable` / `punch_endpoint` fields + `punchBaseUrl()` (mirrors desktop URL resolution); `isUsable` unchanged (punch is an accelerator, not a usability gate).
- **`SingBoxConfiguration.kt`** — redirect the VLESS outbound to the loopback bridge and add the volunteer's reflexive IP to `route_exclude_address`; Reality identity fields unchanged so it still validates end-to-end.
- **`AppConfig.kt`** — `PUNCH_ENABLED` / `PUNCH_HUB_INSECURE` flags.
- **Tests** — `RelayDescriptorPunchTest`, `SingBoxConfigurationPunchTest`.

## Reviewer notes
- **Depends on the openrung `claude/mobile-punch-binding` branch.** Rebuilding the AAR requires `OPENRUNG_SRC=<openrung checkout at that branch> ./android/build-libbox-release.sh`; the currently-built `libbox.aar` already contains `orpunch`.
- `libbox.aar` is git-ignored (generated), so it's not in this diff.
- **iOS is unchanged** (still hub-only); the same `orpunch` package binds to iOS later via the identical seam.
- Falls **open** by design — any punch failure silently uses the hub path.

## Verification
- 69 Android unit tests pass (incl. the two new suites).
- The combined AAR carries both `io.nekohasekai.libbox` (133 classes) and `io.nekohasekai.orpunch` (5) under a single Go runtime; the full **debug APK assembles** (DEX merge clean, single `libbox.so`).
- **Not** covered here: an on-device punch handshake (needs a live hub + punch-capable volunteer + device).

🤖 Generated with [Claude Code](https://claude.com/claude-code)