### PR TITLE
Disclose iOS beta telemetry and add privacy policy link

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -117,7 +117,29 @@ installed independently on the receiving phone. Complete one offline
 phone-to-phone transfer and verify the received APK's SHA-256 and signing
 certificate against the original release artifact before publishing.
 
-## 4. App Store / DRM caveat (must be resolved separately)
+## 4. Verify Apple privacy disclosures
+
+Before every TestFlight or App Store submission, confirm the public policy at
+`https://www.openrung.org/privacy` still matches the shipping iOS telemetry.
+Then update and publish the App Privacy answers in App Store Connect. The
+answers must match [`ios/OpenRung/PrivacyInfo.xcprivacy`](ios/OpenRung/PrivacyInfo.xcprivacy):
+
+| App Store Connect data type | Current iOS beta data | Linked to user | Purposes |
+| --- | --- | --- | --- |
+| Coarse Location | IP-derived country and city | Yes | App Functionality; Analytics |
+| Device ID | Persistent installation ID plus connection/session/event IDs linked to it | Yes | App Functionality; Analytics |
+| Product Interaction | Connection attempts and outcomes, relay choice, manual speed tests | Yes | App Functionality; Analytics |
+| Other Usage Data | Session/connection duration, heartbeats, and cumulative traffic totals | Yes | App Functionality; Analytics |
+| Performance Data | Broker, relay, tunnel, probe, and speed-test timings | Yes | App Functionality; Analytics |
+| Other Diagnostic Data | Failure details plus app, OS, device, and network diagnostics | Yes | App Functionality; Analytics |
+| Other Data Types | Public/source IP, provider/organization/ASN, locale, time zone, and network state | Yes | App Functionality; Analytics |
+
+All current types are **not used for tracking**. Also set the App Store Connect
+Privacy Policy URL to `https://www.openrung.org/privacy`. If the telemetry
+schema changes, update the manifest, this table, the public policy, and App
+Store Connect together before distributing the new build.
+
+## 5. App Store / DRM caveat (must be resolved separately)
 
 Distributing a GPL-linked binary through the App Store (and likely external
 TestFlight) conflicts with Apple's Usage Rules / DRM under GPL §6/§10. This is
@@ -125,7 +147,7 @@ TestFlight) conflicts with Apple's Usage Rules / DRM under GPL §6/§10. This is
 either obtain a licensing exception from SagerNet for sing-box or move the
 engine out-of-process. Google Play does not have the equivalent conflict.
 
-## 5. Retention
+## 6. Retention
 
 OpenRung provides the corresponding source for at least **three (3) years**
 after distribution. Keep the tagged commit (including `android/punchbridge`) +
@@ -135,7 +157,7 @@ the `openrung/openrung` repository recorded in `android/punchbridge/go.mod`)
 reachable for that long. This extends the 3-year retention promise to the
 `openrung/openrung` repository's tagged history.
 
-## 6. Bumping the app version
+## 7. Bumping the app version
 
 The version **string** lives in exactly one place — `version` in
 [`package.json`](package.json). Everything else derives from it, so never edit

--- a/__tests__/screens/SettingsScreen.test.tsx
+++ b/__tests__/screens/SettingsScreen.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactTestRenderer from 'react-test-renderer';
-import { Alert, Text } from 'react-native';
+import { Alert, Linking, Text } from 'react-native';
 
 const mockShareInstalledApk = jest.fn<Promise<void>, [string]>();
 
@@ -126,6 +126,27 @@ describe('SettingsScreen Android APK sharing', () => {
       .findAllByType(Text)
       .some(text => text.props.children === 'Share OpenRung offline');
     expect(hasShareAction).toBe(false);
+    await unmount(tree!);
+  });
+});
+
+describe('AboutScreen links', () => {
+  it('opens the privacy policy from the About tab', async () => {
+    const openURL = jest.spyOn(Linking, 'openURL').mockResolvedValue(undefined);
+    let tree: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(async () => {
+      tree = ReactTestRenderer.create(
+        <AboutScreen onOpenLicenses={jest.fn()} />,
+      );
+    });
+
+    await ReactTestRenderer.act(async () => {
+      findButton(tree!, 'Privacy policy').props.onPress();
+      await Promise.resolve();
+    });
+
+    expect(openURL).toHaveBeenCalledWith('https://www.openrung.org/privacy');
+    openURL.mockRestore();
     await unmount(tree!);
   });
 });

