### PR TITLE
Bump version to 0.2.7

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -90,7 +90,7 @@ android {
         applicationId "com.openrung.mobile"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 7
+        versionCode 8
         versionName appVersionName
     }
     signingConfigs {

--- a/ios/OpenRung.xcodeproj/project.pbxproj
+++ b/ios/OpenRung.xcodeproj/project.pbxproj
@@ -661,7 +661,7 @@
 					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
 					"\"$(inherited)\"",
 				);
-				MARKETING_VERSION = 0.2.6;
+				MARKETING_VERSION = 0.2.7;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -803,7 +803,7 @@
 					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
 					"\"$(inherited)\"",
 				);
-				MARKETING_VERSION = 0.2.6;
+				MARKETING_VERSION = 0.2.7;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				OTHER_CPLUSPLUSFLAGS = (

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openrung-mobile-app",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
## Summary

Single-sourced in `package.json` (Android `versionName` + iOS `MARKETING_VERSION` derive from it); Android `versionCode` 7 → 8 (manual monotonic bump); iOS `MARKETING_VERSION` baked to 0.2.7. `check-versions.mjs` passes.

Merging to main cuts the 0.2.7 Android release. Contents since 0.2.6:
- Android NAT hole punching for CGNAT volunteers — direct client↔volunteer QUIC path with certificate-pinned coordination, end-to-end health monitoring, and bounded recovery with automatic RelayHub fallback (#41)
- Pull-to-refresh on the relay list (#39)

## Test plan
- [x] `npm run version:check` passes
- [ ] CI green on this PR
- [ ] `release.yml` auto-cuts v0.2.7 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)