### PR TITLE
Rank relay ladder by client-measured TCP latency

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -90,7 +90,7 @@ android {
         applicationId "com.openrung.mobile"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 8
+        versionCode 9
         versionName appVersionName
     }
     signingConfigs {

--- a/android/app/src/main/java/com/openrung/net/RelayRanker.kt
+++ b/android/app/src/main/java/com/openrung/net/RelayRanker.kt
@@ -1,0 +1,72 @@
+package com.openrung.net
+
+import com.openrung.model.RelayDescriptor
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+
+/**
+ * Client-side latency ranking for the relay connect ladder.
+ *
+ * The broker already orders relays by a composite score (load headroom, success rate, latency,
+ * speed) from its own vantage; the one signal it cannot know is THIS client's network path. The
+ * ranker probes TCP connect latency to the head of the candidate list in parallel and reorders by
+ * latency BUCKET with a stable sort, so broker order — and with it the broker's load balancing —
+ * still decides among relays whose measured latency is within [DEFAULT_BUCKET_MS] of each other.
+ * Only humanly meaningful differences (a bucket boundary) override the broker.
+ *
+ * Ranking is fail-open by design: it reorders candidates but never drops one. A failed or
+ * timed-out probe sinks that relay below the reachable ones (the connect ladder's own 5s
+ * reachability gate may still succeed where a short probe gave up), and candidates beyond
+ * [DEFAULT_MAX_PROBES] keep broker order after the probed head.
+ *
+ * The probe targets [RelayDescriptor.publicHost], which is the actual exit for the `direct`
+ * relays that pass `isUsable` today. If tunnel (CGNAT) relays ever become usable, publicHost is
+ * the relay hub — TCP latency to it would not measure the exit path (same trap as geolocating
+ * publicHost; see RelayDescriptor).
+ */
+object RelayRanker {
+    const val DEFAULT_MAX_PROBES = 8
+    const val DEFAULT_PROBE_TIMEOUT_MS = 1_500
+
+    /** Bucket width: within one bucket, broker order is preserved (stable sort). */
+    const val DEFAULT_BUCKET_MS = 30L
+
+    data class RankedRelay(val relay: RelayDescriptor, val probeMs: Long?)
+
+    suspend fun rankByTcpLatency(
+        candidates: List<RelayDescriptor>,
+        maxProbes: Int = DEFAULT_MAX_PROBES,
+        probeTimeoutMillis: Int = DEFAULT_PROBE_TIMEOUT_MS,
+        bucketMs: Long = DEFAULT_BUCKET_MS,
+        probe: suspend (RelayDescriptor, Int) -> Long = { relay, timeout ->
+            RelayReachability.checkTcp(relay, timeout)
+        },
+    ): List<RankedRelay> {
+        // Nothing to reorder: skip the probes (and their radio wake) entirely.
+        if (candidates.size < 2) return candidates.map { RankedRelay(it, null) }
+
+        val head = candidates.take(maxProbes)
+        val tail = candidates.drop(maxProbes)
+        val probed = coroutineScope {
+            head.map { relay ->
+                async {
+                    val ms = try {
+                        probe(relay, probeTimeoutMillis)
+                    } catch (error: CancellationException) {
+                        // A racing disconnect cancels the connect coroutine; propagate instead of
+                        // treating cancellation as an unreachable relay.
+                        throw error
+                    } catch (_: Throwable) {
+                        null
+                    }
+                    RankedRelay(relay, ms)
+                }
+            }.awaitAll()
+        }
+        val (reachable, failed) = probed.partition { it.probeMs != null }
+        // sortedBy is stable: equal buckets keep broker order.
+        return reachable.sortedBy { it.probeMs!! / bucketMs } + failed + tail.map { RankedRelay(it, null) }
+    }
+}

--- a/android/app/src/main/java/com/openrung/vpn/OpenRungVpnService.kt
+++ b/android/app/src/main/java/com/openrung/vpn/OpenRungVpnService.kt
@@ -26,6 +26,7 @@ import com.openrung.net.InternetProbe
 import com.openrung.net.NatPunchClient
 import com.openrung.net.NatPunchResult
 import com.openrung.net.NatPunchSession
+import com.openrung.net.RelayRanker
 import com.openrung.net.RelayReachability
 import com.openrung.net.SingBoxConfiguration
 import com.openrung.state.ConnectionStatus
@@ -201,8 +202,26 @@ class OpenRungVpnService : VpnService() {
                 candidates
             }
 
+            // Reorder (never shrink) the ladder by this client's measured TCP latency. Broker
+            // order already scores load headroom / success rate / latency / speed from the
+            // broker's vantage, so RelayRanker only overrides it across latency buckets — within
+            // a bucket the broker's load balancing still decides. A pinned relay skips ranking:
+            // there is exactly one candidate and the user chose it.
+            val rankedCandidates = if (targetRelayId == null && targetedCandidates.size > 1) {
+                failureStage = "relay_rank"
+                OpenRungStatusStore.appendLog(
+                    getString(
+                        R.string.log_rank_probing,
+                        minOf(targetedCandidates.size, RelayRanker.DEFAULT_MAX_PROBES),
+                    ),
+                )
+                RelayRanker.rankByTcpLatency(targetedCandidates)
+            } else {
+                targetedCandidates.map { RelayRanker.RankedRelay(it, null) }
+            }
+
             failureStage = "relay_connect"
-            val connectedRelay = connectFirstAvailable(targetedCandidates)
+            val connectedRelay = connectFirstAvailable(rankedCandidates.map { it.relay })
             // If a disconnect raced in while we were connecting, don't publish CONNECTED for a
             // tunnel that's being torn down. Stopping the engine is owned by disconnect()/a new
             // connect (both call cleanupActiveTunnel); we just must not commit CONNECTED here.
@@ -220,13 +239,23 @@ class OpenRungVpnService : VpnService() {
             TelemetryManager.record(
                 event = "connection_succeeded",
                 relayId = relay.id,
-                measurements = mapOf(
-                    "broker_fetch_ms" to brokerFetchMs,
-                    "relay_tcp_ms" to connectedRelay.tcpLatencyMs,
-                    "tunnel_start_ms" to connectedRelay.tunnelStartMs,
-                    "internet_probe_ms" to connectedRelay.internetProbeMs,
-                    "relay_attempts" to connectedRelay.attempts.toLong(),
-                ),
+                measurements = buildMap {
+                    put("broker_fetch_ms", brokerFetchMs)
+                    put("relay_tcp_ms", connectedRelay.tcpLatencyMs)
+                    put("tunnel_start_ms", connectedRelay.tunnelStartMs)
+                    put("internet_probe_ms", connectedRelay.internetProbeMs)
+                    put("relay_attempts", connectedRelay.attempts.toLong())
+                    // Rank observability: where the connected relay sat in broker order before
+                    // ranking, and its probe latency when it was probed — the pair that shows
+                    // whether client-side ranking actually beats broker order on tunnel_start_ms.
+                    put(
+                        "relay_broker_index",
+                        targetedCandidates.indexOfFirst { it.id == relay.id }.toLong(),
+                    )
+                    rankedCandidates.firstOrNull { it.relay.id == relay.id }
+                        ?.probeMs
+                        ?.let { put("relay_probe_ms", it) }
+                },
             )
             // Promote liveness monitoring before the best-effort telemetry upload. A slow upload
             // must never leave a newly-dead direct path claiming CONNECTED for its HTTP timeout.

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
     <string name="log_broker_returned">broker returned %1$d relays; %2$d usable</string>
     <string name="log_connecting_country">connecting to a relay in %1$s</string>
     <string name="log_connecting_relay">connecting to relay %1$s</string>
+    <string name="log_rank_probing">measuring TCP latency to %1$d relays</string>
     <string name="log_trying_relay">trying relay %1$s at %2$s:%3$d</string>
     <string name="log_checking_relay_reachability">checking relay TCP reachability</string>
     <string name="log_punch_attempting">attempting a direct path to the relay</string>

--- a/android/app/src/test/java/com/openrung/net/RelayRankerTest.kt
+++ b/android/app/src/test/java/com/openrung/net/RelayRankerTest.kt
@@ -1,0 +1,112 @@
+package com.openrung.net
+
+import com.openrung.model.RelayDescriptor
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.currentTime
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.util.concurrent.atomic.AtomicInteger
+
+class RelayRankerTest {
+    @Test
+    fun `sorts probed relays by latency bucket, fastest first`() = runTest {
+        val relays = listOf(relay("a"), relay("b"), relay("c"))
+        val latencies = mapOf("a" to 200L, "b" to 40L, "c" to 120L)
+
+        val ranked = RelayRanker.rankByTcpLatency(relays) { r, _ -> latencies.getValue(r.id) }
+
+        assertEquals(listOf("b", "c", "a"), ranked.map { it.relay.id })
+        assertEquals(listOf(40L, 120L, 200L), ranked.map { it.probeMs })
+    }
+
+    @Test
+    fun `broker order decides within a latency bucket`() = runTest {
+        // 31 and 45 share the 30ms bucket; broker order (a before b) must survive even though
+        // b measured marginally faster. c's 95 lands two buckets up and sorts last.
+        val relays = listOf(relay("a"), relay("b"), relay("c"))
+        val latencies = mapOf("a" to 45L, "b" to 31L, "c" to 95L)
+
+        val ranked = RelayRanker.rankByTcpLatency(relays) { r, _ -> latencies.getValue(r.id) }
+
+        assertEquals(listOf("a", "b", "c"), ranked.map { it.relay.id })
+    }
+
+    @Test
+    fun `failed probes sink below reachable relays but are never dropped`() = runTest {
+        val relays = listOf(relay("dead"), relay("slow"), relay("fast"))
+
+        val ranked = RelayRanker.rankByTcpLatency(relays) { r, _ ->
+            when (r.id) {
+                "dead" -> throw IllegalStateException("connect timed out")
+                "slow" -> 400L
+                else -> 20L
+            }
+        }
+
+        assertEquals(listOf("fast", "slow", "dead"), ranked.map { it.relay.id })
+        assertNull(ranked.last().probeMs)
+    }
+
+    @Test
+    fun `unprobed tail keeps broker order after the probed head`() = runTest {
+        val relays = (1..5).map { relay("r$it") }
+        // Probe only the first three; reverse their latency so the head visibly reorders.
+        val latencies = mapOf("r1" to 300L, "r2" to 150L, "r3" to 10L)
+
+        val ranked = RelayRanker.rankByTcpLatency(relays, maxProbes = 3) { r, _ ->
+            latencies.getValue(r.id)
+        }
+
+        assertEquals(listOf("r3", "r2", "r1", "r4", "r5"), ranked.map { it.relay.id })
+        assertNull(ranked[3].probeMs)
+        assertNull(ranked[4].probeMs)
+    }
+
+    @Test
+    fun `single candidate short-circuits without probing`() = runTest {
+        val probes = AtomicInteger(0)
+
+        val ranked = RelayRanker.rankByTcpLatency(listOf(relay("only"))) { _, _ ->
+            probes.incrementAndGet()
+            10L
+        }
+
+        assertEquals(listOf("only"), ranked.map { it.relay.id })
+        assertNull(ranked.single().probeMs)
+        assertEquals(0, probes.get())
+    }
+
+    @Test
+    fun `probes run concurrently, not sequentially`() = runTest {
+        val relays = (1..4).map { relay("r$it") }
+
+        RelayRanker.rankByTcpLatency(relays) { _, _ ->
+            delay(1_000)
+            50L
+        }
+
+        // Four sequential probes would advance virtual time to 4000ms.
+        assertEquals(1_000L, currentTime)
+    }
+
+    private fun relay(id: String): RelayDescriptor = RelayDescriptor(
+        id = id,
+        publicHost = "203.0.113.10",
+        publicPort = 443,
+        relayProtocol = "vless-reality-vision",
+        clientId = "e6b1a1de-9f0f-4c1a-8bb1-1f2b3c4d5e6f",
+        realityPublicKey = "key",
+        shortId = "abcd",
+        serverName = "www.example.com",
+        flow = "xtls-rprx-vision",
+        exitMode = "direct",
+        maxSessions = 8,
+        maxMbps = 100,
+        relayVersion = "1.0.0",
+        registeredAt = "2026-01-01T00:00:00Z",
+        lastHeartbeatAt = "2026-01-01T00:00:00Z",
+        expiresAt = "2026-01-01T01:00:00Z",
+    )
+}

--- a/ios/OpenRung.xcodeproj/project.pbxproj
+++ b/ios/OpenRung.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		0FECF7EABB4F538A378ECDFF /* RelayListVerifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B42983C9E84DBA57FA9C2AA4 /* RelayListVerifier.swift */; };
 		1001D8102F7EA1A694366DFF /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A9B3E3F0BA7E28C5D05A1731 /* Images.xcassets */; };
 		101812ACF2D87E69B666B516 /* DeviceAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E77D10C22E8939116D44BD /* DeviceAttributes.swift */; };
