### PR TITLE
Prepare iOS 0.3.0 build 8 for TestFlight

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -198,9 +198,9 @@ production app:
 | --- | --- | --- |
 | Android applicationId | `com.openrung.client` | `com.openrung.mobile` |
 | Kotlin root package | `com.openrung.client` | `com.openrung` |
-| iOS app / extension | `com.openrung.client(.PacketTunnel)` | `com.openrung.mobile(.PacketTunnel)` |
-| App group | `group.com.openrung.client` | `group.com.openrung.mobile` |
-| Darwin notification | `com.openrung.client.state-changed` | `com.openrung.mobile.state-changed` |
+| iOS app / extension | `com.openrung.client(.PacketTunnel)` | `com.openrung.app(.PacketTunnel)` |
+| App group | `group.com.openrung.client` | `group.com.openrung.app` |
+| Darwin notification | `com.openrung.client.state-changed` | `com.openrung.app.state-changed` |
 
 ## Android native (§6)
 

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -40,13 +40,13 @@ NOT that the OS blocks traffic while the VPN is down.
 | Android applicationId | `com.openrung.mobile` |
 | Android namespace / Kotlin root package | `com.openrung` |
 | Android minSdk / compile / target | 26 / 36 / 36 (minSdk raised from RN default 24) |
-| iOS app bundle id | `com.openrung.mobile` |
-| iOS extension bundle id | `com.openrung.mobile.PacketTunnel` |
-| iOS app group | `group.com.openrung.mobile` |
+| iOS app bundle id | `com.openrung.app` |
+| iOS extension bundle id | `com.openrung.app.PacketTunnel` |
+| iOS app group | `group.com.openrung.app` |
 | iOS VPN profile localizedDescription | `OpenRung VPN` |
 | iOS deployment target | 16.0 |
 | DEVELOPMENT_TEAM | `9VLV9A7KS9` |
-| Darwin notification (ext→app) | `com.openrung.mobile.state-changed` |
+| Darwin notification (ext→app) | `com.openrung.app.state-changed` |
 
 The production identifiers (`com.openrung.client`, `group.com.openrung.client`,
 `com.openrung.client.state-changed`) are NOT reused so both apps install

--- a/ios/OpenRung.xcodeproj/project.pbxproj
+++ b/ios/OpenRung.xcodeproj/project.pbxproj
@@ -583,7 +583,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.openrung.mobile;
+				PRODUCT_BUNDLE_IDENTIFIER = com.openrung.app;
 				PRODUCT_NAME = OpenRung;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -603,7 +603,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.openrung.mobile.OpenRungTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.openrung.app.OpenRungTests;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -644,7 +644,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 8;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = 9VLV9A7KS9;
 				ENABLE_BITCODE = NO;
@@ -711,7 +711,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.openrung.mobile;
+				PRODUCT_BUNDLE_IDENTIFIER = com.openrung.app;
 				PRODUCT_NAME = OpenRung;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -731,7 +731,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.openrung.mobile.OpenRungTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.openrung.app.OpenRungTests;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -752,7 +752,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.openrung.mobile.PacketTunnel;
+				PRODUCT_BUNDLE_IDENTIFIER = com.openrung.app.PacketTunnel;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -793,7 +793,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 8;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = 9VLV9A7KS9;
 				ENABLE_NS_ASSERTIONS = NO;
@@ -852,7 +852,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.openrung.mobile.PacketTunnel;
+				PRODUCT_BUNDLE_IDENTIFIER = com.openrung.app.PacketTunnel;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/ios/OpenRung/OpenRung.entitlements
+++ b/ios/OpenRung/OpenRung.entitlements
@@ -8,7 +8,7 @@
 	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.com.openrung.mobile</string>
+		<string>group.com.openrung.app</string>
 	</array>
 </dict>
 </plist>

--- a/ios/PacketTunnel/PacketTunnel.entitlements
+++ b/ios/PacketTunnel/PacketTunnel.entitlements
@@ -8,7 +8,7 @@
 	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.com.openrung.mobile</string>
+		<string>group.com.openrung.app</string>
 	</array>
 </dict>
 </plist>

