### PR TITLE
CI: run Android unit tests for all Android changes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,8 +2,9 @@
 # punchcore/vX.Y.Z (see RELEASE.md "Bumping the punchcore pin"). Scoped to that
 # one module on purpose: sing-box pins its own dependency set (SINGBOX_VERSION
 # is the source of truth for the native engine), so generic bumps here would
-# fight the graft. The bump PR path-matches android-punch-check.yml, which
-# rebuilds the AAR from scratch and runs the Android unit tests against it.
+# fight the graft. The bump PR path-matches android-unit-test.yml; changes to
+# go.mod/go.sum invalidate the AAR cache, so CI rebuilds the AAR and runs the
+# Android unit tests against it.
 version: 2
 updates:
   - package-ecosystem: gomod

--- a/.github/workflows/android-punch-check.yml
+++ b/.github/workflows/android-punch-check.yml
@@ -5,18 +5,6 @@ on:
     paths:
       - 'android/punchbridge/**'
       - 'android/build-libbox-release.sh'
-      - 'android/app/src/main/java/com/openrung/config/AppConfig.kt'
-      - 'android/app/src/main/java/com/openrung/model/RelayDescriptor.kt'
-      - 'android/app/src/main/java/com/openrung/net/NatPunchClient.kt'
-      - 'android/app/src/main/java/com/openrung/net/InternetProbe.kt'
-      - 'android/app/src/main/java/com/openrung/net/SingBoxConfiguration.kt'
-      - 'android/app/src/main/java/com/openrung/vpn/OpenRungVpnService.kt'
-      - 'android/app/src/main/java/com/openrung/vpn/PunchRecoveryCircuitBreaker.kt'
-      - 'android/app/src/test/java/com/openrung/model/RelayDescriptorPunchTest.kt'
-      - 'android/app/src/test/java/com/openrung/net/NatPunchClientTest.kt'
-      - 'android/app/src/test/java/com/openrung/net/SingBoxConfigurationPunchTest.kt'
-      - 'android/app/src/test/java/com/openrung/vpn/PunchRecoveryCircuitBreakerTest.kt'
-      - 'android/app/src/main/res/values/strings.xml'
       - 'SINGBOX_VERSION'
       - '.github/workflows/android-punch-check.yml'
   push:
@@ -24,18 +12,6 @@ on:
     paths:
       - 'android/punchbridge/**'
       - 'android/build-libbox-release.sh'
-      - 'android/app/src/main/java/com/openrung/config/AppConfig.kt'
-      - 'android/app/src/main/java/com/openrung/model/RelayDescriptor.kt'
-      - 'android/app/src/main/java/com/openrung/net/NatPunchClient.kt'
-      - 'android/app/src/main/java/com/openrung/net/InternetProbe.kt'
-      - 'android/app/src/main/java/com/openrung/net/SingBoxConfiguration.kt'
-      - 'android/app/src/main/java/com/openrung/vpn/OpenRungVpnService.kt'
-      - 'android/app/src/main/java/com/openrung/vpn/PunchRecoveryCircuitBreaker.kt'
-      - 'android/app/src/test/java/com/openrung/model/RelayDescriptorPunchTest.kt'
-      - 'android/app/src/test/java/com/openrung/net/NatPunchClientTest.kt'
-      - 'android/app/src/test/java/com/openrung/net/SingBoxConfigurationPunchTest.kt'
-      - 'android/app/src/test/java/com/openrung/vpn/PunchRecoveryCircuitBreakerTest.kt'
-      - 'android/app/src/main/res/values/strings.xml'
       - 'SINGBOX_VERSION'
       - '.github/workflows/android-punch-check.yml'
 
@@ -51,45 +27,3 @@ jobs:
       - name: Test punch protocol and gomobile binding
         working-directory: android/punchbridge
         run: go test -race ./...