+		14A31DB460F1128BDFCECBE9 /* RelayReachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5AFE2F1F1556F9E70F0AC99 /* RelayReachability.swift */; };
 		160F427AA318BEC6A772654F /* SpeedTestClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A57C8F876ACF0B8B9BC73749 /* SpeedTestClient.swift */; };
 		1688E26406D6F8E93575AFCA /* CountryGeo.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2570C01745DA49558877810 /* CountryGeo.swift */; };
 		2226FA02DA3CF06280AA3D27 /* CountryGeo.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2570C01745DA49558877810 /* CountryGeo.swift */; };
@@ -38,6 +39,7 @@
 		3D8CFD33EED8FE7AE1FB3299 /* TelemetryEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C9C9695B7E93F7A4F5460B /* TelemetryEvent.swift */; };
 		3E600B1A4A0F6A075AB8D6E7 /* FailureClassifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E89C58EA730C659109459911 /* FailureClassifierTests.swift */; };
 		4AF8C7F150317AC00E8B27FA /* PacketTunnel.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 1EAA8B2F5746A87534F0C87B /* PacketTunnel.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		4B33639315FF6460341572DA /* RelayRanker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69D27334571CA6F3A5CEB1BD /* RelayRanker.swift */; };
 		4F5E5D33E5E0532AB1153B1C /* PacketTunnelProxyEngineError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A0014BD8DAE8D1AB0AA819 /* PacketTunnelProxyEngineError.swift */; };
 		523936029217C10BD01D40DC /* ActivityLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C27022D3D9D7FEEC839F406 /* ActivityLog.swift */; };
 		597C72F1F64C95B607D0F5BD /* TelemetryOutboxState.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFA54F7B4B2DCC1F8706FD7C /* TelemetryOutboxState.swift */; };
