### PR TITLE
feat: add iOS TestFlight share button in Settings

### DIFF
--- a/__tests__/screens/SettingsScreen.test.tsx
+++ b/__tests__/screens/SettingsScreen.test.tsx
@@ -1,8 +1,21 @@
 import React from 'react';
 import ReactTestRenderer from 'react-test-renderer';
-import { Alert, Linking, Text } from 'react-native';
+import { Alert, Linking, Share, Text } from 'react-native';
 
 const mockShareInstalledApk = jest.fn<Promise<void>, [string]>();
+
+// Jest's react-native preset resolves Platform.OS to 'ios', so giving the config a TestFlight
+// link is all it takes to make the iOS sharing row available.
+jest.mock('../../src/config', () => {
+  const actual = jest.requireActual('../../src/config');
+  return {
+    ...actual,
+    AppConfig: {
+      ...actual.AppConfig,
+      TESTFLIGHT_URL: 'https://testflight.apple.com/join/TESTCODE',
+    },
+  };
+});
 
 jest.mock('@react-native-async-storage/async-storage', () => ({
   __esModule: true,
@@ -127,6 +140,62 @@ describe('SettingsScreen Android APK sharing', () => {
       .some(text => text.props.children === 'Share OpenRung offline');
     expect(hasShareAction).toBe(false);
     await unmount(tree!);
+  });
+});
+
+describe('SettingsScreen iOS TestFlight sharing', () => {
+  it('places TestFlight sharing in General and opens the system share sheet', async () => {
+    const share = jest
+      .spyOn(Share, 'share')
+      .mockResolvedValue({ action: Share.sharedAction });
+    const tree = await renderSettings();
+    const labels = tree.root
+      .findAllByType(Text)
+      .map(text => text.props.children)
+      .filter((label): label is string => typeof label === 'string');
+
+    expect(labels.indexOf('GENERAL')).toBeLessThan(
+      labels.indexOf('Share OpenRung'),
+    );
+    expect(labels.indexOf('Share OpenRung')).toBeLessThan(
+      labels.indexOf('DIAGNOSTICS'),
+    );
+
+    await ReactTestRenderer.act(async () => {
+      findButton(tree, 'Share OpenRung').props.onPress();
+      await Promise.resolve();
+    });
+
+    expect(share).toHaveBeenCalledWith(
+      {
+        message: 'Join the OpenRung beta on TestFlight:',
+        url: 'https://testflight.apple.com/join/TESTCODE',
+      },
+      { subject: 'Share OpenRung' },
+    );
+    share.mockRestore();
+    await unmount(tree);
+  });
+
+  it('surfaces an alert when the share sheet cannot be opened', async () => {
+    const share = jest
+      .spyOn(Share, 'share')
+      .mockRejectedValue(new Error('share sheet unavailable'));
+    const alert = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+    const tree = await renderSettings();
+
+    await ReactTestRenderer.act(async () => {
+      findButton(tree, 'Share OpenRung').props.onPress();
+      await Promise.resolve();
+    });
+
+    expect(alert).toHaveBeenCalledWith(
+      'Unable to share OpenRung',
+      'The TestFlight link could not be shared. Try again.',
+    );
+    share.mockRestore();
+    alert.mockRestore();
+    await unmount(tree);
   });
 });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -124,12 +124,12 @@ export const AppConfig = {
 
   /**
    * TestFlight public invite link for the iOS beta, shared from Settings → "Share OpenRung"
-   * (the iOS counterpart of Android's offline APK sharing). Generate it in App Store Connect →
-   * TestFlight → external group → Public Link and paste it here; the Settings row stays hidden
-   * while this is empty. Before enabling, note RELEASE.md §5: external TestFlight distribution
-   * of the GPL-linked binary has an unresolved licensing caveat.
+   * (the iOS counterpart of Android's offline APK sharing). Regenerate it in App Store Connect →
+   * TestFlight → external group → Public Link if the group is ever recreated; the Settings row
+   * hides itself whenever this is empty. Note RELEASE.md §5: external TestFlight distribution of
+   * the GPL-linked binary has an unresolved licensing caveat.
    */
-  TESTFLIGHT_URL: '',
+  TESTFLIGHT_URL: 'https://testflight.apple.com/join/RMTt4UfQ',
 
   /**
    * Vector tiles + glyphs for the exit-node map. We build our own flat style around these MapLibre

--- a/src/config.ts
+++ b/src/config.ts
@@ -123,6 +123,15 @@ export const AppConfig = {
   PRIVACY_URL: 'https://www.openrung.org/privacy',
 
   /**
+   * TestFlight public invite link for the iOS beta, shared from Settings → "Share OpenRung"
+   * (the iOS counterpart of Android's offline APK sharing). Generate it in App Store Connect →
+   * TestFlight → external group → Public Link and paste it here; the Settings row stays hidden
+   * while this is empty. Before enabling, note RELEASE.md §5: external TestFlight distribution
+   * of the GPL-linked binary has an unresolved licensing caveat.
+   */
+  TESTFLIGHT_URL: '',
+
+  /**
    * Vector tiles + glyphs for the exit-node map. We build our own flat style around these MapLibre
    * demo tiles rather than using the demo *style*, which colour-codes every country. An operator
    * can point these at a self-hosted source to avoid third-party tiles.

--- a/src/i18n/strings/ar.ts
+++ b/src/i18n/strings/ar.ts
@@ -109,6 +109,13 @@ export const ar: Partial<Strings> = {
     'تعذّرت مشاركة ملف APK. أبقِ OpenRung مفتوحًا وحاول مرة أخرى.',
   shareApkSplitInstallError:
     'ثُبّتت هذه النسخة من عدة ملفات APK ولا يمكن مشاركتها بأمان. ثبّت ملف APK المستقل لـ OpenRung لاستخدام المشاركة دون اتصال.',
+  shareTestFlightTitle: 'مشاركة OpenRung',
+  shareTestFlightSubtitle:
+    'أرسل رابط TestFlight ليتمكّن الآخرون من تثبيت نسخة iOS التجريبية.',
+  shareTestFlightMessage: 'انضم إلى نسخة OpenRung التجريبية عبر TestFlight:',
+  shareTestFlightErrorTitle: 'تعذّرت مشاركة OpenRung',
+  shareTestFlightErrorBody:
+    'تعذّرت مشاركة رابط TestFlight. حاول مرة أخرى.',
 
   // Home overlay and about screen.
   homeTagline: 'شبكة المُرحّلات',

--- a/src/i18n/strings/en.ts
+++ b/src/i18n/strings/en.ts
@@ -81,6 +81,11 @@ export const en = {
     'The APK could not be shared. Keep OpenRung open and try again.',
   shareApkSplitInstallError:
     'This copy was installed as multiple APK files and cannot be shared safely. Install the standalone OpenRung APK to use offline sharing.',
+  shareTestFlightTitle: 'Share OpenRung',
+  shareTestFlightSubtitle: 'Send a TestFlight link that installs the iOS beta.',
+  shareTestFlightMessage: 'Join the OpenRung beta on TestFlight:',
+  shareTestFlightErrorTitle: 'Unable to share OpenRung',
+  shareTestFlightErrorBody: 'The TestFlight link could not be shared. Try again.',
 
   // --- Redesigned shell (tabs, home overlay, about) ---
   tabHome: 'Home',

--- a/src/i18n/strings/fa.ts
+++ b/src/i18n/strings/fa.ts
@@ -109,6 +109,13 @@ export const fa: Partial<Strings> = {
     'فایل APK قابل اشتراک‌گذاری نبود. OpenRung را باز نگه دارید و دوباره تلاش کنید.',
   shareApkSplitInstallError:
     'این نسخه با چند فایل APK نصب شده است و نمی‌توان آن را به‌طور امن به اشتراک گذاشت. برای اشتراک‌گذاری آفلاین، فایل APK مستقل OpenRung را نصب کنید.',
+  shareTestFlightTitle: 'اشتراک‌گذاری OpenRung',
+  shareTestFlightSubtitle:
+    'پیوند TestFlight را بفرستید تا دیگران بتای iOS را نصب کنند.',
+  shareTestFlightMessage: 'در TestFlight به بتای OpenRung بپیوندید:',
+  shareTestFlightErrorTitle: 'اشتراک‌گذاری OpenRung ممکن نیست',
+  shareTestFlightErrorBody:
+    'پیوند TestFlight به اشتراک گذاشته نشد. دوباره تلاش کنید.',
 
   // Home tagline + about screen.
   homeTagline: 'شبکهٔ رله‌ها',

--- a/src/i18n/strings/my.ts
+++ b/src/i18n/strings/my.ts
@@ -119,6 +119,13 @@ export const my: Partial<Strings> = {
     'APK ကို မျှဝေ၍မရပါ။ OpenRung ကို ဖွင့်ထားပြီး ထပ်မံကြိုးစားပါ။',
   shareApkSplitInstallError:
     'ဤမိတ္တူကို APK ဖိုင်များစွာဖြင့် ထည့်သွင်းထားသဖြင့် လုံခြုံစွာ မျှဝေ၍မရပါ။ အင်တာနက်မလိုဘဲ မျှဝေရန် OpenRung ၏ သီးခြား APK ကို ထည့်သွင်းပါ။',
+  shareTestFlightTitle: 'OpenRung ကို မျှဝေပါ',
+  shareTestFlightSubtitle:
+    'iOS beta ကို ထည့်သွင်းနိုင်ရန် TestFlight လင့်ခ်ကို ပေးပို့ပါ။',
+  shareTestFlightMessage: 'TestFlight တွင် OpenRung beta သို့ ပါဝင်ပါ –',
+  shareTestFlightErrorTitle: 'OpenRung ကို မျှဝေ၍မရပါ',
+  shareTestFlightErrorBody:
+    'TestFlight လင့်ခ်ကို မျှဝေ၍မရပါ။ ထပ်မံကြိုးစားပါ။',
 
   // Home overlay tagline.
   homeTagline: 'ရီလေး ကွန်ရက်',

--- a/src/i18n/strings/ru.ts
+++ b/src/i18n/strings/ru.ts
@@ -108,6 +108,13 @@ export const ru: Partial<Strings> = {
     'Не удалось поделиться APK. Оставьте OpenRung открытым и повторите попытку.',
   shareApkSplitInstallError:
     'Эта копия установлена из нескольких APK и не может быть безопасно передана. Установите отдельный APK OpenRung, чтобы использовать офлайн-обмен.',
+  shareTestFlightTitle: 'Поделиться OpenRung',
+  shareTestFlightSubtitle:
+    'Отправьте ссылку TestFlight, чтобы другие могли установить iOS-бету.',
+  shareTestFlightMessage: 'Присоединяйтесь к бете OpenRung в TestFlight:',
+  shareTestFlightErrorTitle: 'Не удалось поделиться OpenRung',
+  shareTestFlightErrorBody:
+    'Не удалось поделиться ссылкой TestFlight. Попробуйте ещё раз.',
 
   // Home overlay / about screen.
   homeTagline: 'сеть ретрансляторов',

--- a/src/i18n/strings/tr.ts
+++ b/src/i18n/strings/tr.ts
@@ -110,6 +110,13 @@ export const tr: Partial<Strings> = {
   shareApkErrorBody: "APK paylaşılamadı. OpenRung'u açık tutup tekrar deneyin.",
   shareApkSplitInstallError:
     "Bu kopya birden fazla APK dosyasıyla yüklendiği için güvenle paylaşılamaz. Çevrimdışı paylaşım için bağımsız OpenRung APK'sını yükleyin.",
+  shareTestFlightTitle: "OpenRung'u paylaş",
+  shareTestFlightSubtitle:
+    "Başkalarının iOS betasını kurabilmesi için TestFlight bağlantısı gönderin.",
+  shareTestFlightMessage: "TestFlight'ta OpenRung betasına katılın:",
+  shareTestFlightErrorTitle: 'OpenRung paylaşılamıyor',
+  shareTestFlightErrorBody:
+    'TestFlight bağlantısı paylaşılamadı. Tekrar deneyin.',
 
   // Home overlay tagline.
   homeTagline: 'röle ağı',

--- a/src/i18n/strings/vi.ts
+++ b/src/i18n/strings/vi.ts
@@ -106,6 +106,13 @@ export const vi: Partial<Strings> = {
     'Không thể chia sẻ APK. Hãy giữ OpenRung đang mở và thử lại.',
   shareApkSplitInstallError:
     'Bản này được cài bằng nhiều tệp APK nên không thể chia sẻ an toàn. Hãy cài APK OpenRung độc lập để dùng tính năng chia sẻ ngoại tuyến.',
+  shareTestFlightTitle: 'Chia sẻ OpenRung',
+  shareTestFlightSubtitle:
+    'Gửi liên kết TestFlight để người khác cài bản beta iOS.',
+  shareTestFlightMessage: 'Tham gia bản beta OpenRung trên TestFlight:',
+  shareTestFlightErrorTitle: 'Không thể chia sẻ OpenRung',
+  shareTestFlightErrorBody:
+    'Không thể chia sẻ liên kết TestFlight. Hãy thử lại.',
 
   // Home overlay and about screen.
   homeTagline: 'mạng lưới relay',

--- a/src/i18n/strings/zh-CN.ts
+++ b/src/i18n/strings/zh-CN.ts
@@ -108,6 +108,11 @@ export const zhCN: Partial<Strings> = {
   shareApkErrorBody: '无法分享 APK。请保持 OpenRung 打开并重试。',
   shareApkSplitInstallError:
     '此版本由多个 APK 文件安装，无法安全分享。请安装 OpenRung 独立 APK 后使用离线分享。',
+  shareTestFlightTitle: '分享 OpenRung',
+  shareTestFlightSubtitle: '发送 TestFlight 链接，供他人安装 iOS 测试版。',
+  shareTestFlightMessage: '通过 TestFlight 加入 OpenRung 测试版：',
+  shareTestFlightErrorTitle: '无法分享 OpenRung',
+  shareTestFlightErrorBody: '无法分享 TestFlight 链接。请重试。',
 
   // Home tagline and about screen.
   homeTagline: '中继网络',

--- a/src/i18n/strings/zh-TW.ts
+++ b/src/i18n/strings/zh-TW.ts
@@ -100,6 +100,11 @@ export const zhTW: Partial<Strings> = {
   shareApkErrorBody: '無法分享 APK。請保持 OpenRung 開啟並再試一次。',
   shareApkSplitInstallError:
     '此版本由多個 APK 檔案安裝，無法安全分享。請安裝 OpenRung 獨立 APK 後使用離線分享。',
+  shareTestFlightTitle: '分享 OpenRung',
+  shareTestFlightSubtitle: '傳送 TestFlight 連結，供他人安裝 iOS 測試版。',
+  shareTestFlightMessage: '透過 TestFlight 加入 OpenRung 測試版：',
+  shareTestFlightErrorTitle: '無法分享 OpenRung',
+  shareTestFlightErrorBody: '無法分享 TestFlight 連結。請再試一次。',
 
   // Home tagline + about screen.
   homeTagline: '中繼網路',

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,13 +1,24 @@
 /**
  * Settings tab. Large title (it's a root tab now — no back arrow), then
- * sectioned panels: GENERAL (language and Android offline sharing) and
- * DIAGNOSTICS (relay speed test, debug console). Version and licenses live on
- * the About tab. The language picker mirrors the production dropdown semantics
- * with a dark-styled modal list; the speed test RUN button is enabled only
- * while connected and not already running.
+ * sectioned panels: GENERAL (language plus per-platform sharing — Android
+ * offline APK, iOS TestFlight invite link) and DIAGNOSTICS (relay speed test,
+ * debug console). Version and licenses live on the About tab. The language
+ * picker mirrors the production dropdown semantics with a dark-styled modal
+ * list; the speed test RUN button is enabled only while connected and not
+ * already running.
  */
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { Alert, Modal, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import {
+  Alert,
+  Modal,
+  Platform,
+  Pressable,
+  ScrollView,
+  Share,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { SettingPanel } from '../components/SettingPanel';
@@ -31,6 +42,13 @@ import { monoFont, palette, tokens } from '../theme';
 export interface SettingsScreenProps {
   onOpenDebug: () => void;
 }
+
+/**
+ * iOS counterpart of Android's offline APK sharing: nothing to link natively — the TestFlight
+ * invite link just goes to the system share sheet. Hidden until TESTFLIGHT_URL is configured.
+ */
+const isTestFlightShareAvailable =
+  Platform.OS === 'ios' && AppConfig.TESTFLIGHT_URL.length > 0;
 
 export function SettingsScreen({ onOpenDebug }: SettingsScreenProps): React.JSX.Element {
   const s = useStrings();
@@ -74,6 +92,15 @@ export function SettingsScreen({ onOpenDebug }: SettingsScreenProps): React.JSX.
           ? s.shareApkSplitInstallError
           : s.shareApkErrorBody;
       Alert.alert(s.shareApkErrorTitle, message);
+    });
+  }, [s]);
+
+  const onShareTestFlight = useCallback(() => {
+    Share.share(
+      { message: s.shareTestFlightMessage, url: AppConfig.TESTFLIGHT_URL },
+      { subject: s.shareTestFlightTitle },
+    ).catch(() => {
+      Alert.alert(s.shareTestFlightErrorTitle, s.shareTestFlightErrorBody);
     });
   }, [s]);
 
@@ -160,6 +187,13 @@ export function SettingsScreen({ onOpenDebug }: SettingsScreenProps): React.JSX.
           title={s.shareApkTitle}
           subtitle={s.shareApkSubtitle}
           onPress={onShareApk}
+        />
+      ) : null}
+      {isTestFlightShareAvailable ? (
+        <SettingPanel
+          title={s.shareTestFlightTitle}
+          subtitle={s.shareTestFlightSubtitle}
+          onPress={onShareTestFlight}
         />
       ) : null}
 


