### PR TITLE
Bump app version to 0.3.0

### DIFF
--- a/ios/OpenRung.xcodeproj/project.pbxproj
+++ b/ios/OpenRung.xcodeproj/project.pbxproj
@@ -675,7 +675,7 @@
 					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
 					"\"$(inherited)\"",
 				);
-				MARKETING_VERSION = 0.2.9;
+				MARKETING_VERSION = 0.3.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -817,7 +817,7 @@
 					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
 					"\"$(inherited)\"",
 				);
-				MARKETING_VERSION = 0.2.9;
+				MARKETING_VERSION = 0.3.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				OTHER_CPLUSPLUSFLAGS = (

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openrung-mobile-app",
-  "version": "0.2.5",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openrung-mobile-app",
-      "version": "0.2.5",
+      "version": "0.3.0",
       "dependencies": {
         "@maplibre/maplibre-react-native": "^11.3.6",
         "@noble/ed25519": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openrung-mobile-app",
-  "version": "0.2.9",
+  "version": "0.3.0",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
## Summary

- bump the single-sourced app version to 0.3.0
- sync the package lockfile root version
- regenerate the checked-in iOS MARKETING_VERSION

## Verification

- npm test -- --runInBand (139 tests)
- npx --no-install tsc --noEmit
- npm run lint (0 errors; 4 existing warnings)
- npm run version:check
- plutil -lint ios/OpenRung/PrivacyInfo.xcprivacy
- git diff --check