### PR TITLE
Fix application telemetry session handoff and count loss

### DIFF
--- a/android/app/src/main/java/com/openrung/telemetry/ApplicationConnectionAggregator.kt
+++ b/android/app/src/main/java/com/openrung/telemetry/ApplicationConnectionAggregator.kt
@@ -3,11 +3,12 @@ package com.openrung.telemetry
 /**
  * Per-application rate limiter for `application_connection` events. The broker folds these
  * events into an hourly per-application flow total (summing each event's `connection_count`,
- * openrung PR #88) and discards the rest of the payload, so more than one event per
- * application per window is pure transmit overhead. Callers record every tunneled flow; at
- * most one flow per application per [windowMs] passes through, carrying the number of flows
- * observed since the previous emitted event, and [drainPending] flushes the still-suppressed
- * remainder when the session ends.
+ * openrung PR #88) and discards the rest of the payload, so repeated events inside the normal
+ * count range are pure transmit overhead. Callers record every tunneled flow; at
+ * normally one event per application per [windowMs] passes through, carrying the number of flows
+ * observed since the previous emitted event. Totals above the broker's per-event ceiling are
+ * split into lossless chunks, and [drainPending] flushes the still-suppressed remainder when the
+ * session ends.
  */
 internal class ApplicationConnectionAggregator(
     private val windowMs: Long,
@@ -29,49 +30,60 @@ internal class ApplicationConnectionAggregator(
     }
 
     /**
-     * Records one flow for [packageName]. Returns the flow count to report (this flow plus any
-     * suppressed since the last emitted event, clamped to [MAX_REPORTED_FLOWS]) when an event
-     * should be emitted, or null when the flow falls inside the current window and must not
-     * produce an event.
+     * Records one flow for [packageName]. Returns the flow counts to report (this flow plus any
+     * suppressed since the last emitted event, split into chunks no larger than
+     * [MAX_REPORTED_FLOWS]) when the window expires, or an empty list while the flow remains
+     * inside the current window.
      */
     @Synchronized
-    fun recordFlow(packageName: String, uid: Int): Long? {
+    fun recordFlow(packageName: String, uid: Int): List<Long> {
         val now = elapsedMs()
         val window = windows[packageName]
         if (window != null && now - window.emittedAtMs < windowMs) {
             window.suppressedFlows++
             window.uid = uid
-            return null
+            return emptyList()
         }
         val count = (window?.suppressedFlows ?: 0L) + 1L
         windows[packageName] = Window(emittedAtMs = now, suppressedFlows = 0L, uid = uid)
-        return count.coerceAtMost(MAX_REPORTED_FLOWS)
+        return count.toReportedChunks()
     }
 
     /**
-     * Returns every application's still-suppressed flow count (clamped to
-     * [MAX_REPORTED_FLOWS]) and forgets all windows. Called when a session ends or is replaced
-     * so the broker's summed totals keep each window's tail instead of losing it to [reset];
-     * counts pending at process death are still lost (dashboard-grade approximation).
+     * Returns every application's still-suppressed flow count, split into chunks no larger than
+     * [MAX_REPORTED_FLOWS], and forgets all windows. Called when a session ends or is replaced so
+     * the broker's summed totals keep each window's tail instead of losing it to [reset]; counts
+     * pending at process death or displaced from the bounded outbox are still lost
+     * (dashboard-grade approximation).
      */
     @Synchronized
-    fun drainPending(): List<PendingFlows> {
-        val pending = windows.mapNotNull { (packageName, window) ->
-            if (window.suppressedFlows > 0) {
-                PendingFlows(packageName, window.uid, window.suppressedFlows.coerceAtMost(MAX_REPORTED_FLOWS))
-            } else {
-                null
+    fun drainPending(): List<PendingFlows> = buildList {
+        windows.forEach { (packageName, window) ->
+            window.suppressedFlows.toReportedChunks().forEach { flows ->
+                add(PendingFlows(packageName, window.uid, flows))
             }
         }
         windows.clear()
-        return pending
+    }
+
+    private fun Long.toReportedChunks(): List<Long> {
+        if (this <= 0L) return emptyList()
+        var remaining = this
+        return buildList {
+            while (remaining > 0L) {
+                val chunk = remaining.coerceAtMost(MAX_REPORTED_FLOWS)
+                add(chunk)
+                remaining -= chunk
+            }
+        }
     }
 
     companion object {
         /**
-         * The broker treats a `connection_count` above its own 100,000 per-app-per-batch cap
-         * as a malformed value and falls back to weight 1 (openrung PR #88), so clamp here
-         * rather than tripping that cliff.
+         * The broker treats a `connection_count` above its own 100,000 per-app-per-batch cap as a
+         * malformed value and falls back to weight 1 (openrung PR #88), so every emitted chunk
+         * stays at or below that limit. TelemetryManager also separates chunks for the same app
+         * across upload batches so the broker can count all of them.
          */
         const val MAX_REPORTED_FLOWS = 100_000L
     }

--- a/android/app/src/main/java/com/openrung/telemetry/TelemetryManager.kt
+++ b/android/app/src/main/java/com/openrung/telemetry/TelemetryManager.kt
@@ -15,6 +15,9 @@ import java.util.Locale
 import java.util.TimeZone
 import java.util.UUID
 
+internal const val APPLICATION_CONNECTION_EVENT = "application_connection"
+internal const val APPLICATION_CONNECTION_COUNT_MEASUREMENT = "connection_count"
+
 object TelemetryManager {
     private const val PREFS = "openrung_telemetry"
     private const val KEY_OUTBOX = "outbox"
@@ -65,22 +68,68 @@ object TelemetryManager {
 
     fun beginSession(context: Context, brokerUrl: String): Session {
         initialize(context)
-        // A session can be replaced without ever ending (relay switch: ACTION_CONNECT while
-        // connected reaches here with the old session still active) — flush its pending flow
-        // tails under the outgoing session before the reset below would discard them.
-        flushPendingApplicationConnections()
-        appConnections.reset()
-        return Session(
-            id = UUID.randomUUID().toString(),
-            clientId = clientId(context),
-            brokerUrl = brokerUrl,
-            startedElapsedMs = SystemClock.elapsedRealtime(),
-        ).also {
-            synchronized(lock) {
-                activeSession = it
-                sessionTraffic = null
-            }
+        val nextClientId = clientId(context)
+        return synchronized(lock) {
+            // A session can be replaced without ever ending (relay switch: ACTION_CONNECT while
+            // connected reaches here with the old session still active). Draining and replacing
+            // under the same lock linearizes the transition with native flow callbacks.
+            activeSession?.let { outgoing ->
+                enqueueAllLocked(
+                    context.applicationContext,
+                    appConnections.drainPending().map { it.toEvent(outgoing) },
+                )
+            } ?: appConnections.reset()
+            val nextSession = Session(
+                id = UUID.randomUUID().toString(),
+                clientId = nextClientId,
+                brokerUrl = brokerUrl,
+                startedElapsedMs = SystemClock.elapsedRealtime(),
+            )
+            activeSession = nextSession
+            sessionTraffic = null
+            nextSession
         }
+    }
+
+    private fun ApplicationConnectionAggregator.PendingFlows.toEvent(session: Session): TelemetryEvent =
+        applicationConnectionEvent(
+            session = session,
+            packageName = packageName,
+            uid = uid,
+            flowCount = flows,
+        )
+
+    private fun applicationConnectionEvent(
+        session: Session,
+        packageName: String,
+        uid: Int,
+        flowCount: Long,
+    ): TelemetryEvent =
+        TelemetryEvent(
+            eventId = UUID.randomUUID().toString(),
+            event = APPLICATION_CONNECTION_EVENT,
+            occurredAt = Instant.now().toString(),
+            clientId = session.clientId,
+            sessionId = session.id,
+            relayId = session.relayId,
+            applicationPackage = packageName,
+            applicationUid = uid,
+            measurements = mapOf(APPLICATION_CONNECTION_COUNT_MEASUREMENT to flowCount),
+        )
+
+    private fun enqueueApplicationConnectionCountsLocked(
+        appContext: Context,
+        session: Session,
+        packageName: String,
+        uid: Int,
+        flowCounts: List<Long>,
+    ) {
+        enqueueAllLocked(
+            appContext,
+            flowCounts.map { flowCount ->
+                applicationConnectionEvent(session, packageName, uid, flowCount)
+            },
+        )
     }
 
     fun activeSession(): Session? = synchronized(lock) { activeSession }
@@ -121,10 +170,12 @@ object TelemetryManager {
             writeOutbox(
                 appContext,
                 readOutbox(appContext).map { event ->
-                    if (event.sessionId == session.id) {
-                        event.copy(attributes = event.attributes + geoAttributes)
-                    } else {
-                        event
+                    when {
+                        event.event == APPLICATION_CONNECTION_EVENT ->
+                            event.copy(attributes = emptyMap())
+                        event.sessionId == session.id ->
+                            event.copy(attributes = event.attributes + geoAttributes)
+                        else -> event
                     }
                 },
             )
@@ -161,9 +212,9 @@ object TelemetryManager {
      * payload, so the event carries just the application identity: destination address, port and
      * protocol are never put on the wire (the client's IP paired with every destination visited
      * is a privacy hazard, transmitted for nothing). DNS flows are skipped entirely, repeated
-     * flows collapse into at most one event per application per [APP_CONNECTION_WINDOW_MS]
-     * (the `connection_count` measurement carries the collapsed total), and a flow whose UID
-     * maps to several packages reports only the first external package — never one event each.
+     * flows normally collapse into one event per application per [APP_CONNECTION_WINDOW_MS]
+     * (larger totals split into broker-bounded chunks), and a flow whose UID maps to several
+     * packages reports only the first external package — never one event each.
      */
     fun recordApplicationConnection(
         uid: Int,
@@ -171,70 +222,42 @@ object TelemetryManager {
         destinationPort: Int,
     ) {
         if (destinationPort == DNS_PORT) return
-        val appContext = context ?: return
-        val session = activeSession() ?: return
+        val appContext = synchronized(lock) { context } ?: return
+        // PackageManager-backed lists can be slow or externally implemented. Resolve attribution
+        // before taking the session lock; the callback belongs to whichever session is active at
+        // the later atomic record point.
         val packageName = packages.firstOrNull { it != appContext.packageName } ?: return
-        val flowCount = appConnections.recordFlow(packageName, uid) ?: return
-        enqueueApplicationConnection(appContext, session, packageName, uid, flowCount)
-    }
-
-    /**
-     * Emits each application's still-suppressed flow count under the currently active session —
-     * the session the flows happened under. Called whenever that session goes away (endSession,
-     * or beginSession replacing it on a relay switch): the broker sums `connection_count`, so a
-     * tail dropped here would permanently undercount the top-applications rollup. Without an
-     * active session pending counts cannot be attributed and are left for reset() to discard.
-     */
-    private fun flushPendingApplicationConnections() {
-        val appContext = context ?: return
-        val session = activeSession() ?: return
-        appConnections.drainPending().forEach { pending ->
-            enqueueApplicationConnection(appContext, session, pending.packageName, pending.uid, pending.flows)
+        synchronized(lock) {
+            val currentContext = context ?: return
+            val session = activeSession ?: return
+            val flowCounts = appConnections.recordFlow(packageName, uid)
+            if (flowCounts.isEmpty()) return
+            enqueueApplicationConnectionCountsLocked(currentContext, session, packageName, uid, flowCounts)
         }
     }
 
-    private fun enqueueApplicationConnection(
-        appContext: Context,
-        session: Session,
-        packageName: String,
-        uid: Int,
-        flowCount: Long,
-    ) {
-        enqueue(
-            appContext,
-            TelemetryEvent(
-                eventId = UUID.randomUUID().toString(),
-                event = "application_connection",
-                occurredAt = Instant.now().toString(),
-                clientId = session.clientId,
-                sessionId = session.id,
-                relayId = session.relayId,
-                applicationPackage = packageName,
-                applicationUid = uid,
-                attributes = session.geoAttributes,
-                measurements = mapOf("connection_count" to flowCount),
-            ),
-        )
-    }
-
     fun endSession(reason: String) {
-        val session = activeSession() ?: return
-        flushPendingApplicationConnections()
-        val now = SystemClock.elapsedRealtime()
-        val measurements = mutableMapOf("session_duration_ms" to (now - session.startedElapsedMs))
-        session.connectedElapsedMs?.let { measurements["connection_duration_ms"] = now - it }
-        trafficCounters()?.let { measurements.putAll(it.measurements()) }
-        record(
-            event = "connection_ended",
-            relayId = session.relayId,
-            attributes = mapOf("reason" to reason),
-            measurements = measurements,
-        )
         synchronized(lock) {
-            if (activeSession?.id == session.id) {
-                activeSession = null
-                sessionTraffic = null
-            }
+            val appContext = context ?: return
+            val session = activeSession ?: return
+            val now = SystemClock.elapsedRealtime()
+            val measurements = mutableMapOf("session_duration_ms" to (now - session.startedElapsedMs))
+            session.connectedElapsedMs?.let { measurements["connection_duration_ms"] = now - it }
+            sessionTraffic?.let { measurements.putAll(it.measurements()) }
+            val endingEvents = appConnections.drainPending().map { it.toEvent(session) } +
+                TelemetryEvent(
+                    eventId = UUID.randomUUID().toString(),
+                    event = "connection_ended",
+                    occurredAt = Instant.now().toString(),
+                    clientId = session.clientId,
+                    sessionId = session.id,
+                    relayId = session.relayId,
+                    attributes = deviceAttributes(appContext) + session.geoAttributes + ("reason" to reason),
+                    measurements = measurements,
+                )
+            enqueueAllLocked(appContext, endingEvents)
+            activeSession = null
+            sessionTraffic = null
         }
     }
 
@@ -251,7 +274,9 @@ object TelemetryManager {
             attributes = deviceAttributes(appContext) + session.geoAttributes,
             trafficCounters = trafficCounters(),
         ) ?: return
-        val queued = synchronized(lock) { readOutbox(appContext).take(UPLOAD_BATCH_SIZE - 1) }
+        val queued = synchronized(lock) {
+            telemetryUploadBatch(readOutbox(appContext), UPLOAD_BATCH_SIZE - 1)
+        }
         TelemetryClient(session.brokerUrl).send(queued + event)
         if (queued.isNotEmpty()) {
             synchronized(lock) {
@@ -265,7 +290,9 @@ object TelemetryManager {
     suspend fun flush(brokerUrl: String) {
         val appContext = context ?: return
         while (true) {
-            val batch = synchronized(lock) { readOutbox(appContext).take(UPLOAD_BATCH_SIZE) }
+            val batch = synchronized(lock) {
+                telemetryUploadBatch(readOutbox(appContext), UPLOAD_BATCH_SIZE)
+            }
             if (batch.isEmpty()) return
             TelemetryClient(brokerUrl).send(batch)
             synchronized(lock) {
@@ -277,14 +304,24 @@ object TelemetryManager {
 
     private fun enqueue(context: Context, event: TelemetryEvent) {
         synchronized(lock) {
-            writeOutbox(context, (readOutbox(context) + event).takeLast(MAX_QUEUED_EVENTS))
+            enqueueAllLocked(context, listOf(event))
         }
+    }
+
+    private fun enqueueAllLocked(context: Context, events: List<TelemetryEvent>) {
+        if (events.isEmpty()) return
+        writeOutbox(
+            context,
+            (readOutbox(context) + events.map(::sanitizeTelemetryEvent)).takeLast(MAX_QUEUED_EVENTS),
+        )
     }
 
     private fun readOutbox(context: Context): List<TelemetryEvent> {
         val encoded = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE).getString(KEY_OUTBOX, null)
             ?: return emptyList()
-        return runCatching { json.decodeFromString<List<TelemetryEvent>>(encoded) }.getOrDefault(emptyList())
+        return runCatching { json.decodeFromString<List<TelemetryEvent>>(encoded) }
+            .getOrDefault(emptyList())
+            .map(::sanitizeTelemetryEvent)
     }
 
     private fun writeOutbox(context: Context, events: List<TelemetryEvent>) {
@@ -318,6 +355,56 @@ object TelemetryManager {
         capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET) -> "ethernet"
         else -> "other"
     }
+}
+
+/**
+ * Removes client metadata that the broker never retains from application-connection records.
+ * Applying this on every outbox read also scrubs events queued by an older app version before
+ * either upload path can put them on the wire.
+ */
+internal fun sanitizeTelemetryEvent(event: TelemetryEvent): TelemetryEvent =
+    if (event.event == APPLICATION_CONNECTION_EVENT && event.attributes.isNotEmpty()) {
+        event.copy(attributes = emptyMap())
+    } else {
+        event
+    }
+
+/**
+ * Selects one upload request while honoring the broker's 100,000 represented-flow budget per
+ * application. Events that would exceed an application's remaining budget are deferred along
+ * with later events for that application, preserving its FIFO order; unrelated events can still
+ * fill the request. The caller removes selected event IDs after a successful send.
+ */
+internal fun telemetryUploadBatch(events: List<TelemetryEvent>, limit: Int): List<TelemetryEvent> {
+    require(limit > 0) { "telemetry upload batch limit must be positive" }
+    val representedByApplication = mutableMapOf<String, Long>()
+    val deferredApplications = mutableSetOf<String>()
+    return buildList {
+        for (event in events) {
+            if (size >= limit) break
+            if (event.event != APPLICATION_CONNECTION_EVENT) {
+                add(event)
+                continue
+            }
+
+            val application = event.applicationPackage.orEmpty()
+            if (application in deferredApplications) continue
+            val count = event.brokerApplicationConnectionCount()
+            val used = representedByApplication[application] ?: 0L
+            if (count > ApplicationConnectionAggregator.MAX_REPORTED_FLOWS - used) {
+                deferredApplications += application
+                continue
+            }
+            representedByApplication[application] = used + count
+            add(event)
+        }
+    }
+}
+
+/** Mirrors the broker's compatibility behavior for missing or malformed typed counts. */
+internal fun TelemetryEvent.brokerApplicationConnectionCount(): Long {
+    val count = measurements[APPLICATION_CONNECTION_COUNT_MEASUREMENT] ?: return 1L
+    return if (count in 1..ApplicationConnectionAggregator.MAX_REPORTED_FLOWS) count else 1L
 }
 
 internal fun buildSessionHeartbeat(

--- a/android/app/src/test/java/com/openrung/telemetry/ApplicationConnectionAggregatorTest.kt
+++ b/android/app/src/test/java/com/openrung/telemetry/ApplicationConnectionAggregatorTest.kt
@@ -3,7 +3,6 @@ package com.openrung.telemetry
 import com.openrung.telemetry.ApplicationConnectionAggregator.Companion.MAX_REPORTED_FLOWS
 import com.openrung.telemetry.ApplicationConnectionAggregator.PendingFlows
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
 import org.junit.Test
 
 class ApplicationConnectionAggregatorTest {
@@ -12,40 +11,40 @@ class ApplicationConnectionAggregatorTest {
 
     @Test
     fun `first flow for an application emits with count one`() {
-        assertEquals(1L, aggregator.recordFlow("app.a", UID))
+        assertEquals(listOf(1L), aggregator.recordFlow("app.a", UID))
     }
 
     @Test
     fun `flows inside the window are suppressed`() {
         aggregator.recordFlow("app.a", UID)
-        assertNull(aggregator.recordFlow("app.a", UID))
+        assertEquals(emptyList<Long>(), aggregator.recordFlow("app.a", UID))
         nowMs += WINDOW_MS - 1
-        assertNull(aggregator.recordFlow("app.a", UID))
+        assertEquals(emptyList<Long>(), aggregator.recordFlow("app.a", UID))
     }
 
     @Test
     fun `first flow after the window emits the collapsed count and resets it`() {
         aggregator.recordFlow("app.a", UID)
-        repeat(41) { assertNull(aggregator.recordFlow("app.a", UID)) }
+        repeat(41) { assertEquals(emptyList<Long>(), aggregator.recordFlow("app.a", UID)) }
         nowMs += WINDOW_MS
-        assertEquals(42L, aggregator.recordFlow("app.a", UID))
+        assertEquals(listOf(42L), aggregator.recordFlow("app.a", UID))
         nowMs += WINDOW_MS
-        assertEquals(1L, aggregator.recordFlow("app.a", UID))
+        assertEquals(listOf(1L), aggregator.recordFlow("app.a", UID))
     }
 
     @Test
     fun `an idle window emits count one on the next flow`() {
         aggregator.recordFlow("app.a", UID)
         nowMs += WINDOW_MS * 3
-        assertEquals(1L, aggregator.recordFlow("app.a", UID))
+        assertEquals(listOf(1L), aggregator.recordFlow("app.a", UID))
     }
 
     @Test
     fun `applications are windowed independently`() {
-        assertEquals(1L, aggregator.recordFlow("app.a", UID))
-        assertEquals(1L, aggregator.recordFlow("app.b", UID))
-        assertNull(aggregator.recordFlow("app.a", UID))
-        assertNull(aggregator.recordFlow("app.b", UID))
+        assertEquals(listOf(1L), aggregator.recordFlow("app.a", UID))
+        assertEquals(listOf(1L), aggregator.recordFlow("app.b", UID))
+        assertEquals(emptyList<Long>(), aggregator.recordFlow("app.a", UID))
+        assertEquals(emptyList<Long>(), aggregator.recordFlow("app.b", UID))
     }
 
     @Test
@@ -59,22 +58,34 @@ class ApplicationConnectionAggregatorTest {
             aggregator.drainPending(),
         )
         // Drained state is gone: the same app emits again immediately, from one.
-        assertEquals(1L, aggregator.recordFlow("app.a", UID))
+        assertEquals(listOf(1L), aggregator.recordFlow("app.a", UID))
         assertEquals(emptyList<PendingFlows>(), aggregator.drainPending())
     }
 
     @Test
-    fun `emitted and drained counts clamp at the broker maximum`() {
+    fun `elapsed window splits totals above the broker maximum without losing flows`() {
         aggregator.recordFlow("app.a", UID)
         repeat((MAX_REPORTED_FLOWS + 5).toInt()) { aggregator.recordFlow("app.a", UID) }
         nowMs += WINDOW_MS
-        assertEquals(MAX_REPORTED_FLOWS, aggregator.recordFlow("app.a", UID))
+        val emitted = aggregator.recordFlow("app.a", UID)
 
+        assertEquals(listOf(MAX_REPORTED_FLOWS, 6L), emitted)
+        assertEquals(MAX_REPORTED_FLOWS + 7L, 1L + emitted.sum())
+    }
+
+    @Test
+    fun `drain splits pending totals above the broker maximum without losing flows`() {
+        aggregator.recordFlow("app.a", UID)
         repeat((MAX_REPORTED_FLOWS + 5).toInt()) { aggregator.recordFlow("app.a", UID) }
+
         assertEquals(
-            listOf(PendingFlows(packageName = "app.a", uid = UID, flows = MAX_REPORTED_FLOWS)),
+            listOf(
+                PendingFlows(packageName = "app.a", uid = UID, flows = MAX_REPORTED_FLOWS),
+                PendingFlows(packageName = "app.a", uid = UID, flows = 5L),
+            ),
             aggregator.drainPending(),
         )
+        assertEquals(emptyList<PendingFlows>(), aggregator.drainPending())
     }
 
     @Test
@@ -83,7 +94,7 @@ class ApplicationConnectionAggregatorTest {
         repeat(5) { aggregator.recordFlow("app.a", UID) }
         aggregator.reset()
         assertEquals(emptyList<PendingFlows>(), aggregator.drainPending())
-        assertEquals(1L, aggregator.recordFlow("app.a", UID))
+        assertEquals(listOf(1L), aggregator.recordFlow("app.a", UID))
     }
 
     private companion object {

--- a/android/app/src/test/java/com/openrung/telemetry/TelemetryManagerApplicationConnectionTest.kt
+++ b/android/app/src/test/java/com/openrung/telemetry/TelemetryManagerApplicationConnectionTest.kt
@@ -2,7 +2,12 @@ package com.openrung.telemetry
 
 import android.app.Application
 import android.content.Context
+import com.openrung.net.ClientGeoInfo
 import java.time.Duration
+import java.util.AbstractList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import org.junit.After
@@ -74,6 +79,7 @@ class TelemetryManagerApplicationConnectionTest {
         assertEquals("com.example.identity", event.applicationPackage)
         assertEquals(10_002, event.applicationUid)
         assertEquals(1L, event.measurements["connection_count"])
+        assertTrue(event.attributes.isEmpty())
 
         val stored = storedOutboxJson()
         assertFalse(stored.contains("destination_ip"))
@@ -143,6 +149,94 @@ class TelemetryManagerApplicationConnectionTest {
     }
 
     @Test
+    fun `flow attribution linearizes after package lookup during session replacement`() {
+        recordFlow(packageName = "com.example.replace-race")
+        val lookupEntered = CountDownLatch(1)
+        val releaseLookup = CountDownLatch(1)
+        val executor = Executors.newSingleThreadExecutor()
+        try {
+            val callback = executor.submit {
+                TelemetryManager.recordApplicationConnection(
+                    uid = 10_001,
+                    packages = BlockingPackageList("com.example.replace-race", lookupEntered, releaseLookup),
+                    destinationPort = 443,
+                )
+            }
+            assertTrue("flow callback did not enter package lookup", lookupEntered.await(5, TimeUnit.SECONDS))
+
+            val second = TelemetryManager.beginSession(context, "https://broker.invalid/")
+            releaseLookup.countDown()
+            callback.get(5, TimeUnit.SECONDS)
+
+            val events = applicationConnectionEvents()
+                .filter { it.applicationPackage == "com.example.replace-race" }
+            assertEquals(listOf(session.id, second.id), events.map { it.sessionId })
+            assertEquals(listOf(1L, 1L), events.map { it.measurements["connection_count"] })
+        } finally {
+            releaseLookup.countDown()
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `flow callback completing after session end emits nothing`() {
+        recordFlow(packageName = "com.example.end-race")
+        val lookupEntered = CountDownLatch(1)
+        val releaseLookup = CountDownLatch(1)
+        val executor = Executors.newSingleThreadExecutor()
+        try {
+            val callback = executor.submit {
+                TelemetryManager.recordApplicationConnection(
+                    uid = 10_001,
+                    packages = BlockingPackageList("com.example.end-race", lookupEntered, releaseLookup),
+                    destinationPort = 443,
+                )
+            }
+            assertTrue("flow callback did not enter package lookup", lookupEntered.await(5, TimeUnit.SECONDS))
+
+            TelemetryManager.endSession("test_concurrent_end")
+            releaseLookup.countDown()
+            callback.get(5, TimeUnit.SECONDS)
+
+            val events = applicationConnectionEvents()
+                .filter { it.applicationPackage == "com.example.end-race" }
+            assertEquals(1, events.size)
+            assertEquals(session.id, events.single().sessionId)
+        } finally {
+            releaseLookup.countDown()
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `application events omit geo metadata before after and during geo resolution`() {
+        recordFlow(packageName = "com.example.before-geo")
+        recordFlow(packageName = "com.example.before-geo")
+
+        TelemetryManager.setGeoInfo(
+            ClientGeoInfo(
+                ip = "203.0.113.9",
+                country = "Exampleland",
+                countryCode = "EX",
+                city = "Example City",
+                asn = "AS64500",
+                isp = "Example ISP",
+                organization = "Example Org",
+            ),
+        )
+        recordFlow(packageName = "com.example.after-geo")
+        TelemetryManager.endSession("test_geo_privacy")
+
+        val events = json.decodeFromString<List<TelemetryEvent>>(storedOutboxJson())
+        val applicationEvents = events.filter { it.event == APPLICATION_CONNECTION_EVENT }
+        assertEquals(3, applicationEvents.size)
+        assertTrue(applicationEvents.all { it.attributes.isEmpty() })
+        val geoEvent = events.single { it.event == "client_geo_resolved" }
+        assertEquals("203.0.113.9", geoEvent.attributes["client_ip"])
+        assertEquals("Example City", geoEvent.attributes["city"])
+    }
+
+    @Test
     fun `the app's own traffic emits nothing`() {
         recordFlow(packageName = context.packageName)
         assertEquals(emptyList<TelemetryEvent>(), applicationConnectionEvents())
@@ -164,7 +258,8 @@ class TelemetryManagerApplicationConnectionTest {
                 """[{"schema_version":1,"event_id":"legacy-1","event":"application_connection",""" +
                     """"occurred_at":"2026-07-01T00:00:00Z","client_id":"c","session_id":"s",""" +
                     """"application_package":"com.example.legacy","application_uid":10099,""" +
-                    """"destination_ip":"93.184.216.34","destination_port":443,"protocol":"tcp"}]""",
+                    """"destination_ip":"93.184.216.34","destination_port":443,"protocol":"tcp",""" +
+                    """"attributes":{"client_ip":"203.0.113.9","city":"Example City"}}]""",
             )
             .commit()
 
@@ -174,6 +269,8 @@ class TelemetryManagerApplicationConnectionTest {
         assertTrue(stored.contains("legacy-1"))
         assertFalse(stored.contains("destination_ip"))
         assertFalse(stored.contains("93.184.216.34"))
+        assertFalse(stored.contains("203.0.113.9"))
+        assertFalse(stored.contains("Example City"))
     }
 
     private fun recordFlow(packageName: String, destinationPort: Int = 443) {
@@ -197,5 +294,20 @@ class TelemetryManagerApplicationConnectionTest {
             .edit()
             .clear()
             .commit()
+    }
+
+    private class BlockingPackageList(
+        private val packageName: String,
+        private val entered: CountDownLatch,
+        private val release: CountDownLatch,
+    ) : AbstractList<String>() {
+        override val size: Int = 1
+
+        override fun get(index: Int): String {
+            check(index == 0)
+            entered.countDown()
+            check(release.await(5, TimeUnit.SECONDS)) { "timed out waiting to release package lookup" }
+            return packageName
+        }
     }
 }

--- a/android/app/src/test/java/com/openrung/telemetry/TelemetryUploadBatchTest.kt
+++ b/android/app/src/test/java/com/openrung/telemetry/TelemetryUploadBatchTest.kt
@@ -1,0 +1,83 @@
+package com.openrung.telemetry
+
+import com.openrung.telemetry.ApplicationConnectionAggregator.Companion.MAX_REPORTED_FLOWS
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TelemetryUploadBatchTest {
+    @Test
+    fun `same-application chunks are deferred across broker-compatible batches`() {
+        val queued = listOf(
+            event("a-1", application = "app.a", count = 1),
+            event("a-max", application = "app.a", count = MAX_REPORTED_FLOWS),
+            event("a-5", application = "app.a", count = 5),
+            event("b-max", application = "app.b", count = MAX_REPORTED_FLOWS),
+            event("ordinary"),
+        )
+
+        val batches = mutableListOf<List<TelemetryEvent>>()
+        var remaining = queued
+        while (remaining.isNotEmpty()) {
+            val batch = telemetryUploadBatch(remaining, limit = 200)
+            assertTrue("selector made no progress", batch.isNotEmpty())
+            batches += batch
+            val selectedIds = batch.mapTo(hashSetOf()) { it.eventId }
+            remaining = remaining.filterNot { it.eventId in selectedIds }
+        }
+
+        assertEquals(
+            listOf(
+                listOf("a-1", "b-max", "ordinary"),
+                listOf("a-max"),
+                listOf("a-5"),
+            ),
+            batches.map { batch -> batch.map { it.eventId } },
+        )
+        assertEquals(queued.map { it.eventId }.sorted(), batches.flatten().map { it.eventId }.sorted())
+        batches.forEach { batch ->
+            batch.filter { it.event == APPLICATION_CONNECTION_EVENT }
+                .groupBy { it.applicationPackage }
+                .forEach { (_, events) ->
+                    assertTrue(events.sumOf { it.brokerApplicationConnectionCount() } <= MAX_REPORTED_FLOWS)
+                }
+        }
+    }
+
+    @Test
+    fun `batch weighting matches broker compatibility behavior`() {
+        val counts = listOf<Long?>(null, 0, -1, MAX_REPORTED_FLOWS + 1, 42, MAX_REPORTED_FLOWS)
+        assertEquals(
+            listOf(1L, 1L, 1L, 1L, 42L, MAX_REPORTED_FLOWS),
+            counts.mapIndexed { index, count ->
+                event("event-$index", application = "app.$index", count = count)
+                    .brokerApplicationConnectionCount()
+            },
+        )
+    }
+
+    @Test
+    fun `sanitizer strips only application connection attributes`() {
+        val attributes = mapOf("client_ip" to "203.0.113.9", "city" to "Example City")
+        val applicationEvent = event("app", application = "app.a", count = 1).copy(attributes = attributes)
+        val ordinaryEvent = event("ordinary").copy(attributes = attributes)
+
+        assertTrue(sanitizeTelemetryEvent(applicationEvent).attributes.isEmpty())
+        assertEquals(attributes, sanitizeTelemetryEvent(ordinaryEvent).attributes)
+    }
+
+    private fun event(
+        id: String,
+        application: String? = null,
+        count: Long? = null,
+    ): TelemetryEvent =
+        TelemetryEvent(
+            eventId = id,
+            event = if (application == null) "ordinary" else APPLICATION_CONNECTION_EVENT,
+            occurredAt = "2026-07-21T00:00:00Z",
+            clientId = "client-1",
+            sessionId = "session-1",
+            applicationPackage = application,
+            measurements = count?.let { mapOf(APPLICATION_CONNECTION_COUNT_MEASUREMENT to it) }.orEmpty(),
+        )
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -121,13 +121,15 @@ endpoint anywhere in the app.
 
 Telemetry is higher-volume than discovery — heartbeats fire ~once/minute per
 connected user, plus per-app connection records (aggregated client-side: DNS
-flows are skipped, destination addresses are never sent, and repeated flows
-collapse into at most one `application_connection` event per app per 15
-minutes whose `connection_count` measurement carries the represented flow
-total, with each window's still-suppressed tail flushed when the session ends
-or is replaced; the
-broker's hourly per-application rollup sums these counts, treating legacy
-per-flow events as one each) — so its transport is a cost/security trade-off:
+flows are skipped; destination and client geo/device/network attributes are
+never sent; and repeated flows normally collapse into one
+`application_connection` event per app per 15 minutes whose `connection_count`
+measurement carries the represented flow total. Counts above 100,000 are split
+into bounded chunks and separated across HTTP batches to match the broker's
+per-app request budget, while each window's still-suppressed tail is flushed
+atomically when the session ends or is replaced. The broker's hourly
+per-application rollup sums these counts, treating legacy per-flow events as
+one each) — so its transport is a cost/security trade-off:
 
 - **Option B — current.** Send telemetry to the Cloudflare-fronted
   `https://broker.openrung.org/`, the same endpoint as discovery. TLS end-to-end with

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -289,9 +289,11 @@ phases, ENABLE_USER_SCRIPT_SANDBOXING=NO, current pbxproj settings), plus the
   volunteer-run tunnel-transport relays.
 - Telemetry from TS covers only speed-test events; the native connect path keeps
   production telemetry except that `application_connection` is reduced client-side:
-  DNS flows are skipped, destination ip/port/protocol are never sent, and repeated
-  flows collapse into at most one event per application per 15 minutes carrying a
-  `connection_count` flow total (clamped to the broker's 100,000 cap), with the
-  still-suppressed tail flushed when the session ends or is replaced (relay
-  switch) so the broker's summed rollup stays accurate.
+  DNS flows are skipped; destination ip/port/protocol and client
+  geo/device/network attributes are never sent; and repeated flows normally collapse
+  into one event per application per 15 minutes carrying a `connection_count` flow
+  total. Totals above 100,000 are split without discarding the remainder and sent in
+  separate per-app HTTP-batch budgets, with the still-suppressed tail flushed atomically
+  when the session ends or is replaced (relay switch) so the broker's summed rollup
+  stays accurate within the existing bounded-outbox and at-least-once-delivery limits.
 - License: GPL-3.0-or-later (statically links sing-box), same as production.


### PR DESCRIPTION
## Summary

Follow-up to #54 after reviewing the client aggregation behavior against broker PR openrung/openrung#88.

- Linearize application-flow recording with session replacement and teardown under one lock, so native callbacks cannot mutate a different session aggregation window.
- Split totals above 100,000 without dropping the remainder, and select upload batches that stay within the broker per-application request budget.
- Strip geo, device, and network attributes from new and already-queued application_connection events before either upload path.
- Update the telemetry contract and architecture notes to describe the bounded-outbox and at-least-once semantics accurately.

## Regression coverage

- Deterministic blocked-callback tests for beginSession and endSession races.
- Elapsed-window and final-drain overflow chunking tests.
- Per-application upload budget, FIFO deferral, and broker fallback-weight tests.
- Geo-resolution timing and legacy outbox privacy-scrub tests.

## Verification

- ./gradlew --no-daemon :app:testDebugUnitTest
- npm test -- --runInBand (139 tests)
- npm run lint
- npx tsc --noEmit
- npm run version:check