### PR TITLE
CI: run Jest tests on every pull request

### DIFF
--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -1,0 +1,24 @@
+name: Jest unit tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  jest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+      - run: npm ci
+      - name: Run Jest tests
+        run: npm test -- --ci --runInBand

--- a/__tests__/App.test.tsx
+++ b/__tests__/App.test.tsx
@@ -136,6 +136,7 @@ jest.mock('react-native-bottom-tabs', () => {
 });
 
 import App from '../App';
+import { AppConfig } from '../src/config';
 
 // Keep the directory refresh (broker fetch) off the real network: reject fast so
 // the store settles to 'failed' within the test instead of after teardown.
@@ -146,17 +147,26 @@ beforeAll(() => {
 });
 
 test('renders correctly', async () => {
+  jest.useFakeTimers();
   let tree: ReactTestRenderer.ReactTestRenderer | undefined;
-  await ReactTestRenderer.act(async () => {
-    tree = ReactTestRenderer.create(<App />);
-  });
-  // Let mount-time async work settle inside act: native getState() seed,
-  // language hydration, and the (stubbed, rejecting) directory load.
-  await ReactTestRenderer.act(async () => {
-    await Promise.resolve();
-  });
-  // Unmount so nothing can schedule React updates after the test ends.
-  await ReactTestRenderer.act(async () => {
-    tree?.unmount();
-  });
+  try {
+    await ReactTestRenderer.act(async () => {
+      tree = ReactTestRenderer.create(<App />);
+    });
+    // Let mount-time async work settle inside act: native getState() seed,
+    // language hydration, and every staggered broker candidate. The fetch mock
+    // rejects each candidate immediately, but later candidates still wait for
+    // the production stagger timer before joining the race.
+    await ReactTestRenderer.act(async () => {
+      await jest.advanceTimersByTimeAsync(
+        AppConfig.DISCOVERY_STAGGER_MS * AppConfig.DEFAULT_BROKER_URLS.length,
+      );
+    });
+  } finally {
+    // Unmount so component timers cannot schedule updates after the test ends.
+    await ReactTestRenderer.act(async () => {
+      tree?.unmount();
+    });
+    jest.useRealTimers();
+  }
 });


### PR DESCRIPTION
## Summary

- add a standalone Jest workflow for every pull request and push to `main`
- use Node 22, the npm dependency cache, `npm ci`, and a 10-minute timeout
- run the complete suite in CI mode and in-band so asynchronous teardown failures are visible
- settle the App render test's staggered broker fallback timer before unmount

## Why

The repository has JavaScript and TypeScript tests, but no GitHub Actions workflow currently runs `npm test`. This workflow intentionally has no path filter: the suite is inexpensive, its inputs span application code, configuration, fixtures, and tests, and an allowlist could silently make the guard decorative again.

The App render test previously left a broker fallback timer alive after all assertions passed. The test-only fake-timer cleanup lets strict in-band CI finish deterministically without `--forceExit` or production changes.

## Validation

- `npm ci`
- `npm test -- --ci --runInBand` — 11 suites, 138 tests passed
- `npm test -- --ci --runInBand --detectOpenHandles` — passed with no leaked handles
- `npx tsc --noEmit`
- `npm run version:check`
- workflow YAML parse and Prettier check
- `git diff --cached --check`

Existing React test-renderer `act()` warnings in the RelayList and OceanTelemetry suites remain visible; this PR does not suppress them.