-
-  android-integration:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: npm
-      - run: npm ci
-      - uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: '17'
-      - uses: actions/setup-go@v5
-        with:
-          go-version: '1.25.x'
-          cache-dependency-path: android/punchbridge/go.sum
-      - uses: android-actions/setup-android@v3
-      - name: Install Android NDKs
-        run: sdkmanager "ndk;29.0.14206865" "ndk;27.1.12297006"
-      - name: Cache combined libbox AAR
-        id: libbox
-        uses: actions/cache@v4
-        with:
-          path: android/app/libs/libbox.aar
-          key: libbox-${{ hashFiles('SINGBOX_VERSION', 'android/build-libbox-release.sh', 'android/punchbridge/**/*.go', 'android/punchbridge/go.mod', 'android/punchbridge/go.sum') }}
-      - name: Install gomobile
-        if: steps.libbox.outputs.cache-hit != 'true'
-        run: |
-          go install github.com/sagernet/gomobile/cmd/gomobile@v0.1.12
-          go install github.com/sagernet/gomobile/cmd/gobind@v0.1.12
-      - name: Build combined libbox AAR
-        if: steps.libbox.outputs.cache-hit != 'true'
-        run: |
-          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/29.0.14206865"
-          export ANDROID_NDK_ROOT="$ANDROID_HOME/ndk/29.0.14206865"
-          bash android/build-libbox-release.sh
-      - uses: gradle/actions/setup-gradle@v4
-      - name: Compile integration and run Android unit tests
-        working-directory: android
-        run: ./gradlew --no-daemon :app:testDebugUnitTest

--- a/.github/workflows/android-unit-test.yml
+++ b/.github/workflows/android-unit-test.yml
@@ -1,0 +1,68 @@
+name: Android app unit tests
+
+on:
+  pull_request:
+    paths:
+      - 'android/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'react-native.config.js'
+      - 'SINGBOX_VERSION'
+      - '.github/workflows/android-unit-test.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'android/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'react-native.config.js'
+      - 'SINGBOX_VERSION'
+      - '.github/workflows/android-unit-test.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  android-unit-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+      - run: npm ci
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25.x'
+          cache-dependency-path: android/punchbridge/go.sum
+      - uses: android-actions/setup-android@v3
+      - name: Install Android NDKs
+        run: sdkmanager "ndk;29.0.14206865" "ndk;27.1.12297006"
+      - name: Cache combined libbox AAR
+        id: libbox
+        uses: actions/cache@v4
+        with:
+          path: android/app/libs/libbox.aar
+          key: libbox-${{ hashFiles('SINGBOX_VERSION', 'android/build-libbox-release.sh', 'android/punchbridge/**/*.go', 'android/punchbridge/go.mod', 'android/punchbridge/go.sum') }}
+      - name: Install gomobile
+        if: steps.libbox.outputs.cache-hit != 'true'
+        run: |
+          go install github.com/sagernet/gomobile/cmd/gomobile@v0.1.12
+          go install github.com/sagernet/gomobile/cmd/gobind@v0.1.12
+      - name: Build combined libbox AAR
+        if: steps.libbox.outputs.cache-hit != 'true'
+        run: |
+          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/29.0.14206865"
+          export ANDROID_NDK_ROOT="$ANDROID_HOME/ndk/29.0.14206865"
+          bash android/build-libbox-release.sh
+      - uses: gradle/actions/setup-gradle@v4
+      - name: Compile app and run Android unit tests
+        working-directory: android
+        run: ./gradlew --no-daemon :app:testDebugUnitTest --stacktrace

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -51,7 +51,7 @@ A punch wire/protocol change flows like this:
    `android/punchbridge`. Either way the bump automatically busts the AAR CI
    caches (both cache keys hash `go.mod`/`go.sum`), and the bump PR itself
    rebuilds the AAR and runs the Android unit tests via
-   `android-punch-check.yml`.
+   `.github/workflows/android-unit-test.yml`.
 4. Rebuild the AAR via `android/build-libbox-release.sh` and ship.
 
 For local cross-repo development against an untagged punchcore checkout, use an


### PR DESCRIPTION
## Summary

- add a standalone Android app unit-test workflow for all `android/**` changes
- preserve the existing Node, Java, Go, Android SDK, NDK, and libbox setup
- move `:app:testDebugUnitTest` out of the NAT-punch workflow so it has one CI owner
- keep the NAT-punch workflow focused on Go race tests

## Why

The existing Android unit-test job is only scheduled when an explicit NAT-punch path allowlist matches. Android changes outside that list, including the offline APK sharing tests in #46, therefore do not run in CI.

The new workflow uses a broad `android/**` trigger plus the root build inputs it depends on, so future Kotlin source and test changes are covered automatically.

## Validation

- parsed both workflow files as YAML
- verified both workflow files with Prettier
- verified the staged diff with `git diff --cached --check`
- verified `:app:testDebugUnitTest` has exactly one workflow owner

## Follow-up

After this merges, synchronize or rebase #46 onto `main` so GitHub evaluates the new workflow against its Android changes. JavaScript/Jest CI remains separate from this PR.