--- a/ios/Shared/AppConfig.swift
+++ b/ios/Shared/AppConfig.swift
@@ -4,8 +4,8 @@ enum AppConfig {
     static let vpnProfileName = "OpenRung VPN"
     // Recognized only to adopt an existing pre-rename profile without creating a duplicate.
     static let legacyVPNProfileName = "OpenRung Volunteer VPN"
-    static let appGroupIdentifier = "group.com.openrung.mobile"
-    static let packetTunnelBundleIdentifier = "com.openrung.mobile.PacketTunnel"
+    static let appGroupIdentifier = "group.com.openrung.app"
+    static let packetTunnelBundleIdentifier = "com.openrung.app.PacketTunnel"
     static let providerBrokerURLKey = "broker_url"
     static let providerTargetCountryKey = "target_country"
     static let providerTargetRelayIDKey = "target_relay_id"
@@ -88,14 +88,14 @@ enum AppConfig {
     /// RN/Kotlin AppConfigs — the staggered-race semantics are identical across all four clients.
     static let discoveryStaggerMs: UInt64 = 2_500
 
-    static let loggingSubsystem = "com.openrung.mobile.PacketTunnel"
+    static let loggingSubsystem = "com.openrung.app.PacketTunnel"
     static let engineDirectoryName = "OpenRungPacketTunnel"
     static let relayLimit = 5
     static let directoryRelayLimit = 20
     static let maxRecents = 8
 
     // App ↔ extension shared-state plumbing.
-    static let darwinNotificationName = "com.openrung.mobile.state-changed"
+    static let darwinNotificationName = "com.openrung.app.state-changed"
     static let telemetryOutboxFilename = "outbox.json"
 
     // Heartbeat cadence (random in this range), matching Android.

--- a/ios/Shared/NetworkPathMonitor.swift
+++ b/ios/Shared/NetworkPathMonitor.swift
@@ -16,7 +16,7 @@ public final class NetworkPathMonitor: @unchecked Sendable {
     public static let shared = NetworkPathMonitor()
 
     private let monitor = NWPathMonitor()
-    private let queue = DispatchQueue(label: "com.openrung.mobile.networkpath")
+    private let queue = DispatchQueue(label: "com.openrung.app.networkpath")
     private let lock = NSLock()
     private var snapshot: NetworkPathSnapshot = .unknown
     private var started = false

--- a/ios/Shared/RelayReachability.swift
+++ b/ios/Shared/RelayReachability.swift
@@ -20,7 +20,7 @@ public enum RelayReachability {
         }
 
         let connection = NWConnection(host: NWEndpoint.Host(host), port: nwPort, using: .tcp)
-        let queue = DispatchQueue(label: "com.openrung.mobile.reachability")
+        let queue = DispatchQueue(label: "com.openrung.app.reachability")
         let startedNs = DispatchTime.now().uptimeNanoseconds
 
         final class ResumeGuard: @unchecked Sendable {

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -14,7 +14,7 @@ settings:
     # Injected from package.json by scripts/generate-project.sh (the app version string is
     # single-sourced there; check-versions.mjs enforces the baked pbxproj value matches).
     MARKETING_VERSION: "${APP_VERSION}"
-    CURRENT_PROJECT_VERSION: "6"
+    CURRENT_PROJECT_VERSION: "8"
     DEVELOPMENT_TEAM: 9VLV9A7KS9
     CODE_SIGN_STYLE: Automatic
     # The RN bundle phase writes outside the sandbox; Xcode 15+ would block it otherwise.
@@ -62,7 +62,7 @@ targets:
       - target: PacketTunnel
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: com.openrung.mobile
+        PRODUCT_BUNDLE_IDENTIFIER: com.openrung.app
         PRODUCT_NAME: OpenRung
         INFOPLIST_FILE: OpenRung/Info.plist
         CODE_SIGN_ENTITLEMENTS: OpenRung/OpenRung.entitlements
@@ -107,7 +107,7 @@ targets:
       - sdk: libresolv.tbd
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: com.openrung.mobile.PacketTunnel
+        PRODUCT_BUNDLE_IDENTIFIER: com.openrung.app.PacketTunnel
         INFOPLIST_FILE: PacketTunnel/Info.plist
         CODE_SIGN_ENTITLEMENTS: PacketTunnel/PacketTunnel.entitlements
         APPLICATION_EXTENSION_API_ONLY: "YES"
@@ -145,7 +145,7 @@ targets:
       - path: Shared/RelayListVerifier.swift
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: com.openrung.mobile.OpenRungTests
+        PRODUCT_BUNDLE_IDENTIFIER: com.openrung.app.OpenRungTests
         GENERATE_INFOPLIST_FILE: "YES"
         CODE_SIGNING_ALLOWED: "NO"
 


### PR DESCRIPTION
## Summary

- target the existing TestFlight app identity (com.openrung.app)
- keep the packet tunnel, app group, notifications, and runtime identifiers aligned
- advance the iOS build number from 6 to 8 because build 7 is already uploaded
- update the native contract and architecture references

## Verification

- npm test -- --runInBand (139 tests)
- npx --no-install tsc --noEmit
- npm run lint (0 errors; existing warnings only)
- npm run version:check
- plist validation and git diff --check