@@ -63,6 +65,7 @@
 		A2BD7C4271FDE1F796CA7E77 /* AppConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4783169BE46FEE9B0472504 /* AppConfig.swift */; };
 		A456EFF327FBA312F10D2DDA /* ActivityLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C27022D3D9D7FEEC839F406 /* ActivityLog.swift */; };
 		A47671E4D8F1625738EA3742 /* RelayReachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5AFE2F1F1556F9E70F0AC99 /* RelayReachability.swift */; };
+		A8F913880F45765F628CA0BE /* RelayRanker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69D27334571CA6F3A5CEB1BD /* RelayRanker.swift */; };
 		AAD6ED5EDDC44F6648B06B22 /* TelemetryOutboxState.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFA54F7B4B2DCC1F8706FD7C /* TelemetryOutboxState.swift */; };
 		ADCA603D15EE662D1B0A279C /* RelayReachabilityError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FF4517B34B4819F6DCD4D1 /* RelayReachabilityError.swift */; };
 		B466AFF5D620F556EA05524F /* RelaySelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD9B5CA88D770C6F0A9597FE /* RelaySelector.swift */; };
@@ -77,7 +80,9 @@
 		C43600EFCA0F80A743A653C5 /* RelayListVerifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B42983C9E84DBA57FA9C2AA4 /* RelayListVerifier.swift */; };
 		C4B31101802A2AE5B0E26703 /* LibboxPacketTunnelPlatformInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97D23B885595CDD6DD259A85 /* LibboxPacketTunnelPlatformInterface.swift */; };
 		C98C9E042E602DF887F4B995 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A025739761D97ABD7227B8DA /* PrivacyInfo.xcprivacy */; };
