### PR TITLE
Android: add offline APK sharing in v0.2.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ side-by-side with them.
 - 🌃 **Terminal cyberpunk theme** — the production green-on-black palette
   (`#65F58A` on `#030604`), all-monospace type, neon glows and HUD accents.
 - 🌍 **10 locales** — persisted per-app language selection.
+- 📦 **Offline Android sharing** — send the installed, signed APK through the
+  system sharesheet to Quick Share or any compatible nearby-transfer app; no
+  network or storage permission is required.
 - 🕳️ **Direct volunteer-run CGNAT relays on Android** — NAT punching establishes
   a client↔relay QUIC path and keeps RelayHub out of the data plane whenever
   both NATs permit it, with certificate-pinned coordination, end-to-end health
@@ -86,7 +89,8 @@ side-by-side with them.
   reachability, direct NAT punching for volunteer-run CGNAT relays,
   sing-box/libbox engine,
   TUN + DNS, internet probe, connection-failure handling, heartbeat telemetry,
-  plus the `OpenRungVpn` React Native module that bridges it.
+  the `OpenRungVpn` React Native module that bridges it, and a separate
+  read-only installed-APK provider for offline sharing.
 - **iOS native (`ios/`)** — the production `NEPacketTunnelProvider` extension,
   shared Swift sources compiled into both targets, and an `OpenRungVpnModule`
   bridging `NETunnelProviderManager` + app-group shared state to React Native.
@@ -234,6 +238,9 @@ mock simulator — useful for UI work and demos, but no traffic is routed.
   (NetworkExtension requires a signed device build).
 - iOS does not yet consume `punch_capable`; volunteer-run CGNAT relays use
   RelayHub there.
+- Android offline sharing supports the monolithic APK produced by
+  `assembleRelease`. Installs made from split APKs are rejected because sharing
+  only their `base.apk` would produce an incomplete, un-installable copy.
 - Telemetry from TypeScript covers only speed-test events; the native connect
   path keeps full production telemetry.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -105,6 +105,18 @@ advertising the replacement endpoint/certificate.
   repository must be reachable by whoever receives the build (GPL §6). If the
   repo is private, publish it or a mirror before external distribution.
 
