### PR TITLE
CI: enforce JavaScript lint and TypeScript checks

### DIFF
--- a/.github/workflows/javascript-quality.yml
+++ b/.github/workflows/javascript-quality.yml
@@ -1,0 +1,37 @@
+name: JavaScript quality checks
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+      - run: npm ci
+      - name: Run ESLint
+        run: npm run lint
+
+  typecheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+      - run: npm ci
+      - name: Run TypeScript typecheck
+        run: npx tsc --noEmit


### PR DESCRIPTION
## Summary

- add standalone JavaScript quality checks for every pull request and push to `main`
- run ESLint and TypeScript as independent parallel jobs
- use Node 22, npm caching, `npm ci`, read-only permissions, and 10-minute timeouts
- avoid path filters so application, configuration, fixture, and test changes cannot bypass the checks

## Why

Jest now runs in CI, but `npm run lint` and `npx tsc --noEmit` were still local-only claims. This workflow makes both commands visible, repeatable CI checks on every future PR.

The jobs are separate so a lint failure does not hide TypeScript diagnostics, and either check can block independently.

## Validation

- `npm ci`
- `npm run lint` — exits successfully with 0 errors and 4 existing warnings
- `npx tsc --noEmit`
- `npm run version:check`
- workflow YAML parse and Prettier check
- `git diff --cached --check`

This PR deliberately preserves the current lint semantics. It does not add `--max-warnings=0`; making the four existing warnings fatal should be paired with fixing or explicitly baselining them.