+		CA3379CA0C7E8B6506A3861C /* RelayRankerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE70163A0AFAFED70BA816C7 /* RelayRankerTests.swift */; };
 		CCB2C474FEDC465EA9762C71 /* TelemetryClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4254868EF5882AD951E8D23B /* TelemetryClient.swift */; };
+		CDEAE1A5C571C1C12B15F55C /* RelayRanker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69D27334571CA6F3A5CEB1BD /* RelayRanker.swift */; };
 		CE5FF08F60EA9B59A3FAD581 /* RelayReachabilityError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FF4517B34B4819F6DCD4D1 /* RelayReachabilityError.swift */; };
 		D095482C735B4750F9AC99BB /* RelayDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC6AEF8D510DD407C368119F /* RelayDescriptor.swift */; };
 		D222D8CD2611D57559062B89 /* NetworkPathMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C127CAD14278743A1BD298 /* NetworkPathMonitor.swift */; };
@@ -136,6 +141,7 @@
 		4B9BA54065E95B7262DA7A95 /* TunnelDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelDiagnostics.swift; sourceTree = "<group>"; };
 		584A04475F28B3CAC39B501E /* ConnectionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionStatus.swift; sourceTree = "<group>"; };
 		683F07997A392045B7540E47 /* BrokerClientError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrokerClientError.swift; sourceTree = "<group>"; };
+		69D27334571CA6F3A5CEB1BD /* RelayRanker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayRanker.swift; sourceTree = "<group>"; };
 		6A5299A99DA8ED8C75B1E25B /* TelemetrySession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetrySession.swift; sourceTree = "<group>"; };
 		719ACF45718CBF52773FCD6C /* OpenRungVpnModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenRungVpnModule.swift; sourceTree = "<group>"; };
 		7A07146C137269D283F062DB /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -150,6 +156,7 @@
 		A57C8F876ACF0B8B9BC73749 /* SpeedTestClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedTestClient.swift; sourceTree = "<group>"; };
 		A9B3E3F0BA7E28C5D05A1731 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		AB117725DF8A60D9A23412CC /* PacketTunnel.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PacketTunnel.entitlements; sourceTree = "<group>"; };
+		AE70163A0AFAFED70BA816C7 /* RelayRankerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayRankerTests.swift; sourceTree = "<group>"; };
 		B0C127CAD14278743A1BD298 /* NetworkPathMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkPathMonitor.swift; sourceTree = "<group>"; };
 		B3A0014BD8DAE8D1AB0AA819 /* PacketTunnelProxyEngineError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PacketTunnelProxyEngineError.swift; sourceTree = "<group>"; };
 		B42983C9E84DBA57FA9C2AA4 /* RelayListVerifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayListVerifier.swift; sourceTree = "<group>"; };
@@ -224,6 +231,7 @@
 				B0C127CAD14278743A1BD298 /* NetworkPathMonitor.swift */,
 				DC6AEF8D510DD407C368119F /* RelayDescriptor.swift */,
 				B42983C9E84DBA57FA9C2AA4 /* RelayListVerifier.swift */,
+				69D27334571CA6F3A5CEB1BD /* RelayRanker.swift */,
 				D5AFE2F1F1556F9E70F0AC99 /* RelayReachability.swift */,
 				D8FF4517B34B4819F6DCD4D1 /* RelayReachabilityError.swift */,
 				FD9B5CA88D770C6F0A9597FE /* RelaySelector.swift */,
@@ -248,6 +256,7 @@
 				9771BD2BC7057921FF185C4C /* BrokerClientTests.swift */,
 				E89C58EA730C659109459911 /* FailureClassifierTests.swift */,
 				28939B9F48E675DE2070E2F5 /* RelayListVerifierTests.swift */,
+				AE70163A0AFAFED70BA816C7 /* RelayRankerTests.swift */,
 			);
 			path = OpenRungTests;
 			sourceTree = "<group>";
@@ -465,6 +474,7 @@
 				4F5E5D33E5E0532AB1153B1C /* PacketTunnelProxyEngineError.swift in Sources */,
 				D095482C735B4750F9AC99BB /* RelayDescriptor.swift in Sources */,
 				0FECF7EABB4F538A378ECDFF /* RelayListVerifier.swift in Sources */,