### PR DESCRIPTION
## Summary
- Adds an iOS-only "Share OpenRung" row in Settings → General, the counterpart to Android's "Share OpenRung offline" APK-sharing row. Since there's no APK to send on iOS, it shares a TestFlight public invite link via the native `Share` sheet instead.
- The row is gated on a new `AppConfig.TESTFLIGHT_URL` constant ([src/config.ts](src/config.ts)), now set to the external beta group's public link (`https://testflight.apple.com/join/RMTt4UfQ`). The gate is kept rather than hardcoding the URL at the call site so the row hides itself automatically if the link is ever cleared or the group is recreated.
- Added `shareTestFlight*` strings to English and all 8 translated locales (zh-CN, zh-TW, fa, ru, ar, tr, vi, my), matching the existing `shareApk*` coverage.
- Extended `__tests__/screens/SettingsScreen.test.tsx` with two tests mirroring the Android sharing tests: row placement + share-sheet invocation, and the failure-alert path. The tests mock the config with their own URL, so they don't break if the real link is rotated.

## Reviewer notes
- Per `RELEASE.md` §5, external TestFlight distribution of this GPL-linked binary has an unresolved licensing caveat (internal testing only has been the working policy). This PR ships an **external** group's public link, so that caveat is now live rather than hypothetical — worth a conscious sign-off before release.
- Both platform rows (`isApkShareAvailable` for Android, `isTestFlightShareAvailable` for iOS) are simple `Platform.OS` checks computed once, so only one ever renders per build.

## Test plan
- [x] `tsc --noEmit` — clean
- [x] `npm run lint` — no new warnings
- [x] `npx jest` — 141/141 passing across all 11 suites
- [ ] Manual verification on a real iOS build — not done in this session; worth confirming the share sheet shows the link correctly and that the invite actually resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)