--- a/ios/OpenRung/PrivacyInfo.xcprivacy
+++ b/ios/OpenRung/PrivacyInfo.xcprivacy
@@ -17,7 +17,7 @@
 			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
-				<string>CA92.1</string>
+				<string>1C8F.1</string>
 			</array>
 		</dict>
 		<dict>
@@ -30,7 +30,99 @@
 		</dict>
 	</array>
 	<key>NSPrivacyCollectedDataTypes</key>
-	<array/>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeCoarseLocation</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeDeviceID</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeProductInteraction</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherUsageData</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypePerformanceData</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDiagnosticData</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
 	<key>NSPrivacyTracking</key>
 	<false/>
 </dict>

--- a/src/config.ts
+++ b/src/config.ts
@@ -119,6 +119,9 @@ export const AppConfig = {
    */
   SOURCE_URL: 'https://github.com/openrung/openrung-mobile-app',
 
+  /** Public policy covering app and network data handling. */
+  PRIVACY_URL: 'https://www.openrung.org/privacy',
+
   /**
    * Vector tiles + glyphs for the exit-node map. We build our own flat style around these MapLibre
    * demo tiles rather than using the demo *style*, which colour-codes every country. An operator

--- a/src/i18n/strings/ar.ts
+++ b/src/i18n/strings/ar.ts
@@ -96,6 +96,9 @@ export const ar: Partial<Strings> = {
   licensesIntro:
     'OpenRung برمجية حرة مُرخّصة بموجب GPL-3.0-or-later لأنها ترتبط بـ sing-box. الكود المصدري الكامل المقابل لهذا الإصدار متاح عبر الرابط أدناه.',
   licensesSourceTitle: 'الكود المصدري',
+  privacyPolicyTitle: 'سياسة الخصوصية',
+  privacyPolicySubtitle:
+    'كيفية تعامل OpenRung مع بيانات تشخيص النسخة التجريبية والمعلومات الشخصية.',
   licensesFullTextTitle: 'نصوص التراخيص الكاملة',
   licensesFullTextSubtitle: 'GNU GPL-3.0 وإشعارات الجهات الخارجية.',
   licensesComponentsHeader: 'المكوّنات',

--- a/src/i18n/strings/en.ts
+++ b/src/i18n/strings/en.ts
@@ -69,6 +69,8 @@ export const en = {
   licensesIntro:
     'OpenRung is free software licensed under GPL-3.0-or-later because it links sing-box. The complete corresponding source for this build is available at the link below.',
   licensesSourceTitle: 'Source code',
+  privacyPolicyTitle: 'Privacy policy',
+  privacyPolicySubtitle: 'How OpenRung handles beta diagnostics and personal information.',
   licensesFullTextTitle: 'Full license texts',
   licensesFullTextSubtitle: 'GNU GPL-3.0 and third-party notices.',
   licensesComponentsHeader: 'Components',

--- a/src/i18n/strings/fa.ts
+++ b/src/i18n/strings/fa.ts
@@ -95,6 +95,9 @@ export const fa: Partial<Strings> = {
   licensesIntro:
     'OpenRung نرم‌افزار آزاد است و چون به sing-box پیوند می‌خورد، تحت مجوز GPL-3.0-or-later منتشر شده است. کد منبع کامل و متناظر این نسخه از طریق پیوند زیر در دسترس است.',
   licensesSourceTitle: 'کد منبع',
+  privacyPolicyTitle: 'سیاست حفظ حریم خصوصی',
+  privacyPolicySubtitle:
+    'نحوهٔ مدیریت داده‌های تشخیصی نسخهٔ آزمایشی و اطلاعات شخصی توسط OpenRung.',
   licensesFullTextTitle: 'متن کامل مجوزها',
   licensesFullTextSubtitle: 'GNU GPL-3.0 و اعلان‌های اشخاص ثالث.',
   licensesComponentsHeader: 'مؤلفه‌ها',

--- a/src/i18n/strings/my.ts
+++ b/src/i18n/strings/my.ts
@@ -105,6 +105,9 @@ export const my: Partial<Strings> = {
   licensesIntro:
     'OpenRung သည် sing-box ကို ချိတ်ဆက်အသုံးပြုသောကြောင့် GPL-3.0-or-later အောက်တွင် လိုင်စင်ရရှိထားသော အခမဲ့ဆော့ဖ်ဝဲ ဖြစ်သည်။ ဤ build အတွက် ပြည့်စုံသော သက်ဆိုင်ရာ အရင်းအမြစ်ကုဒ်ကို အောက်ပါ လင့်ခ်တွင် ရယူနိုင်သည်။',
   licensesSourceTitle: 'အရင်းအမြစ်ကုဒ်',
+  privacyPolicyTitle: 'ကိုယ်ရေးအချက်အလက် မူဝါဒ',
+  privacyPolicySubtitle:
+    'OpenRung သည် beta စမ်းသပ်မှုဆိုင်ရာ အမှားရှာဖွေဒေတာနှင့် ကိုယ်ရေးအချက်အလက်များကို ကိုင်တွယ်ပုံ။',
   licensesFullTextTitle: 'လိုင်စင် စာသားအပြည့်အစုံ',
   licensesFullTextSubtitle: 'GNU GPL-3.0 နှင့် ပြင်ပ အသိပေးချက်များ။',
   licensesComponentsHeader: 'အစိတ်အပိုင်းများ',

--- a/src/i18n/strings/ru.ts
+++ b/src/i18n/strings/ru.ts
@@ -94,6 +94,9 @@ export const ru: Partial<Strings> = {
   licensesIntro:
     'OpenRung — свободное программное обеспечение под лицензией GPL-3.0-or-later, поскольку использует sing-box. Полный соответствующий исходный код этой сборки доступен по ссылке ниже.',
   licensesSourceTitle: 'Исходный код',
+  privacyPolicyTitle: 'Политика конфиденциальности',
+  privacyPolicySubtitle:
+    'Как OpenRung обрабатывает диагностические данные бета-версии и персональную информацию.',
   licensesFullTextTitle: 'Полные тексты лицензий',
   licensesFullTextSubtitle: 'GNU GPL-3.0 и уведомления третьих сторон.',
   licensesComponentsHeader: 'Компоненты',

--- a/src/i18n/strings/tr.ts
+++ b/src/i18n/strings/tr.ts
@@ -97,6 +97,9 @@ export const tr: Partial<Strings> = {
   licensesIntro:
     "OpenRung, sing-box'a bağlandığı için GPL-3.0-or-later ile lisanslanan özgür bir yazılımdır. Bu derlemeye karşılık gelen eksiksiz kaynak kodu aşağıdaki bağlantıda mevcuttur.",
   licensesSourceTitle: 'Kaynak kodu',
+  privacyPolicyTitle: 'Gizlilik politikası',
+  privacyPolicySubtitle:
+    "OpenRung'un beta tanılama verilerini ve kişisel bilgileri nasıl işlediği.",
   licensesFullTextTitle: 'Tam lisans metinleri',
   licensesFullTextSubtitle: 'GNU GPL-3.0 ve üçüncü taraf bildirimleri.',
   licensesComponentsHeader: 'Bileşenler',

--- a/src/i18n/strings/vi.ts
+++ b/src/i18n/strings/vi.ts
@@ -92,6 +92,9 @@ export const vi: Partial<Strings> = {
   licensesIntro:
     'OpenRung là phần mềm tự do được cấp phép theo GPL-3.0-or-later vì nó liên kết sing-box. Toàn bộ mã nguồn tương ứng của bản dựng này có sẵn tại liên kết bên dưới.',
   licensesSourceTitle: 'Mã nguồn',
+  privacyPolicyTitle: 'Chính sách quyền riêng tư',
+  privacyPolicySubtitle:
+    'Cách OpenRung xử lý dữ liệu chẩn đoán bản beta và thông tin cá nhân.',
   licensesFullTextTitle: 'Toàn văn giấy phép',
   licensesFullTextSubtitle: 'GNU GPL-3.0 và thông báo của bên thứ ba.',
   licensesComponentsHeader: 'Thành phần',

--- a/src/i18n/strings/zh-CN.ts
+++ b/src/i18n/strings/zh-CN.ts
@@ -97,6 +97,8 @@ export const zhCN: Partial<Strings> = {
   licensesIntro:
     'OpenRung 是自由软件，依据 GPL-3.0-or-later 授权，因为它链接了 sing-box。本次构建的完整对应源代码可通过下方链接获取。',
   licensesSourceTitle: '源代码',
+  privacyPolicyTitle: '隐私政策',
+  privacyPolicySubtitle: 'OpenRung 如何处理测试版诊断数据和个人信息。',
   licensesFullTextTitle: '完整许可文本',
   licensesFullTextSubtitle: 'GNU GPL-3.0 及第三方声明。',
   licensesComponentsHeader: '组件',

--- a/src/i18n/strings/zh-TW.ts
+++ b/src/i18n/strings/zh-TW.ts
@@ -89,6 +89,8 @@ export const zhTW: Partial<Strings> = {
   licensesIntro:
     'OpenRung 是自由軟體；由於連結了 sing-box，因此依 GPL-3.0-or-later 授權。此版本的完整對應原始碼可透過下方連結取得。',
   licensesSourceTitle: '原始碼',
+  privacyPolicyTitle: '隱私權政策',
+  privacyPolicySubtitle: 'OpenRung 如何處理測試版診斷資料與個人資訊。',
   licensesFullTextTitle: '完整授權條款全文',
   licensesFullTextSubtitle: 'GNU GPL-3.0 與第三方聲明。',
   licensesComponentsHeader: '元件',

--- a/src/screens/AboutScreen.tsx
+++ b/src/screens/AboutScreen.tsx
@@ -39,6 +39,12 @@ export function AboutScreen({ onOpenLicenses }: AboutScreenProps): React.JSX.Ele
     });
   }, []);
 
+  const onOpenPrivacy = useCallback(() => {
+    Linking.openURL(AppConfig.PRIVACY_URL).catch(() => {
+      // Ignore: no browser available.
+    });
+  }, []);
+
   return (
     <ScrollView
       style={styles.root}
@@ -81,6 +87,11 @@ export function AboutScreen({ onOpenLicenses }: AboutScreenProps): React.JSX.Ele
         title={s.licensesSourceTitle}
         subtitle={AppConfig.SOURCE_URL}
         onPress={onOpenSource}
+      />
+      <SettingPanel
+        title={s.privacyPolicyTitle}
+        subtitle={s.privacyPolicySubtitle}
+        onPress={onOpenPrivacy}
       />
       <SettingPanel
         title={s.licensesSettingTitle}


### PR DESCRIPTION
## Summary

- add a localized, one-tap privacy-policy link to the root About tab
- declare the linked location, identifier, usage, performance, diagnostic, and network data collected by the iOS beta; keep tracking disabled
- correct the UserDefaults required-reason code for app-group sharing
- document the matching App Store Connect privacy answers and policy URL in the release checklist

## Verification

- npm test -- --runInBand (139 tests)
- npx --no-install tsc --noEmit
- npm run lint (0 errors; 4 existing warnings)
- npm run version:check
- plutil -lint ios/OpenRung/PrivacyInfo.xcprivacy
- git diff --check

Full Xcode build not run because the generated, git-ignored Libbox.xcframework is not present in this worktree; the edited manifest is already wired into the app target and validates as a plist.