+				A8F913880F45765F628CA0BE /* RelayRanker.swift in Sources */,
 				C1A6F6AC896E2EE68FCD7AC9 /* RelayReachability.swift in Sources */,
 				CE5FF08F60EA9B59A3FAD581 /* RelayReachabilityError.swift in Sources */,
 				024B9A8C62881E530EB591B4 /* RelaySelector.swift in Sources */,
@@ -500,6 +510,9 @@
 				EB4BB9C6B76C65809224DF35 /* RelayDescriptor.swift in Sources */,
 				C43600EFCA0F80A743A653C5 /* RelayListVerifier.swift in Sources */,
 				D278AC91827C1FECF92B8E0E /* RelayListVerifierTests.swift in Sources */,
+				4B33639315FF6460341572DA /* RelayRanker.swift in Sources */,
+				CA3379CA0C7E8B6506A3861C /* RelayRankerTests.swift in Sources */,
+				14A31DB460F1128BDFCECBE9 /* RelayReachability.swift in Sources */,
 				E6799BE42347DC306ADF2213 /* RelayReachabilityError.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -525,6 +538,7 @@
 				F82F4E03FAD0D3DFDB106718 /* OpenRungVpnModule.swift in Sources */,
 				7AD3CF8197D457CDDC3CCBCE /* RelayDescriptor.swift in Sources */,
 				BAF6846398D40CC0F5AB1023 /* RelayListVerifier.swift in Sources */,
+				CDEAE1A5C571C1C12B15F55C /* RelayRanker.swift in Sources */,
 				A47671E4D8F1625738EA3742 /* RelayReachability.swift in Sources */,
 				ADCA603D15EE662D1B0A279C /* RelayReachabilityError.swift in Sources */,
 				B466AFF5D620F556EA05524F /* RelaySelector.swift in Sources */,
@@ -661,7 +675,7 @@
 					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
 					"\"$(inherited)\"",
 				);
-				MARKETING_VERSION = 0.2.7;
+				MARKETING_VERSION = "${APP_VERSION}";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -803,7 +817,7 @@
 					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
 					"\"$(inherited)\"",
 				);
-				MARKETING_VERSION = 0.2.7;
+				MARKETING_VERSION = "${APP_VERSION}";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				OTHER_CPLUSPLUSFLAGS = (

--- a/ios/OpenRung.xcodeproj/project.pbxproj
+++ b/ios/OpenRung.xcodeproj/project.pbxproj
@@ -675,7 +675,7 @@
 					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
 					"\"$(inherited)\"",
 				);
-				MARKETING_VERSION = "${APP_VERSION}";
+				MARKETING_VERSION = 0.2.8;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -817,7 +817,7 @@
 					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
 					"\"$(inherited)\"",
 				);
