### PR TITLE
chore: bump version to 0.3.1

### DIFF
--- a/ios/OpenRung.xcodeproj/project.pbxproj
+++ b/ios/OpenRung.xcodeproj/project.pbxproj
@@ -675,7 +675,7 @@
 					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
 					"\"$(inherited)\"",
 				);
-				MARKETING_VERSION = 0.3.0;
+				MARKETING_VERSION = 0.3.1;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -817,7 +817,7 @@
 					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
 					"\"$(inherited)\"",
 				);
-				MARKETING_VERSION = 0.3.0;
+				MARKETING_VERSION = 0.3.1;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				OTHER_CPLUSPLUSFLAGS = (

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openrung-mobile-app",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openrung-mobile-app",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@maplibre/maplibre-react-native": "^11.3.6",
         "@noble/ed25519": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openrung-mobile-app",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
Bumps the single-sourced app version from 0.3.0 to 0.3.1.

## ⚠️ Merge order

**Merge [#54](https://github.com/openrung/openrung-mobile-app/pull/54) first.** Merging this PR triggers the version-gated release workflow, which builds and publishes the signed Android APK as a GitHub Release. If this lands before #54, the 0.3.1 release ships **without** the `application_connection` telemetry reduction.

Broker prerequisite is already satisfied: openrung#88 (summing `measurements.connection_count`) is merged and deployed to production (`sha-3436734`), so the aggregating client's collapsed counts are summed correctly rather than collapsing Top-applications.

## What changed

The same three files the 0.3.0 bump (#51) touched — no more:

- `package.json` — 0.3.0 → 0.3.1 (canonical source)
- `package-lock.json` — matching version fields
- `ios/OpenRung.xcodeproj/project.pbxproj` — `MARKETING_VERSION` (2 entries), regenerated with `xcodegen generate` and `APP_VERSION` injected

Android `versionName` and `src/config.ts` `APP_VERSION` derive from `package.json` at build time, so they need no edit (CI enforces they keep deriving).

## Deliberately unchanged

- **Android `versionCode` (10)** — a separate monotonic build counter, not bumped per version (0.3.0 didn't bump it either). Needs a manual bump before any Play Store upload.
- **iOS `CURRENT_PROJECT_VERSION` (8)** — the iOS build number, bumped separately at TestFlight prep (as in #52).

`pod install` was intentionally not run: the committed pbxproj is bare-xcodegen output with zero `[CP]` phases, and running it would add those phases back and churn `Podfile.lock`.

## Testing

`npm run version:check` ✓ (all sources single-sourced from 0.3.1) · `tsc` ✓ · Jest 139 passed ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)