+### Android offline-sharing check
+
+Install the signed `assembleRelease` artifact on an Android device and confirm
+that Settings → General → "Share OpenRung offline" opens the system sharesheet
+with an `OpenRung-<version>.apk` attachment.
+`adb shell pm path com.openrung.mobile` must report exactly one APK path for the
+release used in this test. The app intentionally refuses installs with
+`splitSourceDirs`, because their `sourceDir` is only `base.apk` and cannot be
+installed independently on the receiving phone. Complete one offline
+phone-to-phone transfer and verify the received APK's SHA-256 and signing
+certificate against the original release artifact before publishing.
+
 ## 4. App Store / DRM caveat (must be resolved separately)
 
 Distributing a GPL-linked binary through the App Store (and likely external

--- a/__tests__/screens/SettingsScreen.test.tsx
+++ b/__tests__/screens/SettingsScreen.test.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import ReactTestRenderer from 'react-test-renderer';
+import { Alert, Text } from 'react-native';
+
+const mockShareInstalledApk = jest.fn<Promise<void>, [string]>();
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(async () => null),
+    setItem: jest.fn(async () => {}),
+    removeItem: jest.fn(async () => {}),
+  },
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 0, left: 0 }),
+}));
+
+jest.mock('../../src/state/useVpnState', () => ({
+  useVpnState: () => ({ isConnected: false }),
+}));
+
+jest.mock('../../src/native/OpenRungApkShare', () => ({
+  isApkShareAvailable: true,
+  shareInstalledApk: (chooserTitle: string) =>
+    mockShareInstalledApk(chooserTitle),
+  apkShareErrorCode: (error: unknown) =>
+    typeof error === 'object' && error != null && 'code' in error
+      ? (error as { code: string }).code
+      : null,
+}));
+
+import { AboutScreen } from '../../src/screens/AboutScreen';
+import { SettingsScreen } from '../../src/screens/SettingsScreen';
+
+async function renderSettings(): Promise<ReactTestRenderer.ReactTestRenderer> {
+  let tree: ReactTestRenderer.ReactTestRenderer | undefined;
+  await ReactTestRenderer.act(async () => {
+    tree = ReactTestRenderer.create(<SettingsScreen onOpenDebug={jest.fn()} />);
+  });
+  return tree!;
+}
+
+function findButton(
+  tree: ReactTestRenderer.ReactTestRenderer,
+  title: string,
+): ReactTestRenderer.ReactTestInstance {
+  return tree.root
+    .findAll(node => typeof node.props.onPress === 'function')
+    .find(node =>
+      node.findAllByType(Text).some(text => text.props.children === title),
+    )!;
+}
+
+async function unmount(
+  tree: ReactTestRenderer.ReactTestRenderer,
+): Promise<void> {
+  await ReactTestRenderer.act(async () => {
+    tree.unmount();
+  });
+}
+
+describe('SettingsScreen Android APK sharing', () => {
+  beforeEach(() => {
+    mockShareInstalledApk.mockReset();
+  });
+
+  it('places offline sharing in General and opens the native share sheet', async () => {
+    mockShareInstalledApk.mockResolvedValue(undefined);
+    const tree = await renderSettings();
+    const labels = tree.root
+      .findAllByType(Text)
+      .map(text => text.props.children)
+      .filter((label): label is string => typeof label === 'string');
+
+    expect(labels.indexOf('GENERAL')).toBeLessThan(
+      labels.indexOf('Share OpenRung offline'),
+    );
+    expect(labels.indexOf('Share OpenRung offline')).toBeLessThan(
+      labels.indexOf('DIAGNOSTICS'),
+    );
+
+    await ReactTestRenderer.act(async () => {
+      findButton(tree, 'Share OpenRung offline').props.onPress();
+      await Promise.resolve();
+    });
+
+    expect(mockShareInstalledApk).toHaveBeenCalledWith(
+      'Share OpenRung offline',
+    );
+    await unmount(tree);
+  });
+
+  it('explains why a split install cannot be shared', async () => {
+    mockShareInstalledApk.mockRejectedValue(
+      Object.assign(new Error('split install'), {
+        code: 'E_SPLIT_APK_INSTALL',
+      }),
+    );
+    const alert = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+    const tree = await renderSettings();
+
+    await ReactTestRenderer.act(async () => {
+      findButton(tree, 'Share OpenRung offline').props.onPress();
+      await Promise.resolve();
+    });
+
+    expect(alert).toHaveBeenCalledWith(
+      'Unable to share OpenRung',
+      'This copy was installed as multiple APK files and cannot be shared safely. Install the standalone OpenRung APK to use offline sharing.',
+    );
+    alert.mockRestore();
+    await unmount(tree);
+  });
+
+  it('does not leave a duplicate sharing action on the About tab', async () => {
+    let tree: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(async () => {
+      tree = ReactTestRenderer.create(
+        <AboutScreen onOpenLicenses={jest.fn()} />,
+      );
+    });
+
+    const hasShareAction = tree!.root
+      .findAllByType(Text)
+      .some(text => text.props.children === 'Share OpenRung offline');
+    expect(hasShareAction).toBe(false);
+    await unmount(tree!);
+  });
+});

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -90,7 +90,7 @@ android {
         applicationId "com.openrung.mobile"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 9
+        versionCode 10
         versionName appVersionName
     }
     signingConfigs {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -29,6 +29,12 @@
         </intent-filter>
       </activity>
 
+      <provider
+        android:name=".share.InstalledApkProvider"
+        android:authorities="${applicationId}.apk-share"
+        android:exported="false"
+        android:grantUriPermissions="true" />
+
       <service
         android:name=".vpn.OpenRungVpnService"
         android:exported="false"

--- a/android/app/src/main/java/com/openrung/bridge/OpenRungApkShareModule.kt
+++ b/android/app/src/main/java/com/openrung/bridge/OpenRungApkShareModule.kt
@@ -1,0 +1,45 @@
+package com.openrung.bridge
+
+import android.content.Intent
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.UiThreadUtil
+import com.openrung.share.ApkShareException
+import com.openrung.share.InstalledApkShare
+
+/** Android-only bridge that opens the system sharesheet for the installed OpenRung APK. */
+class OpenRungApkShareModule(
+    private val reactContext: ReactApplicationContext,
+) : ReactContextBaseJavaModule(reactContext) {
+    override fun getName(): String = NAME
+
+    @ReactMethod
+    fun shareApk(chooserTitle: String, promise: Promise) {
+        UiThreadUtil.runOnUiThread {
+            try {
+                val activity = reactContext.currentActivity
+                    ?: run {
+                        promise.reject(ERROR_NO_ACTIVITY, "no foreground activity to open the share sheet")
+                        return@runOnUiThread
+                    }
+                val sendIntent = InstalledApkShare.createSendIntent(reactContext.applicationContext)
+                val chooser = Intent.createChooser(sendIntent, chooserTitle)
+                activity.startActivity(chooser)
+                // Android does not report whether the chosen target completed the transfer.
+                promise.resolve(null)
+            } catch (error: ApkShareException) {
+                promise.reject(error.code, error.message, error)
+            } catch (error: Throwable) {
+                promise.reject(ERROR_SHARE_FAILED, "unable to open the APK share sheet", error)
+            }
+        }
+    }
+
+    companion object {
+        const val NAME = "OpenRungApkShare"
+        private const val ERROR_NO_ACTIVITY = "E_NO_ACTIVITY"
+        private const val ERROR_SHARE_FAILED = "E_SHARE_FAILED"
+    }
+}

--- a/android/app/src/main/java/com/openrung/bridge/OpenRungVpnPackage.kt
+++ b/android/app/src/main/java/com/openrung/bridge/OpenRungVpnPackage.kt
@@ -7,7 +7,10 @@ import com.facebook.react.uimanager.ViewManager
 
 class OpenRungVpnPackage : ReactPackage {
     override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> =
-        listOf(OpenRungVpnModule(reactContext))
+        listOf(
+            OpenRungVpnModule(reactContext),
+            OpenRungApkShareModule(reactContext),
+        )
 
     override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> =
         emptyList()

--- a/android/app/src/main/java/com/openrung/share/InstalledApkProvider.kt
+++ b/android/app/src/main/java/com/openrung/share/InstalledApkProvider.kt
@@ -1,0 +1,91 @@
+package com.openrung.share
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.database.Cursor
+import android.database.MatrixCursor
+import android.net.Uri
+import android.os.ParcelFileDescriptor
+import android.provider.OpenableColumns
+import java.io.File
+import java.io.FileNotFoundException
+
+/**
+ * Read-only provider for exactly one file: this package's installed, monolithic APK.
+ *
+ * Streaming [android.content.pm.ApplicationInfo.sourceDir] avoids keeping a second copy of the
+ * large APK in app storage. URI validation is deliberately exact, and all mutation APIs are
+ * rejected. The manifest keeps the provider non-exported; a receiver gets access only through the
+ * temporary read grant attached to the system share intent.
+ */
+class InstalledApkProvider : ContentProvider() {
+    override fun onCreate(): Boolean = true
+
+    override fun getType(uri: Uri): String {
+        requireApk(uri)
+        return InstalledApkShare.APK_MIME_TYPE
+    }
+
+    override fun query(
+        uri: Uri,
+        projection: Array<out String>?,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+        sortOrder: String?,
+    ): Cursor {
+        val apk = requireApk(uri)
+        val requestedColumns = projection ?: DEFAULT_PROJECTION
+        val columns = requestedColumns.filter { it == OpenableColumns.DISPLAY_NAME || it == OpenableColumns.SIZE }
+        val values = columns.map { column ->
+            when (column) {
+                OpenableColumns.DISPLAY_NAME -> InstalledApkShare.displayName()
+                OpenableColumns.SIZE -> apk.length()
+                else -> error("unreachable")
+            }
+        }
+        return MatrixCursor(columns.toTypedArray(), 1).apply {
+            addRow(values)
+        }
+    }
+
+    override fun openFile(uri: Uri, mode: String): ParcelFileDescriptor {
+        if (mode != "r") {
+            throw FileNotFoundException("the shared APK is read-only")
+        }
+        return ParcelFileDescriptor.open(requireApk(uri), ParcelFileDescriptor.MODE_READ_ONLY)
+    }
+
+    override fun insert(uri: Uri, values: ContentValues?): Uri? =
+        throw UnsupportedOperationException("the shared APK is read-only")
+
+    override fun update(
+        uri: Uri,
+        values: ContentValues?,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+    ): Int = throw UnsupportedOperationException("the shared APK is read-only")
+
+    override fun delete(uri: Uri, selection: String?, selectionArgs: Array<out String>?): Int =
+        throw UnsupportedOperationException("the shared APK is read-only")
+
+    private fun requireApk(uri: Uri): File {
+        val providerContext = context ?: throw FileNotFoundException("provider context unavailable")
+        val expectedAuthority = providerContext.packageName + InstalledApkShare.PROVIDER_AUTHORITY_SUFFIX
+        if (
+            uri.scheme != "content" ||
+            uri.authority != expectedAuthority ||
+            uri.pathSegments != listOf(InstalledApkShare.displayName())
+        ) {
+            throw FileNotFoundException("unknown APK URI")
+        }
+        return try {
+            InstalledApkShare.requireShareableApk(providerContext)
+        } catch (error: ApkShareException) {
+            throw FileNotFoundException(error.message).apply { initCause(error) }
+        }
+    }
+
+    private companion object {
+        val DEFAULT_PROJECTION = arrayOf(OpenableColumns.DISPLAY_NAME, OpenableColumns.SIZE)
+    }
+}

--- a/android/app/src/main/java/com/openrung/share/InstalledApkShare.kt
+++ b/android/app/src/main/java/com/openrung/share/InstalledApkShare.kt
@@ -1,0 +1,83 @@
+package com.openrung.share
+
+import android.content.ClipData
+import android.content.ClipDescription
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import com.openrung.BuildConfig
+import java.io.File
+
+/** Builds the tightly-scoped URI and share intent for this app's installed monolithic APK. */
+internal object InstalledApkShare {
+    const val APK_MIME_TYPE = "application/vnd.android.package-archive"
+    const val PROVIDER_AUTHORITY_SUFFIX = ".apk-share"
+
+    fun requireShareableApk(context: Context): File {
+        val applicationInfo = context.applicationInfo
+        return requireShareableApk(applicationInfo.sourceDir, applicationInfo.splitSourceDirs)
+    }
+
+    fun requireShareableApk(sourceDir: String?, splitSourceDirs: Array<String>?): File {
+        if (!splitSourceDirs.isNullOrEmpty()) {
+            throw ApkShareException(
+                error = ApkShareError.SPLIT_INSTALL,
+                message = "the installed app uses split APKs; sharing base.apk alone would be incomplete",
+            )
+        }
+
+        val sourcePath = sourceDir?.takeIf(String::isNotBlank)
+            ?: throw ApkShareException(
+                error = ApkShareError.APK_UNAVAILABLE,
+                message = "the installed APK path is unavailable",
+            )
+        val sourceApk = File(sourcePath)
+        if (!sourceApk.isFile || !sourceApk.canRead()) {
+            throw ApkShareException(
+                error = ApkShareError.APK_UNAVAILABLE,
+                message = "the installed APK is not readable",
+            )
+        }
+        return sourceApk
+    }
+
+    fun displayName(): String {
+        val safeVersion = BuildConfig.VERSION_NAME.replace(Regex("[^A-Za-z0-9._-]"), "_")
+        return "OpenRung-$safeVersion.apk"
+    }
+
+    fun contentUri(context: Context): Uri =
+        Uri.Builder()
+            .scheme("content")
+            .authority(context.packageName + PROVIDER_AUTHORITY_SUFFIX)
+            .appendPath(displayName())
+            .build()
+
+    fun createSendIntent(context: Context): Intent {
+        // Fail before opening the chooser rather than sending an unusable base APK from a split install.
+        requireShareableApk(context)
+        val uri = contentUri(context)
+        return Intent(Intent.ACTION_SEND).apply {
+            type = APK_MIME_TYPE
+            putExtra(Intent.EXTRA_STREAM, uri)
+            clipData = ClipData(
+                ClipDescription(displayName(), arrayOf(APK_MIME_TYPE)),
+                ClipData.Item(uri),
+            )
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+    }
+}
+
+internal enum class ApkShareError(val code: String) {
+    SPLIT_INSTALL("E_SPLIT_APK_INSTALL"),
+    APK_UNAVAILABLE("E_APK_UNAVAILABLE"),
+}
+
+internal class ApkShareException(
+    val error: ApkShareError,
+    message: String,
+) : IllegalStateException(message) {
+    val code: String
+        get() = error.code
+}

--- a/android/app/src/test/java/com/openrung/share/InstalledApkShareTest.kt
+++ b/android/app/src/test/java/com/openrung/share/InstalledApkShareTest.kt
@@ -1,0 +1,152 @@
+package com.openrung.share
+
+import android.app.Application
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.provider.OpenableColumns
+import androidx.core.content.IntentCompat
+import com.openrung.BuildConfig
+import org.junit.After
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import java.io.File
+import java.io.FileNotFoundException
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = Application::class)
+class InstalledApkShareTest {
+    private lateinit var context: Context
+    private lateinit var originalSourceDir: String
+    private var originalSplitSourceDirs: Array<String>? = null
+
+    @Before
+    fun setUp() {
+        context = RuntimeEnvironment.getApplication()
+        originalSourceDir = context.applicationInfo.sourceDir
+        originalSplitSourceDirs = context.applicationInfo.splitSourceDirs
+    }
+
+    @After
+    fun tearDown() {
+        context.applicationInfo.sourceDir = originalSourceDir
+        context.applicationInfo.splitSourceDirs = originalSplitSourceDirs
+    }
+
+    @Test
+    fun `monolithic installed APK is accepted`() {
+        val sourceApk = fakeInstalledApk(byteArrayOf(1, 2, 3, 4))
+
+        assertEquals(
+            sourceApk.canonicalFile,
+            InstalledApkShare.requireShareableApk(sourceApk.path, null).canonicalFile,
+        )
+        assertEquals(
+            sourceApk.canonicalFile,
+            InstalledApkShare.requireShareableApk(sourceApk.path, emptyArray()).canonicalFile,
+        )
+    }
+
+    @Test
+    fun `split install is rejected instead of sharing incomplete base APK`() {
+        val sourceApk = fakeInstalledApk(byteArrayOf(1, 2, 3, 4))
+
+        val error = assertThrows(ApkShareException::class.java) {
+            InstalledApkShare.requireShareableApk(
+                sourceApk.path,
+                arrayOf("/data/app/com.openrung.mobile/split_config.arm64_v8a.apk"),
+            )
+        }
+
+        assertEquals(ApkShareError.SPLIT_INSTALL.code, error.code)
+    }
+
+    @Test
+    fun `missing installed APK is rejected with stable error`() {
+        val error = assertThrows(ApkShareException::class.java) {
+            InstalledApkShare.requireShareableApk("/does/not/exist/base.apk", null)
+        }
+
+        assertEquals(ApkShareError.APK_UNAVAILABLE.code, error.code)
+    }
+
+    @Test
+    fun `share intent carries exact APK URI MIME and temporary read grant`() {
+        fakeInstalledApk(byteArrayOf(9, 8, 7, 6))
+
+        val intent = InstalledApkShare.createSendIntent(context)
+        val uri = IntentCompat.getParcelableExtra(intent, Intent.EXTRA_STREAM, Uri::class.java)
+
+        assertEquals(Intent.ACTION_SEND, intent.action)
+        assertEquals(InstalledApkShare.APK_MIME_TYPE, intent.type)
+        assertEquals(InstalledApkShare.contentUri(context), uri)
+        assertEquals(uri, intent.clipData?.getItemAt(0)?.uri)
+        assertEquals(InstalledApkShare.APK_MIME_TYPE, intent.clipData?.description?.getMimeType(0))
+        assertTrue(intent.flags and Intent.FLAG_GRANT_READ_URI_PERMISSION != 0)
+        assertFalse(intent.flags and Intent.FLAG_GRANT_WRITE_URI_PERMISSION != 0)
+    }
+
+    @Test
+    fun `provider exposes friendly metadata and streams installed APK byte for byte`() {
+        val expectedBytes = byteArrayOf(0x50, 0x4b, 3, 4, 10, 20, 30)
+        fakeInstalledApk(expectedBytes)
+        val uri = InstalledApkShare.contentUri(context)
+
+        assertEquals(InstalledApkShare.APK_MIME_TYPE, context.contentResolver.getType(uri))
+        context.contentResolver.query(uri, null, null, null, null).use { cursor ->
+            assertNotNull(cursor)
+            assertTrue(cursor!!.moveToFirst())
+            assertEquals(
+                "OpenRung-${BuildConfig.VERSION_NAME}.apk",
+                cursor.getString(cursor.getColumnIndexOrThrow(OpenableColumns.DISPLAY_NAME)),
+            )
+            assertEquals(
+                expectedBytes.size.toLong(),
+                cursor.getLong(cursor.getColumnIndexOrThrow(OpenableColumns.SIZE)),
+            )
+        }
+        val actualBytes = context.contentResolver.openInputStream(uri)!!.use { it.readBytes() }
+        assertArrayEquals(expectedBytes, actualBytes)
+    }
+
+    @Test
+    fun `provider is private read-only and rejects every other URI`() {
+        fakeInstalledApk(byteArrayOf(1, 2, 3, 4))
+        val authority = context.packageName + InstalledApkShare.PROVIDER_AUTHORITY_SUFFIX
+        val providerInfo = context.packageManager.resolveContentProvider(
+            authority,
+            PackageManager.GET_META_DATA,
+        )
+        assertNotNull(providerInfo)
+        assertFalse(providerInfo!!.exported)
+        assertTrue(providerInfo.grantUriPermissions)
+
+        val validUri = InstalledApkShare.contentUri(context)
+        assertThrows(FileNotFoundException::class.java) {
+            context.contentResolver.openFileDescriptor(validUri, "w")
+        }
+
+        val unknownUri = validUri.buildUpon().appendPath("private-file").build()
+        assertThrows(FileNotFoundException::class.java) {
+            context.contentResolver.openInputStream(unknownUri)
+        }
+    }
+
+    private fun fakeInstalledApk(bytes: ByteArray): File {
+        val sourceApk = File(context.cacheDir, "installed-test.apk").apply { writeBytes(bytes) }
+        context.applicationInfo.sourceDir = sourceApk.path
+        context.applicationInfo.splitSourceDirs = null
+        return sourceApk
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -9,7 +9,9 @@ A React Native (TypeScript) shell owns all UI and the "app-process" logic of
 the production OpenRung clients, while the entire VPN connect path is a
 verbatim port of the production native code — a Kotlin `VpnService` on
 Android, a Swift `NEPacketTunnelProvider` extension on iOS — exposed to
-TypeScript through one small bridge module, `OpenRungVpn`.
+TypeScript through one small cross-platform bridge module, `OpenRungVpn`.
+Android-only OS integrations, such as installed-APK sharing, use separate
+modules so they do not widen the VPN contract.
 
 ## Division of responsibility
 
@@ -164,6 +166,21 @@ shape (the RN 0.86 bridgeless interop layer handles it):
 
 `src/native/types.ts` is the single source of truth for these types.
 
+### Android-only offline APK sharing
+
+The Settings tab's General section has a "Share OpenRung offline" row that calls
+the separate `OpenRungApkShare` native module. `InstalledApkProvider` exposes
+one exact, read-only `content://` URI for the package's own installed APK and
+the module opens the standard `ACTION_SEND` chooser with a temporary read
+grant. The provider streams `ApplicationInfo.sourceDir` directly, so sharing
+does not keep a second copy of the large APK in app storage.
+
+This path is enabled only for a monolithic installation. If
+`ApplicationInfo.splitSourceDirs` is non-empty, the module rejects the action:
+`sourceDir` is only `base.apk`, and sending it without its configuration splits
+would give the recipient an incomplete app. No storage or package-install
+permission is requested by the sender.
+
 ### The mock
 
 When `NativeModules.OpenRungVpn` is missing (Jest, or Metro attached to a
@@ -206,6 +223,9 @@ are not ported (TS owns them). Key pieces:
   (`openrung_status`).
 - `bridge/OpenRungVpnModule.kt` — implements the contract; collects the
   status store's flow, maps it to a WritableMap, emits events.
+- `bridge/OpenRungApkShareModule.kt` + `share/InstalledApkProvider.kt` —
+  Android-only sharesheet integration for streaming the installed monolithic
+  APK through a narrowly scoped, temporary URI grant.
 - libbox arrives as a git-ignored local AAR (`app/libs/libbox.aar`,
   conditional Gradle file dependency); a `StubProxyEngine` that throws
   "engine not linked" protects checkouts without the AAR.

--- a/ios/OpenRung.xcodeproj/project.pbxproj
+++ b/ios/OpenRung.xcodeproj/project.pbxproj
@@ -675,7 +675,7 @@
 					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
 					"\"$(inherited)\"",
 				);
-				MARKETING_VERSION = 0.2.8;
+				MARKETING_VERSION = 0.2.9;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -817,7 +817,7 @@
 					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
 					"\"$(inherited)\"",
 				);
-				MARKETING_VERSION = 0.2.8;
+				MARKETING_VERSION = 0.2.9;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				OTHER_CPLUSPLUSFLAGS = (

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openrung-mobile-app",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/src/i18n/strings/ar.ts
+++ b/src/i18n/strings/ar.ts
@@ -99,6 +99,13 @@ export const ar: Partial<Strings> = {
   licensesFullTextTitle: 'نصوص التراخيص الكاملة',
   licensesFullTextSubtitle: 'GNU GPL-3.0 وإشعارات الجهات الخارجية.',
   licensesComponentsHeader: 'المكوّنات',
+  shareApkTitle: 'مشاركة OpenRung دون اتصال',
+  shareApkSubtitle: 'أرسل ملف APK هذا إلى هاتف Android قريب دون إنترنت.',
+  shareApkErrorTitle: 'تعذّرت مشاركة OpenRung',
+  shareApkErrorBody:
+    'تعذّرت مشاركة ملف APK. أبقِ OpenRung مفتوحًا وحاول مرة أخرى.',
+  shareApkSplitInstallError:
+    'ثُبّتت هذه النسخة من عدة ملفات APK ولا يمكن مشاركتها بأمان. ثبّت ملف APK المستقل لـ OpenRung لاستخدام المشاركة دون اتصال.',
 
   // Home overlay and about screen.
   homeTagline: 'شبكة المُرحّلات',

--- a/src/i18n/strings/en.ts
+++ b/src/i18n/strings/en.ts
@@ -72,6 +72,13 @@ export const en = {
   licensesFullTextTitle: 'Full license texts',
   licensesFullTextSubtitle: 'GNU GPL-3.0 and third-party notices.',
   licensesComponentsHeader: 'Components',
+  shareApkTitle: 'Share OpenRung offline',
+  shareApkSubtitle: 'Send this APK to a nearby Android phone without internet.',
+  shareApkErrorTitle: 'Unable to share OpenRung',
+  shareApkErrorBody:
+    'The APK could not be shared. Keep OpenRung open and try again.',
+  shareApkSplitInstallError:
+    'This copy was installed as multiple APK files and cannot be shared safely. Install the standalone OpenRung APK to use offline sharing.',
 
   // --- Redesigned shell (tabs, home overlay, about) ---
   tabHome: 'Home',

--- a/src/i18n/strings/fa.ts
+++ b/src/i18n/strings/fa.ts
@@ -98,6 +98,14 @@ export const fa: Partial<Strings> = {
   licensesFullTextTitle: 'متن کامل مجوزها',
   licensesFullTextSubtitle: 'GNU GPL-3.0 و اعلان‌های اشخاص ثالث.',
   licensesComponentsHeader: 'مؤلفه‌ها',
+  shareApkTitle: 'اشتراک‌گذاری آفلاین OpenRung',
+  shareApkSubtitle:
+    'این فایل APK را بدون اینترنت به یک گوشی Android نزدیک بفرستید.',
+  shareApkErrorTitle: 'اشتراک‌گذاری OpenRung ممکن نیست',
+  shareApkErrorBody:
+    'فایل APK قابل اشتراک‌گذاری نبود. OpenRung را باز نگه دارید و دوباره تلاش کنید.',
+  shareApkSplitInstallError:
+    'این نسخه با چند فایل APK نصب شده است و نمی‌توان آن را به‌طور امن به اشتراک گذاشت. برای اشتراک‌گذاری آفلاین، فایل APK مستقل OpenRung را نصب کنید.',
 
   // Home tagline + about screen.
   homeTagline: 'شبکهٔ رله‌ها',

--- a/src/i18n/strings/my.ts
+++ b/src/i18n/strings/my.ts
@@ -108,6 +108,14 @@ export const my: Partial<Strings> = {
   licensesFullTextTitle: 'လိုင်စင် စာသားအပြည့်အစုံ',
   licensesFullTextSubtitle: 'GNU GPL-3.0 နှင့် ပြင်ပ အသိပေးချက်များ။',
   licensesComponentsHeader: 'အစိတ်အပိုင်းများ',
+  shareApkTitle: 'OpenRung ကို အင်တာနက်မလိုဘဲ မျှဝေပါ',
+  shareApkSubtitle:
+    'ဤ APK ကို အင်တာနက်မလိုဘဲ အနီးရှိ Android ဖုန်းသို့ ပို့ပါ။',
+  shareApkErrorTitle: 'OpenRung ကို မျှဝေ၍မရပါ',
+  shareApkErrorBody:
+    'APK ကို မျှဝေ၍မရပါ။ OpenRung ကို ဖွင့်ထားပြီး ထပ်မံကြိုးစားပါ။',
+  shareApkSplitInstallError:
+    'ဤမိတ္တူကို APK ဖိုင်များစွာဖြင့် ထည့်သွင်းထားသဖြင့် လုံခြုံစွာ မျှဝေ၍မရပါ။ အင်တာနက်မလိုဘဲ မျှဝေရန် OpenRung ၏ သီးခြား APK ကို ထည့်သွင်းပါ။',
 
   // Home overlay tagline.
   homeTagline: 'ရီလေး ကွန်ရက်',

--- a/src/i18n/strings/ru.ts
+++ b/src/i18n/strings/ru.ts
@@ -97,6 +97,14 @@ export const ru: Partial<Strings> = {
   licensesFullTextTitle: 'Полные тексты лицензий',
   licensesFullTextSubtitle: 'GNU GPL-3.0 и уведомления третьих сторон.',
   licensesComponentsHeader: 'Компоненты',
+  shareApkTitle: 'Поделиться OpenRung офлайн',
+  shareApkSubtitle:
+    'Отправьте этот APK на ближайший Android-телефон без интернета.',
+  shareApkErrorTitle: 'Не удалось поделиться OpenRung',
+  shareApkErrorBody:
+    'Не удалось поделиться APK. Оставьте OpenRung открытым и повторите попытку.',
+  shareApkSplitInstallError:
+    'Эта копия установлена из нескольких APK и не может быть безопасно передана. Установите отдельный APK OpenRung, чтобы использовать офлайн-обмен.',
 
   // Home overlay / about screen.
   homeTagline: 'сеть ретрансляторов',

--- a/src/i18n/strings/tr.ts
+++ b/src/i18n/strings/tr.ts
@@ -100,6 +100,13 @@ export const tr: Partial<Strings> = {
   licensesFullTextTitle: 'Tam lisans metinleri',
   licensesFullTextSubtitle: 'GNU GPL-3.0 ve üçüncü taraf bildirimleri.',
   licensesComponentsHeader: 'Bileşenler',
+  shareApkTitle: "OpenRung'u çevrimdışı paylaş",
+  shareApkSubtitle:
+    "Bu APK'yı internet olmadan yakındaki bir Android telefona gönderin.",
+  shareApkErrorTitle: 'OpenRung paylaşılamıyor',
+  shareApkErrorBody: "APK paylaşılamadı. OpenRung'u açık tutup tekrar deneyin.",
+  shareApkSplitInstallError:
+    "Bu kopya birden fazla APK dosyasıyla yüklendiği için güvenle paylaşılamaz. Çevrimdışı paylaşım için bağımsız OpenRung APK'sını yükleyin.",
 
   // Home overlay tagline.
   homeTagline: 'röle ağı',

--- a/src/i18n/strings/vi.ts
+++ b/src/i18n/strings/vi.ts
@@ -95,6 +95,14 @@ export const vi: Partial<Strings> = {
   licensesFullTextTitle: 'Toàn văn giấy phép',
   licensesFullTextSubtitle: 'GNU GPL-3.0 và thông báo của bên thứ ba.',
   licensesComponentsHeader: 'Thành phần',
+  shareApkTitle: 'Chia sẻ OpenRung ngoại tuyến',
+  shareApkSubtitle:
+    'Gửi APK này đến một điện thoại Android ở gần mà không cần Internet.',
+  shareApkErrorTitle: 'Không thể chia sẻ OpenRung',
+  shareApkErrorBody:
+    'Không thể chia sẻ APK. Hãy giữ OpenRung đang mở và thử lại.',
+  shareApkSplitInstallError:
+    'Bản này được cài bằng nhiều tệp APK nên không thể chia sẻ an toàn. Hãy cài APK OpenRung độc lập để dùng tính năng chia sẻ ngoại tuyến.',
 
   // Home overlay and about screen.
   homeTagline: 'mạng lưới relay',

--- a/src/i18n/strings/zh-CN.ts
+++ b/src/i18n/strings/zh-CN.ts
@@ -100,6 +100,12 @@ export const zhCN: Partial<Strings> = {
   licensesFullTextTitle: '完整许可文本',
   licensesFullTextSubtitle: 'GNU GPL-3.0 及第三方声明。',
   licensesComponentsHeader: '组件',
+  shareApkTitle: '离线分享 OpenRung',
+  shareApkSubtitle: '无需互联网，将此 APK 发送到附近的 Android 手机。',
+  shareApkErrorTitle: '无法分享 OpenRung',
+  shareApkErrorBody: '无法分享 APK。请保持 OpenRung 打开并重试。',
+  shareApkSplitInstallError:
+    '此版本由多个 APK 文件安装，无法安全分享。请安装 OpenRung 独立 APK 后使用离线分享。',
 
   // Home tagline and about screen.
   homeTagline: '中继网络',

--- a/src/i18n/strings/zh-TW.ts
+++ b/src/i18n/strings/zh-TW.ts
@@ -92,6 +92,12 @@ export const zhTW: Partial<Strings> = {
   licensesFullTextTitle: '完整授權條款全文',
   licensesFullTextSubtitle: 'GNU GPL-3.0 與第三方聲明。',
   licensesComponentsHeader: '元件',
+  shareApkTitle: '離線分享 OpenRung',
+  shareApkSubtitle: '無需網際網路，將此 APK 傳送到附近的 Android 手機。',
+  shareApkErrorTitle: '無法分享 OpenRung',
+  shareApkErrorBody: '無法分享 APK。請保持 OpenRung 開啟並再試一次。',
+  shareApkSplitInstallError:
+    '此版本由多個 APK 檔案安裝，無法安全分享。請安裝 OpenRung 獨立 APK 後使用離線分享。',
 
   // Home tagline + about screen.
   homeTagline: '中繼網路',

--- a/src/native/OpenRungApkShare.ts
+++ b/src/native/OpenRungApkShare.ts
@@ -1,0 +1,33 @@
+import { NativeModules, Platform } from 'react-native';
+
+interface OpenRungApkShareModule {
+  shareApk(chooserTitle: string): Promise<void>;
+}
+
+const nativeModule = (NativeModules as Record<string, unknown>)
+  .OpenRungApkShare as OpenRungApkShareModule | null | undefined;
+
+/** The action is intentionally Android-only and requires a binary with the native module linked. */
+export const isApkShareAvailable =
+  Platform.OS === 'android' && nativeModule != null;
+
+export async function shareInstalledApk(chooserTitle: string): Promise<void> {
+  if (!isApkShareAvailable || nativeModule == null) {
+    const error = new Error(
+      'offline APK sharing is unavailable on this platform',
+    ) as Error & {
+      code?: string;
+    };
+    error.code = 'E_SHARE_UNAVAILABLE';
+    throw error;
+  }
+  await nativeModule.shareApk(chooserTitle);
+}
+
+export function apkShareErrorCode(error: unknown): string | null {
+  if (typeof error !== 'object' || error == null || !('code' in error)) {
+    return null;
+  }
+  const code = (error as { code?: unknown }).code;
+  return typeof code === 'string' ? code : null;
+}

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,18 +1,23 @@
 /**
  * Settings tab. Large title (it's a root tab now — no back arrow), then
- * sectioned panels: GENERAL (language) and DIAGNOSTICS (relay speed test,
- * debug console). Version and licenses live on the About tab. The language
- * picker mirrors the production dropdown semantics with a dark-styled modal
- * list; the speed test RUN button is enabled only while connected and not
- * already running.
+ * sectioned panels: GENERAL (language and Android offline sharing) and
+ * DIAGNOSTICS (relay speed test, debug console). Version and licenses live on
+ * the About tab. The language picker mirrors the production dropdown semantics
+ * with a dark-styled modal list; the speed test RUN button is enabled only
+ * while connected and not already running.
  */
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { Modal, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { Alert, Modal, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { SettingPanel } from '../components/SettingPanel';
 import { AppConfig } from '../config';
 import { languageOptions, useLanguage, useStrings } from '../i18n';
+import {
+  apkShareErrorCode,
+  isApkShareAvailable,
+  shareInstalledApk,
+} from '../native/OpenRungApkShare';
 import { OpenRungVpn } from '../native/OpenRungVpn';
 import { runSpeedTest, type SpeedTestResult } from '../net/speedTestClient';
 import {
@@ -61,6 +66,16 @@ export function SettingsScreen({ onOpenDebug }: SettingsScreenProps): React.JSX.
           : s.speedTestReady;
 
   const runEnabled = isConnected && !speedTestRunning;
+
+  const onShareApk = useCallback(() => {
+    shareInstalledApk(s.shareApkTitle).catch(error => {
+      const message =
+        apkShareErrorCode(error) === 'E_SPLIT_APK_INSTALL'
+          ? s.shareApkSplitInstallError
+          : s.shareApkErrorBody;
+      Alert.alert(s.shareApkErrorTitle, message);
+    });
+  }, [s]);
 
   const onRunSpeedTest = useCallback(() => {
     const controller = new AbortController();
@@ -140,6 +155,13 @@ export function SettingsScreen({ onOpenDebug }: SettingsScreenProps): React.JSX.
         subtitle={s.languageSettingSubtitle}
         trailing={<LanguagePicker />}
       />
+      {isApkShareAvailable ? (
+        <SettingPanel
+          title={s.shareApkTitle}
+          subtitle={s.shareApkSubtitle}
+          onPress={onShareApk}
+        />
+      ) : null}
 
       <Text style={styles.sectionHeader}>{s.settingsDiagnosticsHeader.toUpperCase()}</Text>
       <SettingPanel


### PR DESCRIPTION
## Summary

- Add “Share OpenRung offline” under Settings → General on Android.
- Stream the installed monolithic APK through the system share sheet using a private, read-only content provider and a temporary URI grant.
- Reject split-APK installations so recipients never receive an unusable `base.apk`.
- Localize the flow across all supported languages and add native/UI coverage.
- Document release verification and bump OpenRung to 0.2.9, Android build 10.

## Impact

Users can transfer OpenRung directly to nearby Android devices with Quick Share or compatible OEM transfer apps without internet access or an extra APK copy in app storage.

## Verification

- Hardware-verified offline APK sharing and installation
- Relocated action verified under Settings → General; duplicate About action removed
- `npm test -- --runInBand --forceExit` — 138 tests passed
- `npx tsc --noEmit`
- `npm run lint` — 0 errors
- `npm run version:check`
- Android `:app:testDebugUnitTest :app:assembleDebug`
- `git diff --check`

## Release note

Merging this PR changes `package.json` from 0.2.8 to 0.2.9, which triggers the signed Android v0.2.9 build-10 release workflow.