-				MARKETING_VERSION = "${APP_VERSION}";
+				MARKETING_VERSION = 0.2.8;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				OTHER_CPLUSPLUSFLAGS = (

--- a/ios/OpenRungTests/RelayRankerTests.swift
+++ b/ios/OpenRungTests/RelayRankerTests.swift
@@ -1,0 +1,117 @@
+import Foundation
+import XCTest
+
+/// Unit tests for `RelayRanker`. The ranker and its compile closure (`RelayDescriptor`,
+/// `RelayReachability`, `RelayReachabilityError`) are compiled directly into this test target —
+/// see the `OpenRungTests` target in `project.yml` — so no import of the app/extension is needed.
+/// Every test injects a fake probe; no sockets are opened.
+final class RelayRankerTests: XCTestCase {
+
+    func testSortsProbedRelaysByLatencyBucketFastestFirst() async {
+        let relays = [relay("a"), relay("b"), relay("c")]
+        let latencies: [String: Int64] = ["a": 200, "b": 40, "c": 120]
+
+        let ranked = await RelayRanker.rankByTcpLatency(relays) { relay, _ in
+            latencies[relay.id]!
+        }
+
+        XCTAssertEqual(ranked.map(\.relay.id), ["b", "c", "a"])
+        XCTAssertEqual(ranked.map(\.probeMs), [40, 120, 200])
+    }
+
+    func testBrokerOrderDecidesWithinALatencyBucket() async {
+        // 31 and 45 share the 30ms bucket; broker order (a before b) must survive even though
+        // b measured marginally faster. c's 95 lands two buckets up and sorts last.
+        let relays = [relay("a"), relay("b"), relay("c")]
+        let latencies: [String: Int64] = ["a": 45, "b": 31, "c": 95]
+
+        let ranked = await RelayRanker.rankByTcpLatency(relays) { relay, _ in
+            latencies[relay.id]!
+        }
+
+        XCTAssertEqual(ranked.map(\.relay.id), ["a", "b", "c"])
+    }
+
+    func testFailedProbesSinkBelowReachableRelaysButAreNeverDropped() async {
+        let relays = [relay("dead"), relay("slow"), relay("fast")]
+
+        let ranked = await RelayRanker.rankByTcpLatency(relays) { relay, _ in
+            switch relay.id {
+            case "dead": throw RelayReachabilityError.timeout
+            case "slow": return 400
+            default: return 20
+            }
+        }
+
+        XCTAssertEqual(ranked.map(\.relay.id), ["fast", "slow", "dead"])
+        XCTAssertNil(ranked.last?.probeMs ?? nil)
+    }
+
+    func testUnprobedTailKeepsBrokerOrderAfterTheProbedHead() async {
+        let relays = (1...5).map { relay("r\($0)") }
+        // Probe only the first three; reverse their latency so the head visibly reorders.
+        let latencies: [String: Int64] = ["r1": 300, "r2": 150, "r3": 10]
+
+        let ranked = await RelayRanker.rankByTcpLatency(relays, maxProbes: 3) { relay, _ in
+            latencies[relay.id]!
+        }
+
+        XCTAssertEqual(ranked.map(\.relay.id), ["r3", "r2", "r1", "r4", "r5"])
+        XCTAssertNil(ranked[3].probeMs)
+        XCTAssertNil(ranked[4].probeMs)
+    }
+
+    func testSingleCandidateShortCircuitsWithoutProbing() async {
+        final class Counter: @unchecked Sendable {
+            private let lock = NSLock()
+            private var value = 0
+            func increment() { lock.lock(); value += 1; lock.unlock() }
+            var count: Int { lock.lock(); defer { lock.unlock() }; return value }
+        }
+        let probes = Counter()
+
+        let ranked = await RelayRanker.rankByTcpLatency([relay("only")]) { _, _ in
+            probes.increment()
+            return 10
+        }
+
+        XCTAssertEqual(ranked.map(\.relay.id), ["only"])
+        XCTAssertNil(ranked[0].probeMs)
+        XCTAssertEqual(probes.count, 0)
+    }
+
+    func testProbesRunConcurrentlyNotSequentially() async {
+        let relays = (1...4).map { relay("r\($0)") }
+        let started = DispatchTime.now().uptimeNanoseconds
+
+        _ = await RelayRanker.rankByTcpLatency(relays) { _, _ in
+            try await Task.sleep(nanoseconds: 200_000_000) // 200ms each
+            return 50
+        }
+
+        let elapsedMs = (DispatchTime.now().uptimeNanoseconds - started) / 1_000_000
+        // Four sequential probes would need >=800ms; allow generous scheduler slack.
+        XCTAssertLessThan(elapsedMs, 600)
+    }
+
+    private func relay(_ id: String) -> RelayDescriptor {
+        RelayDescriptor(
+            id: id,
+            publicHost: "203.0.113.10",
+            publicPort: 443,
+            relayProtocol: RelayConstants.protocolVLESSRealityVision,
+            clientID: "e6b1a1de-9f0f-4c1a-8bb1-1f2b3c4d5e6f",
+            realityPublicKey: "key",
+            shortID: "abcd",
+            serverName: "www.example.com",
+            flow: RelayConstants.flowVision,
+            exitMode: RelayConstants.exitModeDirect,
+            maxSessions: 8,
+            maxMbps: 100,
+            relayVersion: "1.0.0",
+            registeredAt: Date(timeIntervalSince1970: 1_767_225_600),
+            lastHeartbeatAt: Date(timeIntervalSince1970: 1_767_225_600),
+            expiresAt: Date(timeIntervalSince1970: 1_767_229_200)
+        )
+    }
+}

--- a/ios/PacketTunnel/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider.swift
@@ -150,8 +150,23 @@ final class PacketTunnelProvider: NEPacketTunnelProvider {
                 targetedCandidates = candidates
             }
 
+            // Reorder (never shrink) the ladder by this client's measured TCP latency. Broker
+            // order already scores load headroom / success rate / latency / speed from the
+            // broker's vantage, so RelayRanker only overrides it across latency buckets — within
+            // a bucket the broker's load balancing still decides. A pinned relay skips ranking:
+            // there is exactly one candidate and the user chose it.
+            let rankedCandidates: [RelayRanker.RankedRelay]
+            if targetRelayID == nil, targetedCandidates.count > 1 {
+                failureStage = "relay_rank"
+                let probeCount = min(targetedCandidates.count, RelayRanker.defaultMaxProbes)
+                SharedConnectionState.appendLog("measuring TCP latency to \(probeCount) relays")
+                rankedCandidates = await RelayRanker.rankByTcpLatency(targetedCandidates)
+            } else {
+                rankedCandidates = targetedCandidates.map { .init(relay: $0, probeMs: nil) }
+            }
+
             failureStage = "relay_connect"
-            let connected = try await connectFirstAvailableRelay(targetedCandidates)
+            let connected = try await connectFirstAvailableRelay(rankedCandidates.map(\.relay))
 
             // A stop may have arrived while we were connecting. Don't publish .connected or start
             // the heartbeat for a tunnel that's being torn down; stopTunnel awaited this task and
@@ -163,16 +178,25 @@ final class PacketTunnelProvider: NEPacketTunnelProvider {
             TelemetryManager.markConnected(relayId: relay.id)
             SharedConnectionState.setStatus(.connected, clearRelayLabel: true, clearError: true)
             applyRelayLocation(relay)
+            var successMeasurements: [String: Int64] = [
+                "broker_fetch_ms": brokerFetchMs,
+                "relay_tcp_ms": connected.tcpLatencyMs,
+                "tunnel_start_ms": connected.tunnelStartMs,
+                "internet_probe_ms": connected.internetProbeMs,
+                "relay_attempts": Int64(connected.attempts),
+            ]
+            // Rank observability: where the connected relay sat in broker order before ranking,
+            // and its probe latency when it was probed — the pair that shows whether client-side
+            // ranking actually beats broker order on tunnel_start_ms.
+            successMeasurements["relay_broker_index"] =
+                Int64(targetedCandidates.firstIndex { $0.id == relay.id } ?? -1)
+            if let probeMs = rankedCandidates.first(where: { $0.relay.id == relay.id })?.probeMs {
+                successMeasurements["relay_probe_ms"] = probeMs
+            }
             TelemetryManager.record(
                 "connection_succeeded",
                 relayId: relay.id,
-                measurements: [
-                    "broker_fetch_ms": brokerFetchMs,
-                    "relay_tcp_ms": connected.tcpLatencyMs,
-                    "tunnel_start_ms": connected.tunnelStartMs,
-                    "internet_probe_ms": connected.internetProbeMs,
-                    "relay_attempts": Int64(connected.attempts),
-                ]
+                measurements: successMeasurements
             )
             try? await TelemetryManager.flush(brokerURL: AppConfig.telemetryBrokerURL.absoluteString)
             startHeartbeatLoop()

--- a/ios/Shared/RelayRanker.swift
+++ b/ios/Shared/RelayRanker.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+/// Client-side latency ranking for the relay connect ladder. Port of Android `RelayRanker`.
+///
+/// The broker already orders relays by a composite score (load headroom, success rate, latency,
+/// speed) from its own vantage; the one signal it cannot know is THIS client's network path. The
+/// ranker probes TCP connect latency to the head of the candidate list in parallel and reorders by
+/// latency BUCKET with a stable sort, so broker order — and with it the broker's load balancing —
+/// still decides among relays whose measured latency is within `defaultBucketMs` of each other.
+/// Only humanly meaningful differences (a bucket boundary) override the broker.
+///
+/// Ranking is fail-open by design: it reorders candidates but never drops one. A failed or
+/// timed-out probe sinks that relay below the reachable ones (the connect ladder's own 5s
+/// reachability gate may still succeed where a short probe gave up), and candidates beyond
+/// `defaultMaxProbes` keep broker order after the probed head.
+///
+/// The probe targets `publicHost`, which is the actual exit for the `direct` relays that pass
+/// `isUsable` today. If tunnel (CGNAT) relays ever become usable, publicHost is the relay hub —
+/// TCP latency to it would not measure the exit path (same trap as geolocating publicHost; see
+/// RelayDescriptor).
+public enum RelayRanker {
+    public static let defaultMaxProbes = 8
+    public static let defaultProbeTimeoutMillis = 1_500
+
+    /// Bucket width: within one bucket, broker order is preserved (stable sort).
+    public static let defaultBucketMs: Int64 = 30
+
+    public struct RankedRelay: Sendable {
+        public let relay: RelayDescriptor
+        public let probeMs: Int64?
+
+        public init(relay: RelayDescriptor, probeMs: Int64?) {
+            self.relay = relay
+            self.probeMs = probeMs
+        }
+    }
+
+    public static func rankByTcpLatency(
+        _ candidates: [RelayDescriptor],
+        maxProbes: Int = defaultMaxProbes,
+        probeTimeoutMillis: Int = defaultProbeTimeoutMillis,
+        bucketMs: Int64 = defaultBucketMs,
+        probe: @escaping @Sendable (RelayDescriptor, Int) async throws -> Int64 = { relay, timeout in
+            try await RelayReachability.checkTcp(relay, timeoutMillis: timeout)
+        }
+    ) async -> [RankedRelay] {
+        // Nothing to reorder: skip the probes (and their radio wake) entirely.
+        guard candidates.count > 1 else {
+            return candidates.map { RankedRelay(relay: $0, probeMs: nil) }
+        }
+
+        let head = Array(candidates.prefix(maxProbes))
+        let tail = candidates.dropFirst(maxProbes)
+        var probeResults = [Int64?](repeating: nil, count: head.count)
+        await withTaskGroup(of: (Int, Int64?).self) { group in
+            for (index, relay) in head.enumerated() {
+                group.addTask {
+                    // A failed/timed-out/cancelled probe maps to nil (fail-open); the caller's
+                    // Task.checkCancellation surfaces a racing stop right after ranking.
+                    (index, try? await probe(relay, probeTimeoutMillis))
+                }
+            }
+            for await (index, ms) in group {
+                probeResults[index] = ms
+            }
+        }
+        let probed = head.enumerated().map { index, relay in
+            RankedRelay(relay: relay, probeMs: probeResults[index])
+        }
+        // Swift's sort is not guaranteed stable — sort on (bucket, broker index) explicitly so
+        // equal buckets keep broker order.
+        let reachable = probed.enumerated()
+            .filter { $0.element.probeMs != nil }
+            .sorted { lhs, rhs in
+                let lhsBucket = lhs.element.probeMs! / bucketMs
+                let rhsBucket = rhs.element.probeMs! / bucketMs
+                return lhsBucket == rhsBucket ? lhs.offset < rhs.offset : lhsBucket < rhsBucket
+            }
+            .map(\.element)
+        let failed = probed.filter { $0.probeMs == nil }
+        return reachable + failed + tail.map { RankedRelay(relay: $0, probeMs: nil) }
+    }
+}

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -114,13 +114,15 @@ targets:
 
   # Hostless logic-test bundle. It compiles the units under test and their source closure directly
   # into the test module (rather than @testable-importing the app/extension), so the suites build and
-  # run without the app, CocoaPods, or Libbox. Three suites live here:
+  # run without the app, CocoaPods, or Libbox. Four suites live here:
   #   - FailureClassifierTests: FailureClassifier + the small error types it maps.
   #   - BrokerClientTests: the broker discovery flow (staggered race + override-first).
   #   - RelayListVerifierTests: RelayListVerifier, plus AppConfig and its compile closure
   #     (BrokerClient/RelayDescriptor/DeviceAttributes/NetworkPathMonitor/BrokerEndpoint) so the §11
   #     pinned-key CI guard verifies the committed rotation vectors against the REAL
   #     AppConfig.relaySigningKeys constant — a typo'd pin fails CI here, not on rotation day.
+  #   - RelayRankerTests: the latency-bucket ladder reorder (RelayRanker + RelayReachability,
+  #     which its default probe closure references).
   # All sources are Foundation/UIKit/Network/CryptoKit only (no CocoaPods, no Libbox).
   OpenRungTests:
     type: bundle.unit-test
@@ -137,6 +139,8 @@ targets:
       - path: Shared/DeviceAttributes.swift
       - path: Shared/NetworkPathMonitor.swift
       - path: Shared/RelayDescriptor.swift
+      - path: Shared/RelayRanker.swift
+      - path: Shared/RelayReachability.swift
       - path: Shared/RelayReachabilityError.swift
       - path: Shared/RelayListVerifier.swift
     settings:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openrung-mobile-app",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/src/model/relay.ts
+++ b/src/model/relay.ts
@@ -100,8 +100,11 @@ export function serverTimeMs(response: RelayListResponse): number {
 }
 
 /**
- * `RelaySelector.orderedCandidates`: no client-side scoring — filter to usable relays preserving
- * broker order. Freshness is judged against broker server time, not the device clock.
+ * `RelaySelector.orderedCandidates`: score-free filter to usable relays preserving broker order.
+ * Freshness is judged against broker server time, not the device clock. (The native connect path
+ * may afterwards reorder — never shrink — the ladder by this client's measured TCP latency; see
+ * `RelayRanker` on Android/iOS. That is a separate, fail-open stage: the filter itself stays
+ * score-free.)
  */
 export function orderedCandidates(relays: RelayDescriptor[], nowMs: number): RelayDescriptor[] {
   return relays.filter(relay => isUsable(relay, nowMs));


### PR DESCRIPTION
## What

Adds a client-side latency ranking stage to the relay connect ladder on Android and iOS. Before walking the first-available ladder, the client probes TCP connect latency to the head of the candidate list (up to 8 relays, 1.5s timeout, in parallel) and reorders by **30ms latency bucket** with a stable sort.

## Why bucketed, not raw-sorted

The broker already orders relays by a composite score (`0.45·load headroom + 0.25·successRate + 0.20·latencyScore + 0.10·speedScore`) — but from its own vantage. The one signal it cannot know is the connecting client's network path. Bucketing composes the two: within one 30ms bucket, broker order (and with it the load balancing) still decides; only a humanly meaningful latency difference overrides it.

## Properties

- **Fail-open**: ranking reorders, never drops. Failed/timed-out probes sink below reachable relays but stay in the ladder (its 5s reachability gate may still connect where a 1.5s probe gave up). Candidates beyond the probed head keep broker order.
- **Pinned relay skips ranking** (single, user-chosen candidate); country-targeted connects rank within the filtered set.
- **Recovery re-ranks for free**: Android's punch-monitor recovery re-runs `connect()`, so post-drop reconnects probe fresh.
- **Observable before trusted**: `connection_succeeded` gains `relay_broker_index` + `relay_probe_ms`, so dashboards can compare client ranking vs broker order on `tunnel_start_ms` and tune bucket width with data.
- `RelaySelector` stays a score-free filter on all three platforms; ranking is a separate native stage.

## Notes

- The pbxproj diff is the additive bare-`xcodegen generate` output — the tracked project carries no CocoaPods phases, so the regen matches the committed convention.
- Probe targets `publicHost`, which is the true exit for the `direct` relays that pass `isUsable` today; a code comment flags the tunnel-relay (hub ≠ exit) trap if that ever changes.

## Testing

- `:app:testDebugUnitTest` green — new `RelayRankerTest` 6/6 (bucket sort, in-bucket broker-order stability, fail-open sinking, unprobed tail, single-candidate short-circuit, probe concurrency via virtual time)
- `RelayRankerTests` 6/6 (new hostless XCTest suite, run via SwiftPM harness)
- `PacketTunnel` extension builds against Libbox (`xcodebuild -target PacketTunnel` BUILD SUCCEEDED)
- Jest relay suite 7/7

🤖 Generated with [Claude Code](https://claude.com/claude-code)