### PR TITLE
feat: in-app update check with signed manifest and broadcast channel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,17 @@ jobs:
         with:
           node-version: '22'
           cache: npm
+
+      # Fail fast on update-manifest problems BEFORE the ~30-minute Android build: an invalid
+      # policy file, broken vectors, or a signing seed that doesn't match the pinned keys would
+      # otherwise only surface in the post-build generate step. Needs no node_modules.
+      - name: Validate update manifest inputs
+        env:
+          OPENRUNG_MANIFEST_SIGNING_SEED_B64: ${{ secrets.OPENRUNG_MANIFEST_SIGNING_SEED_B64 }}
+        run: |
+          node scripts/update-manifest.mjs check
+          node scripts/update-manifest.mjs generate --out /tmp/update-manifest-preflight.json
+
       - run: npm ci
 
       - uses: actions/setup-java@v4
@@ -150,6 +161,14 @@ jobs:
           cp android/app/build/outputs/apk/release/app-release.apk "$ASSET"
           cp android/app/build/outputs/apk/release/app-release.apk openrung-android.apk
 
+      # The in-app update check reads this envelope (docs/UPDATE_MANIFEST.md). Signing is
+      # optional-but-strongly-wanted: without the seed secret the envelope ships unsigned and
+      # clients cap it at the passive "update available" tier (no banner, no kill switch).
+      - name: Generate update manifest
+        env:
+          OPENRUNG_MANIFEST_SIGNING_SEED_B64: ${{ secrets.OPENRUNG_MANIFEST_SIGNING_SEED_B64 }}
+        run: node scripts/update-manifest.mjs generate --out update-manifest.json
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
@@ -160,6 +179,7 @@ jobs:
           files: |
             ${{ env.ASSET }}
             openrung-android.apk
+            update-manifest.json
 
       # Optional: mirror to Cloudflare R2, but only if the token secret is configured.
       # No-op (not a failure) when CLOUDFLARE_API_TOKEN is absent.
@@ -181,4 +201,9 @@ jobs:
             "openrung-downloads/android/openrung-android.apk" \
             --file openrung-android.apk \
             --content-type application/vnd.android.package-archive \
+            --remote
+          npx --yes wrangler@4 r2 object put \
+            "openrung-downloads/app/update-manifest.json" \
+            --file update-manifest.json \
+            --content-type application/json \
             --remote

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,14 +161,6 @@ jobs:
           cp android/app/build/outputs/apk/release/app-release.apk "$ASSET"
           cp android/app/build/outputs/apk/release/app-release.apk openrung-android.apk
 
-      # The in-app update check reads this envelope (docs/UPDATE_MANIFEST.md). Signing is
-      # optional-but-strongly-wanted: without the seed secret the envelope ships unsigned and
-      # clients cap it at the passive "update available" tier (no banner, no kill switch).
-      - name: Generate update manifest
-        env:
-          OPENRUNG_MANIFEST_SIGNING_SEED_B64: ${{ secrets.OPENRUNG_MANIFEST_SIGNING_SEED_B64 }}
-        run: node scripts/update-manifest.mjs generate --out update-manifest.json
-
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
@@ -179,7 +171,6 @@ jobs:
           files: |
             ${{ env.ASSET }}
             openrung-android.apk
-            update-manifest.json
 
       # Optional: mirror to Cloudflare R2, but only if the token secret is configured.
       # No-op (not a failure) when CLOUDFLARE_API_TOKEN is absent.
@@ -202,8 +193,14 @@ jobs:
             --file openrung-android.apk \
             --content-type application/vnd.android.package-archive \
             --remote
-          npx --yes wrangler@4 r2 object put \
-            "openrung-downloads/app/update-manifest.json" \
-            --file update-manifest.json \
-            --content-type application/json \
-            --remote
+
+  # Publish update-manifest.json through the ONE serialized publisher (shared concurrency mutex,
+  # always generated from latest main) — never from this job's checkout: a ~30-min build racing a
+  # policy edit must not overwrite the newer policy with a stale-but-fresher-stamped manifest.
+  # See docs/UPDATE_MANIFEST.md.
+  publish-manifest:
+    needs: release
+    uses: ./.github/workflows/update-manifest.yml
+    permissions:
+      contents: write
+    secrets: inherit

--- a/.github/workflows/update-manifest.yml
+++ b/.github/workflows/update-manifest.yml
@@ -37,16 +37,13 @@ jobs:
       - name: Validate policy and vectors
         run: node scripts/update-manifest.mjs check
 
-      - name: Generate update manifest
-        env:
-          OPENRUNG_MANIFEST_SIGNING_SEED_B64: ${{ secrets.OPENRUNG_MANIFEST_SIGNING_SEED_B64 }}
-        run: node scripts/update-manifest.mjs generate --out update-manifest.json
-
-      # Clobber the asset on the LATEST release so the stable
-      # releases/latest/download/update-manifest.json URL serves the new policy immediately.
-      # Only a genuine 404 (no release exists yet) skips; auth/API/network failures must FAIL the
-      # run — a green skip while the broadcast never shipped would be silently wrong.
-      - name: Upload to latest GitHub release
+      # The advertised Android version comes from the latest RELEASE, never from main's
+      # package.json: a version bump whose release is still building (or failed) must not be
+      # advertised before the APK exists. Only a genuine 404 (no release yet) skips the whole
+      # publish; auth/API/network failures must FAIL the run — a green skip while the broadcast
+      # never shipped would be silently wrong.
+      - name: Resolve latest release
+        id: latest
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -56,17 +53,37 @@ jobs:
           set -e
           if [ "$status" -ne 0 ]; then
             if grep -q "HTTP 404" gh-error.txt; then
-              echo "::notice::No release exists yet — skipping release-asset upload."
+              echo "::notice::No release exists yet — nothing to publish a manifest against."
+              echo "tag=" >> "$GITHUB_OUTPUT"
               exit 0
             fi
             echo "::error::Could not resolve the latest release:"
             cat gh-error.txt
             exit 1
           fi
-          gh release upload "$tag" update-manifest.json --clobber
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Generate update manifest
+        if: steps.latest.outputs.tag != ''
+        env:
+          OPENRUNG_MANIFEST_SIGNING_SEED_B64: ${{ secrets.OPENRUNG_MANIFEST_SIGNING_SEED_B64 }}
+          LATEST_TAG: ${{ steps.latest.outputs.tag }}
+        run: |
+          node scripts/update-manifest.mjs generate \
+            --out update-manifest.json \
+            --android-latest "${LATEST_TAG#v}"
+
+      # Clobber the asset on the LATEST release so the stable
+      # releases/latest/download/update-manifest.json URL serves the new policy immediately.
+      - name: Upload to latest GitHub release
+        if: steps.latest.outputs.tag != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ steps.latest.outputs.tag }}" update-manifest.json --clobber
 
       # Optional R2 mirror, same conditional convention as release.yml.
       - name: Mirror to Cloudflare R2
+        if: steps.latest.outputs.tag != ''
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/update-manifest.yml
+++ b/.github/workflows/update-manifest.yml
@@ -1,0 +1,82 @@
+name: Publish update manifest
+
+# The broadcast path of the in-app update check (docs/UPDATE_MANIFEST.md): editing
+# release/update-policy.json on main republishes the signed manifest to the LATEST GitHub
+# release asset and the R2 mirror — no app release needed. release.yml also attaches a fresh
+# manifest to every new release; both producers generate from the same repo state, so
+# last-writer-wins is always consistent.
+#
+# push-only (never pull_request) so fork PRs cannot reach the signing seed secret.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - release/update-policy.json
+      - scripts/update-manifest.mjs
+  workflow_dispatch:
+
+concurrency:
+  group: publish-update-manifest
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write # upload the asset onto the latest release
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      # scripts/update-manifest.mjs uses only node:crypto — no npm ci needed.
+      - name: Validate policy and vectors
+        run: node scripts/update-manifest.mjs check
+
+      - name: Generate update manifest
+        env:
+          OPENRUNG_MANIFEST_SIGNING_SEED_B64: ${{ secrets.OPENRUNG_MANIFEST_SIGNING_SEED_B64 }}
+        run: node scripts/update-manifest.mjs generate --out update-manifest.json
+
+      # Clobber the asset on the LATEST release so the stable
+      # releases/latest/download/update-manifest.json URL serves the new policy immediately.
+      # Only a genuine 404 (no release exists yet) skips; auth/API/network failures must FAIL the
+      # run — a green skip while the broadcast never shipped would be silently wrong.
+      - name: Upload to latest GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set +e
+          tag=$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name 2>gh-error.txt)
+          status=$?
+          set -e
+          if [ "$status" -ne 0 ]; then
+            if grep -q "HTTP 404" gh-error.txt; then
+              echo "::notice::No release exists yet — skipping release-asset upload."
+              exit 0
+            fi
+            echo "::error::Could not resolve the latest release:"
+            cat gh-error.txt
+            exit 1
+          fi
+          gh release upload "$tag" update-manifest.json --clobber
+
+      # Optional R2 mirror, same conditional convention as release.yml.
+      - name: Mirror to Cloudflare R2
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          if [ -z "$CLOUDFLARE_API_TOKEN" ]; then
+            echo "CLOUDFLARE_API_TOKEN not set — skipping R2 mirror."
+            exit 0
+          fi
+          npx --yes wrangler@4 r2 object put \
+            "openrung-downloads/app/update-manifest.json" \
+            --file update-manifest.json \
+            --content-type application/json \
+            --remote

--- a/.github/workflows/update-manifest.yml
+++ b/.github/workflows/update-manifest.yml
@@ -1,12 +1,17 @@
 name: Publish update manifest
 
-# The broadcast path of the in-app update check (docs/UPDATE_MANIFEST.md): editing
-# release/update-policy.json on main republishes the signed manifest to the LATEST GitHub
-# release asset and the R2 mirror — no app release needed. release.yml also attaches a fresh
-# manifest to every new release; both producers generate from the same repo state, so
-# last-writer-wins is always consistent.
+# The ONE publisher of update-manifest.json (docs/UPDATE_MANIFEST.md). Three ways in, one
+# serialized code path:
+#   - push to main touching release/update-policy.json (the broadcast path — no app release)
+#   - workflow_dispatch (manual re-publish)
+#   - workflow_call from release.yml after each release is created
+# Serializing every path behind one concurrency mutex, and ALWAYS generating from latest main,
+# is what prevents the stale-publisher race: a ~30-min release build that generated its own
+# manifest from its job-start checkout could otherwise overwrite a newer policy published while
+# it was building — with a wall-clock generated_at that clients would trust as newer.
 #
-# push-only (never pull_request) so fork PRs cannot reach the signing seed secret.
+# push-only + call from a push-only workflow (never pull_request) so fork PRs cannot reach the
+# signing seed secret.
 
 on:
   push:
@@ -15,19 +20,28 @@ on:
       - release/update-policy.json
       - scripts/update-manifest.mjs
   workflow_dispatch:
-
-concurrency:
-  group: publish-update-manifest
-  cancel-in-progress: false
+  workflow_call:
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Shared mutex across every invocation path. Queued runs execute in order and each generates
+    # from latest main, so the final published state is always the newest policy. Keep
+    # cancel-in-progress false: a superseded run still converges, whereas cancelling a
+    # half-publish (release asset written, R2 not) would leave the fronts disagreeing.
+    concurrency:
+      group: publish-update-manifest
+      cancel-in-progress: false
     permissions:
       contents: write # upload the asset onto the latest release
     steps:
       - uses: actions/checkout@v4
+        with:
+          # ALWAYS latest main, never the triggering sha: a release-triggered call arrives ~30
+          # build-minutes after its version-bump commit and must not resurrect the policy as it
+          # stood back then.
+          ref: main
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/update-manifest.yml
+++ b/.github/workflows/update-manifest.yml
@@ -62,7 +62,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set +e
-          tag=$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name 2>gh-error.txt)
+          release_json=$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" 2>gh-error.txt)
           status=$?
           set -e
           if [ "$status" -ne 0 ]; then
@@ -75,17 +75,22 @@ jobs:
             cat gh-error.txt
             exit 1
           fi
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "tag=$(jq -r .tag_name <<<"$release_json")" >> "$GITHUB_OUTPUT"
+          # published_at feeds generated_at so the release input is part of the manifest's
+          # ordering stamp (same-commit republishes after a new release must rank strictly newer).
+          echo "published_at=$(jq -r .published_at <<<"$release_json")" >> "$GITHUB_OUTPUT"
 
       - name: Generate update manifest
         if: steps.latest.outputs.tag != ''
         env:
           OPENRUNG_MANIFEST_SIGNING_SEED_B64: ${{ secrets.OPENRUNG_MANIFEST_SIGNING_SEED_B64 }}
           LATEST_TAG: ${{ steps.latest.outputs.tag }}
+          LATEST_PUBLISHED_AT: ${{ steps.latest.outputs.published_at }}
         run: |
           node scripts/update-manifest.mjs generate \
             --out update-manifest.json \
-            --android-latest "${LATEST_TAG#v}"
+            --android-latest "${LATEST_TAG#v}" \
+            --release-published-at "$LATEST_PUBLISHED_AT"
 
       # Clobber the asset on the LATEST release so the stable
       # releases/latest/download/update-manifest.json URL serves the new policy immediately.

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -17,3 +17,5 @@ jobs:
         with:
           node-version: '22'
       - run: node scripts/check-versions.mjs
+      # Update-manifest policy + signing-vector guard (docs/UPDATE_MANIFEST.md).
+      - run: node scripts/update-manifest.mjs check

--- a/App.tsx
+++ b/App.tsx
@@ -27,12 +27,19 @@ import { LicenseTextScreen } from './src/screens/LicenseTextScreen';
 import { LicensesScreen } from './src/screens/LicensesScreen';
 import { MainScreen } from './src/screens/MainScreen';
 import { SettingsScreen } from './src/screens/SettingsScreen';
+import { UpdateRequiredScreen } from './src/screens/UpdateRequiredScreen';
+import { useAppState } from './src/state/store';
+import { startUpdateCheck } from './src/state/updateCheck';
 import { palette } from './src/theme';
 
 /** Screens pushed over the tabs (each has its own back arrow). */
 type SubRoute = 'DEBUG' | 'LICENSES' | 'LICENSE_TEXT' | null;
 
 function App(): React.JSX.Element {
+  // Kick off the fail-open update check (hydrate + throttled fetch + foreground re-checks).
+  // It never gates rendering: the manifest only ever changes what AppRoutes shows.
+  useEffect(() => startUpdateCheck(), []);
+
   return (
     <SafeAreaProvider>
       <LanguageProvider>
@@ -46,6 +53,7 @@ function App(): React.JSX.Element {
 function AppRoutes(): React.JSX.Element {
   const [tab, setTab] = useState<AppTab>('home');
   const [subRoute, setSubRoute] = useState<SubRoute>(null);
+  const { update } = useAppState();
 
   const goBack = useCallback((): boolean => {
     if (subRoute === 'LICENSE_TEXT') {
@@ -130,6 +138,14 @@ function AppRoutes(): React.JSX.Element {
         </>
       )}
       {subScreen != null ? <View style={styles.subOverlay}>{subScreen}</View> : null}
+      {update.tier === 'blocked' ? (
+        // Verified-manifest kill switch: covers everything including the tab bar. Hardware back
+        // keeps its normal behaviour underneath (worst case it exits the app — that's not a
+        // bypass); "Continue anyway" on the screen is the sanctioned way past it.
+        <View style={styles.subOverlay}>
+          <UpdateRequiredScreen />
+        </View>
+      ) : null}
     </View>
   );
 }

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -290,3 +290,17 @@ re-running `generate-project.sh`).
 The Android `versionCode` and iOS `CURRENT_PROJECT_VERSION` are **build
 numbers**, a separate monotonic integer from the version string; bump those by
 hand per store upload.
+
+## 9. Update manifest (in-app update check)
+
+Every release automatically publishes a signed `update-manifest.json` (release
+asset + R2 mirror) that shipped apps poll to learn about new versions, the
+supported-version floor, and operator broadcasts. Per release, decide ONE
+thing: does this release warrant a prompt? If yes, set `promote: "notify"` in
+[`release/update-policy.json`](release/update-policy.json) in the version-bump
+PR (and revert to `"silent"` in the next one); if it's a routine release,
+touch nothing. Raising `min_supported` (the kill switch) and broadcasting
+notices are policy edits with their own workflow and do not require a release
+at all — see [`release/README.md`](release/README.md) and
+[`docs/UPDATE_MANIFEST.md`](docs/UPDATE_MANIFEST.md) (signing-key handling
+lives there too: secret `OPENRUNG_MANIFEST_SIGNING_SEED_B64`).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -299,7 +299,9 @@ supported-version floor, and operator broadcasts. Per release, decide ONE
 thing: does this release warrant a prompt? If yes, set `promote: "notify"` in
 [`release/update-policy.json`](release/update-policy.json) in the version-bump
 PR (and revert to `"silent"` in the next one); if it's a routine release,
-touch nothing. Raising `min_supported` (the kill switch) and broadcasting
+touch nothing. After manually uploading an iOS build to TestFlight, bump
+`ios_latest` in the same policy file — the manifest advertises exactly that
+to iOS users, so it stays honest while the (manual) iOS pipeline lags Android. Raising `min_supported` (the kill switch) and broadcasting
 notices are policy edits with their own workflow and do not require a release
 at all — see [`release/README.md`](release/README.md) and
 [`docs/UPDATE_MANIFEST.md`](docs/UPDATE_MANIFEST.md) (signing-key handling

--- a/__tests__/core/updateCheck.test.ts
+++ b/__tests__/core/updateCheck.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Update-check orchestration (src/state/updateCheck.ts): hydrate-then-fetch, success/failure
+ * throttles, the cache-replacement trust ladder, and the dismissal actions — all against an
+ * in-memory AsyncStorage and a stubbed fetch (Jest's react-native preset resolves Platform.OS to
+ * 'ios', so fixtures drive the ios manifest section).
+ */
+
+const mockMemoryStore = new Map<string, string>();
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(async (key: string) => mockMemoryStore.get(key) ?? null),
+    setItem: jest.fn(async (key: string, value: string) => {
+      mockMemoryStore.set(key, value);
+    }),
+    removeItem: jest.fn(async (key: string) => {
+      mockMemoryStore.delete(key);
+    }),
+  },
+}));
+
+import { setManifestSigningKeysForTests } from '../../src/net/updateManifestClient';
+import { getSnapshot, resetStoreForTests } from '../../src/state/store';
+import {
+  UPDATE_CHECKED_AT_STORAGE_KEY,
+  UPDATE_DISMISSED_BANNER_STORAGE_KEY,
+  UPDATE_DISMISSED_NOTICES_STORAGE_KEY,
+  UPDATE_MANIFEST_STORAGE_KEY,
+  continueDespiteBlock,
+  dismissUpdateBanner,
+  dismissUpdateNotice,
+  refreshUpdateManifest,
+  resetUpdateCheckForTests,
+  startUpdateCheck,
+} from '../../src/state/updateCheck';
+import {
+  TEST_MANIFEST_KEY,
+  envelopeFor,
+  manifestPayload,
+  manifestResponse,
+} from '../helpers/updateManifest';
+
+const originalFetch = globalThis.fetch;
+
+/** Lets the service's fire-and-forget async chains settle. */
+async function flush(): Promise<void> {
+  for (let i = 0; i < 8; i++) {
+    await new Promise<void>(resolve => setTimeout(() => resolve(), 0));
+  }
+}
+
+function mockFetchReturning(...bodies: (string | Error)[]): jest.Mock {
+  const mock = jest.fn();
+  for (const body of bodies) {
+    if (body instanceof Error) {
+      mock.mockRejectedValueOnce(body);
+    } else {
+      mock.mockResolvedValueOnce(manifestResponse(body));
+    }
+  }
+  globalThis.fetch = mock as unknown as typeof fetch;
+  return mock;
+}
+
+beforeEach(() => {
+  mockMemoryStore.clear();
+  resetStoreForTests();
+  resetUpdateCheckForTests();
+  setManifestSigningKeysForTests([TEST_MANIFEST_KEY]);
+});
+
+afterEach(() => {
+  resetUpdateCheckForTests();
+  setManifestSigningKeysForTests(null);
+  globalThis.fetch = originalFetch;
+});
+
+// APP_VERSION is 0.x.y, so ios latest 9.9.9 is always "behind".
+const iosPayload = (ios: Record<string, unknown>, extra: Record<string, unknown> = {}) =>
+  manifestPayload({ ios, ...extra });
+
+describe('refreshUpdateManifest', () => {
+  it('fetches, persists, and mirrors the derived tier into the store', async () => {
+    const envelope = envelopeFor(iosPayload({ latest: '9.9.9', min_supported: '0.0.0' }));
+    const fetchMock = mockFetchReturning(envelope);
+
+    await refreshUpdateManifest(true);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(getSnapshot().update.tier).toBe('available');
+    expect(getSnapshot().update.latestVersion).toBe('9.9.9');
+    expect(mockMemoryStore.get(UPDATE_MANIFEST_STORAGE_KEY)).toBe(envelope);
+    expect(Number(mockMemoryStore.get(UPDATE_CHECKED_AT_STORAGE_KEY))).toBeGreaterThan(0);
+  });
+
+  it('throttles after a success and backs off after a failure', async () => {
+    const envelope = envelopeFor(iosPayload({ latest: '9.9.9' }));
+    const fetchMock = mockFetchReturning(envelope);
+    await refreshUpdateManifest(true);
+    await refreshUpdateManifest(); // within the 6h window — must not fetch
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    resetUpdateCheckForTests();
+    resetStoreForTests();
+    mockMemoryStore.clear();
+    const failing = mockFetchReturning(
+      new Error('down'),
+      new Error('down'),
+      new Error('down'),
+    );
+    await refreshUpdateManifest(true); // burns all 3 candidates
+    expect(getSnapshot().update.tier).toBe('none'); // fail open
+    expect(mockMemoryStore.get(UPDATE_CHECKED_AT_STORAGE_KEY)).toBeUndefined();
+    await refreshUpdateManifest(); // inside the 15-min failure backoff — must not fetch
+    expect(failing).toHaveBeenCalledTimes(3);
+  });
+
+  it('never lets an older verified manifest roll back a newer one', async () => {
+    const newer = envelopeFor(
+      iosPayload({ latest: '9.9.9' }, { generated_at: '2026-07-22T00:00:00Z' }),
+    );
+    const older = envelopeFor(
+      iosPayload({ latest: '8.8.8' }, { generated_at: '2026-07-01T00:00:00Z' }),
+    );
+    mockFetchReturning(newer);
+    await refreshUpdateManifest(true);
+    mockFetchReturning(older);
+    await refreshUpdateManifest(true);
+
+    expect(getSnapshot().update.latestVersion).toBe('9.9.9');
+    expect(mockMemoryStore.get(UPDATE_MANIFEST_STORAGE_KEY)).toBe(newer);
+  });
+
+  it('never lets an unsigned manifest displace a verified one', async () => {
+    const signed = envelopeFor(iosPayload({ latest: '9.9.9' }));
+    const stripped = envelopeFor(
+      iosPayload({ latest: '8.8.8' }, { generated_at: '2027-01-01T00:00:00Z' }),
+      { omitSig: true },
+    );
+    mockFetchReturning(signed);
+    await refreshUpdateManifest(true);
+    mockFetchReturning(stripped);
+    await refreshUpdateManifest(true);
+
+    expect(getSnapshot().update.latestVersion).toBe('9.9.9');
+    expect(getSnapshot().update.verified).toBe(true);
+  });
+
+  it('does not count a sig-stripped fetch against a verified cache as a success', async () => {
+    mockFetchReturning(envelopeFor(iosPayload({ latest: '9.9.9' })));
+    await refreshUpdateManifest(true);
+    const checkedAtAfterSuccess = mockMemoryStore.get(UPDATE_CHECKED_AT_STORAGE_KEY);
+
+    // All three candidates serve only an unsigned copy — the walk returns the unsigned fallback,
+    // which must be treated as a FAILED check: no checkedAt bump, cache untouched.
+    const stripped = envelopeFor(iosPayload({ latest: '8.8.8' }), { omitSig: true });
+    mockFetchReturning(stripped, stripped, stripped);
+    await refreshUpdateManifest(true);
+
+    expect(mockMemoryStore.get(UPDATE_CHECKED_AT_STORAGE_KEY)).toBe(checkedAtAfterSuccess);
+    expect(getSnapshot().update.latestVersion).toBe('9.9.9');
+    expect(getSnapshot().update.verified).toBe(true);
+  });
+
+  it('a future persisted checkedAt (clock skew) does not freeze the check cadence', async () => {
+    const T0 = 1_800_000_000_000;
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(T0);
+    try {
+      // Persisted under a clock a year ahead; without the hydrate clamp this would throttle
+      // every refresh until wall-clock catches up.
+      mockMemoryStore.set(UPDATE_CHECKED_AT_STORAGE_KEY, String(T0 + 365 * 24 * 3_600_000));
+      const fetchMock = mockFetchReturning(envelopeFor(iosPayload({ latest: '9.9.9' })));
+
+      const stop = startUpdateCheck();
+      await flush();
+      // Clamped to "now": treated as freshly checked, so the cold-start refresh is throttled…
+      expect(fetchMock).toHaveBeenCalledTimes(0);
+
+      // …but one ordinary interval later the cadence resumes instead of being frozen for a year.
+      nowSpy.mockReturnValue(T0 + 7 * 3_600_000);
+      await refreshUpdateManifest();
+      stop();
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(getSnapshot().update.latestVersion).toBe('9.9.9');
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it('unsigned-over-unsigned is last-write-wins', async () => {
+    mockFetchReturning(envelopeFor(iosPayload({ latest: '9.9.9' }), { omitSig: true }));
+    await refreshUpdateManifest(true);
+    mockFetchReturning(envelopeFor(iosPayload({ latest: '8.8.8' }), { omitSig: true }));
+    await refreshUpdateManifest(true);
+
+    expect(getSnapshot().update.latestVersion).toBe('8.8.8');
+    expect(getSnapshot().update.verified).toBe(false);
+  });
+});
+
+describe('startUpdateCheck', () => {
+  it('hydrates a persisted manifest without fetching when the check is fresh', async () => {
+    const envelope = envelopeFor(iosPayload({ latest: '9.9.9' }));
+    mockMemoryStore.set(UPDATE_MANIFEST_STORAGE_KEY, envelope);
+    mockMemoryStore.set(UPDATE_CHECKED_AT_STORAGE_KEY, String(Date.now()));
+    const fetchMock = mockFetchReturning();
+
+    const stop = startUpdateCheck();
+    await flush();
+    stop();
+
+    expect(getSnapshot().update.tier).toBe('available');
+    expect(getSnapshot().update.verified).toBe(true);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('drops a cached envelope that no longer verifies and keeps running', async () => {
+    mockMemoryStore.set(UPDATE_MANIFEST_STORAGE_KEY, 'corrupted{{{');
+    mockMemoryStore.set(UPDATE_CHECKED_AT_STORAGE_KEY, String(Date.now()));
+    const fetchMock = mockFetchReturning();
+
+    const stop = startUpdateCheck();
+    await flush();
+    stop();
+
+    expect(getSnapshot().update.tier).toBe('none');
+    expect(mockMemoryStore.has(UPDATE_MANIFEST_STORAGE_KEY)).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('is idempotent while started', async () => {
+    mockMemoryStore.set(UPDATE_CHECKED_AT_STORAGE_KEY, String(Date.now()));
+    mockFetchReturning();
+    const stop = startUpdateCheck();
+    const stopAgain = startUpdateCheck(); // no-op
+    await flush();
+    stopAgain();
+    stop();
+  });
+});
+
+describe('dismissals and the block override', () => {
+  it('banner dismissal persists and downgrades notify -> available', async () => {
+    mockFetchReturning(
+      envelopeFor(iosPayload({ latest: '9.9.9' }, { promote: 'notify' })),
+    );
+    await refreshUpdateManifest(true);
+    expect(getSnapshot().update.tier).toBe('notify');
+
+    dismissUpdateBanner();
+    expect(getSnapshot().update.tier).toBe('available');
+    expect(mockMemoryStore.get(UPDATE_DISMISSED_BANNER_STORAGE_KEY)).toBe('9.9.9');
+  });
+
+  it('notice dismissal persists by id', async () => {
+    const withNotice = {
+      id: 'maintenance-1',
+      level: 'warn',
+      title: { en: 'Heads up' },
+      body: { en: 'Something is changing.' },
+      url: null,
+      expires: null,
+    };
+    mockFetchReturning(envelopeFor(iosPayload({ latest: '9.9.9' }, { notice: withNotice })));
+    await refreshUpdateManifest(true);
+    expect(getSnapshot().update.notice?.id).toBe('maintenance-1');
+
+    dismissUpdateNotice('maintenance-1');
+    expect(getSnapshot().update.notice).toBeNull();
+    expect(JSON.parse(mockMemoryStore.get(UPDATE_DISMISSED_NOTICES_STORAGE_KEY) ?? '[]')).toEqual([
+      'maintenance-1',
+    ]);
+  });
+
+  it('continueDespiteBlock downgrades blocked -> available for the session', async () => {
+    mockFetchReturning(
+      envelopeFor(iosPayload({ latest: '9.9.9', min_supported: '9.0.0' })),
+    );
+    await refreshUpdateManifest(true);
+    expect(getSnapshot().update.tier).toBe('blocked');
+
+    continueDespiteBlock();
+    expect(getSnapshot().update.tier).toBe('available');
+  });
+});

--- a/__tests__/core/updateCheck.test.ts
+++ b/__tests__/core/updateCheck.test.ts
@@ -86,7 +86,8 @@ describe('refreshUpdateManifest', () => {
 
     await refreshUpdateManifest(true);
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // No verified cache yet -> survey mode: every configured candidate is consulted once.
+    expect(fetchMock).toHaveBeenCalledTimes(3);
     expect(getSnapshot().update.tier).toBe('available');
     expect(getSnapshot().update.latestVersion).toBe('9.9.9');
     expect(mockMemoryStore.get(UPDATE_MANIFEST_STORAGE_KEY)).toBe(envelope);
@@ -96,9 +97,9 @@ describe('refreshUpdateManifest', () => {
   it('throttles after a success and backs off after a failure', async () => {
     const envelope = envelopeFor(iosPayload({ latest: '9.9.9' }));
     const fetchMock = mockFetchReturning(envelope);
-    await refreshUpdateManifest(true);
-    await refreshUpdateManifest(); // within the 6h window — must not fetch
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await refreshUpdateManifest(true); // survey mode: 3 candidate calls
+    await refreshUpdateManifest(); // within the 6h window — must not fetch again
+    expect(fetchMock).toHaveBeenCalledTimes(3);
 
     resetUpdateCheckForTests();
     resetStoreForTests();
@@ -146,6 +147,25 @@ describe('refreshUpdateManifest', () => {
     expect(getSnapshot().update.verified).toBe(true);
   });
 
+  it('does not count an all-stale signed replay against a fresher verified cache as a success', async () => {
+    mockFetchReturning(
+      envelopeFor(iosPayload({ latest: '9.9.9' }, { generated_at: '2026-07-22T00:00:00Z' })),
+    );
+    await refreshUpdateManifest(true);
+    const checkedAtAfterSuccess = mockMemoryStore.get(UPDATE_CHECKED_AT_STORAGE_KEY);
+
+    // Every front replays an older signed manifest: the walk returns the newest stale copy,
+    // which must be treated as a FAILED check — no checkedAt bump, cache untouched.
+    const replayed = envelopeFor(
+      iosPayload({ latest: '8.8.8' }, { generated_at: '2026-07-01T00:00:00Z' }),
+    );
+    mockFetchReturning(replayed, replayed, replayed);
+    await refreshUpdateManifest(true);
+
+    expect(mockMemoryStore.get(UPDATE_CHECKED_AT_STORAGE_KEY)).toBe(checkedAtAfterSuccess);
+    expect(getSnapshot().update.latestVersion).toBe('9.9.9');
+  });
+
   it('does not count a sig-stripped fetch against a verified cache as a success', async () => {
     mockFetchReturning(envelopeFor(iosPayload({ latest: '9.9.9' })));
     await refreshUpdateManifest(true);
@@ -180,7 +200,8 @@ describe('refreshUpdateManifest', () => {
       nowSpy.mockReturnValue(T0 + 7 * 3_600_000);
       await refreshUpdateManifest();
       stop();
-      expect(fetchMock).toHaveBeenCalledTimes(1);
+      // No verified cache (only checkedAt was seeded) -> survey mode consults all 3 candidates.
+      expect(fetchMock).toHaveBeenCalledTimes(3);
       expect(getSnapshot().update.latestVersion).toBe('9.9.9');
     } finally {
       nowSpy.mockRestore();

--- a/__tests__/core/updateCheck.test.ts
+++ b/__tests__/core/updateCheck.test.ts
@@ -206,6 +206,10 @@ describe('refreshUpdateManifest', () => {
     try {
       // Persisted under a clock a year ahead; without the hydrate clamp this would throttle
       // every refresh until wall-clock catches up.
+      mockMemoryStore.set(
+        UPDATE_MANIFEST_STORAGE_KEY,
+        envelopeFor(iosPayload({ latest: '9.9.9' })),
+      );
       mockMemoryStore.set(UPDATE_CHECKED_AT_STORAGE_KEY, String(T0 + 365 * 24 * 3_600_000));
       const fetchMock = mockFetchReturning(envelopeFor(iosPayload({ latest: '9.9.9' })));
 
@@ -218,8 +222,7 @@ describe('refreshUpdateManifest', () => {
       nowSpy.mockReturnValue(T0 + 7 * 3_600_000);
       await refreshUpdateManifest();
       stop();
-      // No verified cache (only checkedAt was seeded) -> survey mode consults all 3 candidates.
-      expect(fetchMock).toHaveBeenCalledTimes(3);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
       expect(getSnapshot().update.latestVersion).toBe('9.9.9');
     } finally {
       nowSpy.mockRestore();
@@ -253,10 +256,14 @@ describe('startUpdateCheck', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it('drops a cached envelope that no longer verifies and keeps running', async () => {
+  it('drops a cached envelope that no longer verifies and refreshes immediately', async () => {
     mockMemoryStore.set(UPDATE_MANIFEST_STORAGE_KEY, 'corrupted{{{');
     mockMemoryStore.set(UPDATE_CHECKED_AT_STORAGE_KEY, String(Date.now()));
-    const fetchMock = mockFetchReturning();
+    const fetchMock = mockFetchReturning(
+      new Error('down'),
+      new Error('down'),
+      new Error('down'),
+    );
 
     const stop = startUpdateCheck();
     await flush();
@@ -264,7 +271,20 @@ describe('startUpdateCheck', () => {
 
     expect(getSnapshot().update.tier).toBe('none');
     expect(mockMemoryStore.has(UPDATE_MANIFEST_STORAGE_KEY)).toBe(false);
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not let a checkedAt partial write throttle when the manifest body is missing', async () => {
+    mockMemoryStore.set(UPDATE_CHECKED_AT_STORAGE_KEY, String(Date.now()));
+    const envelope = envelopeFor(iosPayload({ latest: '9.9.9' }));
+    const fetchMock = mockFetchReturning(envelope);
+
+    const stop = startUpdateCheck();
+    await flush();
+    stop();
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(getSnapshot().update.latestVersion).toBe('9.9.9');
   });
 
   it('is idempotent while started', async () => {
@@ -309,6 +329,32 @@ describe('dismissals and the block override', () => {
     expect(JSON.parse(mockMemoryStore.get(UPDATE_DISMISSED_NOTICES_STORAGE_KEY) ?? '[]')).toEqual([
       'maintenance-1',
     ]);
+  });
+
+  it('automatically hides a notice when it expires while the app remains active', async () => {
+    const T0 = 1_800_000_000_000;
+    jest.useFakeTimers();
+    jest.setSystemTime(T0);
+    try {
+      const withNotice = {
+        id: 'maintenance-expiring',
+        level: 'info',
+        title: { en: 'Heads up' },
+        body: { en: 'This message expires shortly.' },
+        url: null,
+        expires: new Date(T0 + 1_000).toISOString(),
+      };
+      mockFetchReturning(envelopeFor(iosPayload({ latest: '9.9.9' }, { notice: withNotice })));
+
+      await refreshUpdateManifest(true);
+      expect(getSnapshot().update.notice?.id).toBe('maintenance-expiring');
+
+      jest.advanceTimersByTime(1_001);
+      expect(getSnapshot().update.notice).toBeNull();
+    } finally {
+      resetUpdateCheckForTests();
+      jest.useRealTimers();
+    }
   });
 
   it('continueDespiteBlock downgrades blocked -> available for the session', async () => {

--- a/__tests__/core/updateCheck.test.ts
+++ b/__tests__/core/updateCheck.test.ts
@@ -116,6 +116,24 @@ describe('refreshUpdateManifest', () => {
     expect(failing).toHaveBeenCalledTimes(3);
   });
 
+  it('keeps the cache on an equal-stamp verified fetch (no flapping between fronts)', async () => {
+    // Two different manifests sharing a generated_at should be impossible under the publisher's
+    // stamp-covers-all-inputs invariant; if a front ever serves one anyway, first-writer-wins.
+    const first = envelopeFor(
+      iosPayload({ latest: '9.9.9' }, { generated_at: '2026-07-22T00:00:00Z' }),
+    );
+    const second = envelopeFor(
+      iosPayload({ latest: '8.8.8' }, { generated_at: '2026-07-22T00:00:00Z' }),
+    );
+    mockFetchReturning(first);
+    await refreshUpdateManifest(true);
+    mockFetchReturning(second);
+    await refreshUpdateManifest(true);
+
+    expect(getSnapshot().update.latestVersion).toBe('9.9.9');
+    expect(mockMemoryStore.get(UPDATE_MANIFEST_STORAGE_KEY)).toBe(first);
+  });
+
   it('never lets an older verified manifest roll back a newer one', async () => {
     const newer = envelopeFor(
       iosPayload({ latest: '9.9.9' }, { generated_at: '2026-07-22T00:00:00Z' }),

--- a/__tests__/core/updateManifest.test.ts
+++ b/__tests__/core/updateManifest.test.ts
@@ -318,6 +318,62 @@ describe('fetchUpdateManifest — sequential fail-open', () => {
     expect(fetched?.decoded.verified).toBe(false);
   });
 
+  it('walks past a stale signed front to a fresher one when a freshness floor is set', async () => {
+    const stale = envelopeFor(manifestPayload({ generated_at: '2026-07-01T00:00:00Z' }));
+    const fresh = envelopeFor(manifestPayload({ generated_at: '2026-07-22T00:00:00Z' }));
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(manifestResponse(stale))
+      .mockResolvedValueOnce(manifestResponse(fresh));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const fetched = await fetchUpdateManifest(['https://stale/', 'https://fresh/'], {
+      atLeastGeneratedAtMs: Date.parse('2026-07-22T00:00:00Z'),
+    });
+    expect(fetched?.url).toBe('https://fresh/');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops at the first front when it is at least as fresh as the floor (steady state)', async () => {
+    const current = envelopeFor(manifestPayload({ generated_at: '2026-07-22T00:00:00Z' }));
+    const fetchMock = jest.fn().mockResolvedValue(manifestResponse(current));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const fetched = await fetchUpdateManifest(['https://a/', 'https://b/', 'https://c/'], {
+      atLeastGeneratedAtMs: Date.parse('2026-07-22T00:00:00Z'),
+    });
+    expect(fetched?.url).toBe('https://a/');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns the newest stale copy when no front meets the floor', async () => {
+    const older = envelopeFor(manifestPayload({ generated_at: '2026-07-01T00:00:00Z' }));
+    const newer = envelopeFor(manifestPayload({ generated_at: '2026-07-10T00:00:00Z' }));
+    globalThis.fetch = jest
+      .fn()
+      .mockResolvedValueOnce(manifestResponse(older))
+      .mockResolvedValueOnce(manifestResponse(newer)) as unknown as typeof fetch;
+
+    const fetched = await fetchUpdateManifest(['https://a/', 'https://b/'], {
+      atLeastGeneratedAtMs: Date.parse('2026-07-22T00:00:00Z'),
+    });
+    expect(fetched?.decoded.manifest.generatedAtMs).toBe(Date.parse('2026-07-10T00:00:00Z'));
+  });
+
+  it('with no floor (fresh install) surveys every front and takes the newest verified', async () => {
+    const older = envelopeFor(manifestPayload({ generated_at: '2026-07-01T00:00:00Z' }));
+    const newer = envelopeFor(manifestPayload({ generated_at: '2026-07-10T00:00:00Z' }));
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(manifestResponse(older))
+      .mockResolvedValueOnce(manifestResponse(newer));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const fetched = await fetchUpdateManifest(['https://a/', 'https://b/']);
+    expect(fetched?.url).toBe('https://b/');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it('returns null (never throws) when every candidate fails', async () => {
     globalThis.fetch = jest
       .fn()

--- a/__tests__/core/updateManifest.test.ts
+++ b/__tests__/core/updateManifest.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Update-manifest decode/verify (docs/UPDATE_MANIFEST.md): the committed vector plus negative
+ * variants, the lenient-payload rules, strict version comparison, the pinned-key CI guard, and
+ * the sequential fail-open fetch. Envelopes are signed with the PUBLIC test seed — the
+ * production seed stays offline.
+ */
+import * as ed from '@noble/ed25519';
+
+import { APP_VERSION, AppConfig } from '../../src/config';
+import {
+  compareVersions,
+  decodeUpdateEnvelope,
+  fetchUpdateManifest,
+  setManifestSigningKeysForTests,
+} from '../../src/net/updateManifestClient';
+import { base64ToBytes, bytesToBase64, deriveKeyId, utf8Bytes } from '../helpers/signing';
+import {
+  TEST_MANIFEST_KEY,
+  UNPINNED_SEED_B64,
+  envelopeFor,
+  manifestPayload,
+  manifestResponse,
+  manifestVectors,
+} from '../helpers/updateManifest';
+
+const VECTOR = manifestVectors.vector;
+
+beforeEach(() => {
+  setManifestSigningKeysForTests([TEST_MANIFEST_KEY]);
+});
+
+afterEach(() => {
+  setManifestSigningKeysForTests(null);
+});
+
+describe('decodeUpdateEnvelope — committed vector', () => {
+  it('accepts the vector envelope verbatim', () => {
+    const decoded = decodeUpdateEnvelope(VECTOR.envelope_json);
+    expect(decoded.verified).toBe(true);
+    expect(decoded.keyIdUsed).toBe(manifestVectors.test_key.key_id);
+    expect(decoded.manifest.android).toEqual({ latest: '9.9.9', minSupported: '0.2.0' });
+    expect(decoded.manifest.ios).toEqual({ latest: '9.9.9', minSupported: '0.2.0' });
+    expect(decoded.manifest.promote).toBe('notify');
+    expect(decoded.manifest.generatedAtMs).toBe(Date.parse('2026-07-22T00:00:00Z'));
+    expect(decoded.manifest.notice).toEqual({
+      id: 'vector-notice',
+      level: 'info',
+      title: { en: 'Vector notice', fa: 'اعلان آزمایشی' },
+      body: { en: 'Test-only manifest vector.' },
+      url: null,
+      expiresMs: null,
+    });
+  });
+
+  it('rejects a flipped payload byte', () => {
+    const envelope = JSON.parse(VECTOR.envelope_json) as { payload_b64: string };
+    const bytes = base64ToBytes(envelope.payload_b64);
+    // eslint-disable-next-line no-bitwise -- deliberate single-byte tamper
+    bytes[3] ^= 0x01;
+    const tampered = JSON.stringify({
+      ...JSON.parse(VECTOR.envelope_json),
+      payload_b64: bytesToBase64(bytes),
+    });
+    expect(() => decodeUpdateEnvelope(tampered)).toThrow(/does not verify/);
+  });
+
+  it('rejects a flipped signature byte', () => {
+    const tampered = VECTOR.envelope_json.replace(/"sig":"ed25519;([^;]+);A/, '"sig":"ed25519;$1;B');
+    // Guard the test itself: the replacement must have changed something.
+    const changed =
+      tampered !== VECTOR.envelope_json
+        ? tampered
+        : VECTOR.envelope_json.replace(/0EcgHAmy/, '1EcgHAmy');
+    expect(changed).not.toBe(VECTOR.envelope_json);
+    expect(() => decodeUpdateEnvelope(changed)).toThrow(/invalid/);
+  });
+
+  it('rejects a signature from an unpinned key', () => {
+    const envelope = envelopeFor(manifestPayload(), { seedB64: UNPINNED_SEED_B64 });
+    expect(() => decodeUpdateEnvelope(envelope)).toThrow(/does not verify against any pinned key/);
+  });
+
+  it('still verifies with a wrong advisory key_id in the sig field', () => {
+    const envelope = envelopeFor(manifestPayload(), { keyId: 'ffffffffffffffff' });
+    const decoded = decodeUpdateEnvelope(envelope);
+    expect(decoded.verified).toBe(true);
+    expect(decoded.keyIdUsed).toBe(TEST_MANIFEST_KEY.keyId);
+  });
+
+  it('accepts an unsigned envelope as verified=false', () => {
+    const decoded = decodeUpdateEnvelope(envelopeFor(manifestPayload(), { omitSig: true }));
+    expect(decoded.verified).toBe(false);
+    expect(decoded.keyIdUsed).toBeNull();
+    expect(decoded.manifest.android?.latest).toBe('9.9.9');
+  });
+});
+
+describe('decodeUpdateEnvelope — malformed envelopes', () => {
+  const payload = manifestPayload();
+
+  it.each([
+    ['not JSON', 'nonsense{{{', /not JSON/],
+    ['an array', '[1,2]', /not an object/],
+    ['schema 2', JSON.stringify({ schema: 2, payload_b64: 'AAAA' }), /unsupported envelope schema/],
+    ['missing payload_b64', JSON.stringify({ schema: 1 }), /payload_b64 missing/],
+    ['bad base64', JSON.stringify({ schema: 1, payload_b64: '!!!!' }), /not valid base64/],
+  ])('rejects %s', (_name, raw, pattern) => {
+    expect(() => decodeUpdateEnvelope(raw)).toThrow(pattern);
+  });
+
+  it.each([
+    ['two fields', 'ed25519;abc'],
+    ['four fields', 'ed25519;a;b;c'],
+    ['wrong algorithm', 'rsa;abc;AAAA'],
+    ['non-base64 signature', 'ed25519;abc;@@@@'],
+    ['an empty string', ''],
+  ])('rejects a sig field with %s', (_name, sig) => {
+    expect(() => decodeUpdateEnvelope(envelopeFor(payload, { sig }))).toThrow(/invalid/);
+  });
+
+  it('rejects a present non-string sig (only a truly absent sig decodes as unsigned)', () => {
+    const bytes = JSON.parse(envelopeFor(payload, { omitSig: true })) as Record<string, unknown>;
+    expect(() =>
+      decodeUpdateEnvelope(JSON.stringify({ ...bytes, sig: 123 })),
+    ).toThrow(/malformed sig field/);
+  });
+
+  it('rejects a truncated (63-byte) signature', () => {
+    const sig63 = bytesToBase64(new Uint8Array(63).fill(7));
+    expect(() =>
+      decodeUpdateEnvelope(envelopeFor(payload, { sig: `ed25519;abc;${sig63}` })),
+    ).toThrow(/64 bytes/);
+  });
+
+  it('rejects a payload that is not JSON', () => {
+    expect(() => decodeUpdateEnvelope(envelopeFor('not json at all'))).toThrow(/not JSON/);
+  });
+
+  it('rejects an unsupported payload schema', () => {
+    expect(() =>
+      decodeUpdateEnvelope(envelopeFor(manifestPayload({ schema: 3 }))),
+    ).toThrow(/unsupported payload schema/);
+  });
+});
+
+describe('decodeUpdateEnvelope — lenient payload rules', () => {
+  const decode = (overrides: Record<string, unknown>) =>
+    decodeUpdateEnvelope(envelopeFor(manifestPayload(overrides)));
+
+  it('ignores unknown fields', () => {
+    const decoded = decode({ some_future_field: { deeply: 'nested' } });
+    expect(decoded.manifest.android?.latest).toBe('9.9.9');
+  });
+
+  it('nulls an unparseable latest but keeps the floor', () => {
+    const decoded = decode({ android: { latest: 'v9.9', min_supported: '0.2.0' } });
+    expect(decoded.manifest.android).toEqual({ latest: null, minSupported: '0.2.0' });
+  });
+
+  it('drops a platform section with nothing usable', () => {
+    expect(decode({ android: { latest: 42 } }).manifest.android).toBeNull();
+    expect(decode({ android: 'nope' }).manifest.android).toBeNull();
+  });
+
+  it('treats an unknown promote as silent', () => {
+    expect(decode({ promote: 'shout' }).manifest.promote).toBe('silent');
+  });
+
+  it('drops a notice missing id/title/body', () => {
+    expect(decode({ notice: { id: 'x', title: { en: 't' } } }).manifest.notice).toBeNull();
+    expect(
+      decode({ notice: { id: '', title: { en: 't' }, body: { en: 'b' } } }).manifest.notice,
+    ).toBeNull();
+    expect(
+      decode({ notice: { id: 'x', title: { fa: 'no en' }, body: { en: 'b' } } }).manifest.notice,
+    ).toBeNull();
+  });
+
+  it('renders an unknown notice level as info and drops non-https urls', () => {
+    const decoded = decode({
+      notice: {
+        id: 'n1',
+        level: 'catastrophic',
+        title: { en: 't' },
+        body: { en: 'b' },
+        url: 'http://insecure.example',
+        expires: '2027-01-01T00:00:00Z',
+      },
+    });
+    expect(decoded.manifest.notice?.level).toBe('info');
+    expect(decoded.manifest.notice?.url).toBeNull();
+    expect(decoded.manifest.notice?.expiresMs).toBe(Date.parse('2027-01-01T00:00:00Z'));
+  });
+
+  it('treats a missing/invalid generated_at as 0', () => {
+    expect(decode({ generated_at: 'whenever' }).manifest.generatedAtMs).toBe(0);
+    expect(decode({ generated_at: undefined }).manifest.generatedAtMs).toBe(0);
+  });
+});
+
+describe('compareVersions', () => {
+  it.each([
+    ['0.3.2', '0.3.2', 0],
+    ['0.3.1', '0.3.2', -1],
+    ['0.3.2', '0.3.1', 1],
+    ['0.9.0', '0.10.0', -1],
+    ['1.0.0', '0.99.99', 1],
+    ['0.0.9', '0.1.0', -1],
+  ])('compares %s vs %s numerically', (a, b, expected) => {
+    expect(compareVersions(a, b)).toBe(expected);
+  });
+
+  it.each([['1.2'], ['v1.2.3'], ['1.2.3-beta'], [''], ['1.2.3.4']])(
+    'returns null for unparseable %p',
+    bad => {
+      expect(compareVersions(bad, '1.0.0')).toBeNull();
+      expect(compareVersions('1.0.0', bad)).toBeNull();
+    },
+  );
+
+  it('parses the real APP_VERSION', () => {
+    expect(compareVersions(APP_VERSION, APP_VERSION)).toBe(0);
+  });
+});
+
+describe('pinned-key CI guard', () => {
+  it('MANIFEST_SIGNING_KEYS mirrors the committed pinned_keys block', () => {
+    expect(AppConfig.MANIFEST_SIGNING_KEYS.map(key => key.keyId)).toEqual(
+      manifestVectors.pinned_keys.map(key => key.key_id),
+    );
+    expect(AppConfig.MANIFEST_SIGNING_KEYS.map(key => key.publicKeyHex)).toEqual(
+      manifestVectors.pinned_keys.map(key => key.public_key_hex),
+    );
+  });
+
+  it('every pinned key is well-formed and its vector signature verifies', () => {
+    for (const key of manifestVectors.pinned_keys) {
+      const publicKey = ed.etc.hexToBytes(key.public_key_hex);
+      expect(publicKey.length).toBe(32);
+      expect(deriveKeyId(publicKey)).toBe(key.key_id);
+      expect(
+        ed.verify(
+          base64ToBytes(key.vector_signature_b64),
+          utf8Bytes(key.vector_message),
+          publicKey,
+        ),
+      ).toBe(true);
+    }
+  });
+
+  it('the test key derives from its committed seed', () => {
+    const publicKey = ed.getPublicKey(base64ToBytes(manifestVectors.test_key.seed_b64));
+    expect(ed.etc.bytesToHex(publicKey)).toBe(manifestVectors.test_key.public_key_hex);
+    expect(deriveKeyId(publicKey)).toBe(manifestVectors.test_key.key_id);
+  });
+});
+
+describe('fetchUpdateManifest — sequential fail-open', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('falls through failing candidates to the first good one', async () => {
+    const good = envelopeFor(manifestPayload());
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(manifestResponse('irrelevant', 404))
+      .mockRejectedValueOnce(new Error('network down'))
+      .mockResolvedValueOnce(manifestResponse(good));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const fetched = await fetchUpdateManifest(['https://a/', 'https://b/', 'https://c/']);
+    expect(fetched?.url).toBe('https://c/');
+    expect(fetched?.raw).toBe(good);
+    expect(fetched?.decoded.verified).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('a tampered candidate loses to a clean later candidate', async () => {
+    const clean = envelopeFor(manifestPayload());
+    const tampered = envelopeFor(manifestPayload(), { seedB64: UNPINNED_SEED_B64 });
+    globalThis.fetch = jest
+      .fn()
+      .mockResolvedValueOnce(manifestResponse(tampered))
+      .mockResolvedValueOnce(manifestResponse(clean)) as unknown as typeof fetch;
+
+    const fetched = await fetchUpdateManifest(['https://bad/', 'https://good/']);
+    expect(fetched?.url).toBe('https://good/');
+  });
+
+  it('keeps walking past an unsigned copy to a verified one on a later front', async () => {
+    const unsigned = envelopeFor(manifestPayload(), { omitSig: true });
+    const signed = envelopeFor(manifestPayload());
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(manifestResponse(unsigned))
+      .mockResolvedValueOnce(manifestResponse(signed));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const fetched = await fetchUpdateManifest(['https://stripped/', 'https://signed/']);
+    expect(fetched?.url).toBe('https://signed/');
+    expect(fetched?.decoded.verified).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns the first unsigned copy only when no candidate verifies', async () => {
+    const unsignedA = envelopeFor(manifestPayload({ promote: 'notify' }), { omitSig: true });
+    const unsignedB = envelopeFor(manifestPayload(), { omitSig: true });
+    globalThis.fetch = jest
+      .fn()
+      .mockResolvedValueOnce(manifestResponse(unsignedA))
+      .mockResolvedValueOnce(manifestResponse(unsignedB)) as unknown as typeof fetch;
+
+    const fetched = await fetchUpdateManifest(['https://a/', 'https://b/']);
+    expect(fetched?.url).toBe('https://a/');
+    expect(fetched?.decoded.verified).toBe(false);
+  });
+
+  it('returns null (never throws) when every candidate fails', async () => {
+    globalThis.fetch = jest
+      .fn()
+      .mockRejectedValue(new Error('offline')) as unknown as typeof fetch;
+    await expect(fetchUpdateManifest(['https://a/', 'https://b/'])).resolves.toBeNull();
+  });
+
+  it('sends the version headers and cache busters', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(manifestResponse(envelopeFor(manifestPayload())));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    await fetchUpdateManifest(['https://a/']);
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(init.headers).toMatchObject({
+      'X-OpenRung-App-Version': APP_VERSION,
+      'Cache-Control': 'no-cache, no-store',
+      Pragma: 'no-cache',
+    });
+  });
+});

--- a/__tests__/core/updateStatus.test.ts
+++ b/__tests__/core/updateStatus.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Tier-ladder derivation (src/model/updateStatus.ts): blocked/notify require a VERIFIED
+ * manifest, unsigned tops out at the passive row, "Continue anyway" downgrades a block, and
+ * notices filter on verification, dismissal and expiry.
+ */
+import {
+  INITIAL_UPDATE_UI,
+  deriveUpdateUiState,
+  pickLocalizedText,
+  type DeriveUpdateInputs,
+} from '../../src/model/updateStatus';
+import type {
+  DecodedUpdateManifest,
+  UpdateManifest,
+  UpdateNotice,
+} from '../../src/net/updateManifestClient';
+
+const NOW = Date.parse('2026-07-22T12:00:00Z');
+
+function manifest(overrides: Partial<UpdateManifest> = {}): UpdateManifest {
+  return {
+    generatedAtMs: NOW - 3_600_000,
+    android: { latest: '0.4.0', minSupported: null },
+    ios: { latest: '0.4.0', minSupported: null },
+    promote: 'silent',
+    notice: null,
+    ...overrides,
+  };
+}
+
+function notice(overrides: Partial<UpdateNotice> = {}): UpdateNotice {
+  return {
+    id: 'n1',
+    level: 'warn',
+    title: { en: 'Title' },
+    body: { en: 'Body' },
+    url: null,
+    expiresMs: null,
+    ...overrides,
+  };
+}
+
+function derive(
+  decoded: DecodedUpdateManifest | null,
+  overrides: Partial<DeriveUpdateInputs> = {},
+) {
+  return deriveUpdateUiState({
+    decoded,
+    platform: 'android',
+    currentVersion: '0.3.2',
+    dismissedBannerVersion: null,
+    dismissedNoticeIds: [],
+    blockOverridden: false,
+    nowMs: NOW,
+    ...overrides,
+  });
+}
+
+const verified = (m: UpdateManifest): DecodedUpdateManifest => ({
+  manifest: m,
+  verified: true,
+  keyIdUsed: 'test',
+});
+const unsigned = (m: UpdateManifest): DecodedUpdateManifest => ({
+  manifest: m,
+  verified: false,
+  keyIdUsed: null,
+});
+
+describe('deriveUpdateUiState — version tiers', () => {
+  it('no manifest -> initial state', () => {
+    expect(derive(null)).toEqual(INITIAL_UPDATE_UI);
+  });
+
+  it('up to date -> none', () => {
+    expect(derive(verified(manifest()), { currentVersion: '0.4.0' }).tier).toBe('none');
+  });
+
+  it('ahead of latest (dev build) -> none', () => {
+    expect(derive(verified(manifest()), { currentVersion: '9.9.9' }).tier).toBe('none');
+  });
+
+  it('behind, promote silent -> available', () => {
+    const ui = derive(verified(manifest()));
+    expect(ui.tier).toBe('available');
+    expect(ui.latestVersion).toBe('0.4.0');
+    expect(ui.verified).toBe(true);
+  });
+
+  it('behind, promote notify, verified -> notify (once per version)', () => {
+    const m = manifest({ promote: 'notify' });
+    expect(derive(verified(m)).tier).toBe('notify');
+    expect(derive(verified(m), { dismissedBannerVersion: '0.4.0' }).tier).toBe('available');
+    // A NEWER latest re-arms the banner after a dismissal of the old one.
+    const newer = manifest({ promote: 'notify', android: { latest: '0.5.0', minSupported: null } });
+    expect(derive(verified(newer), { dismissedBannerVersion: '0.4.0' }).tier).toBe('notify');
+  });
+
+  it('unsigned manifests top out at available — no banner, no block', () => {
+    expect(derive(unsigned(manifest({ promote: 'notify' }))).tier).toBe('available');
+    const floored = manifest({ android: { latest: '0.4.0', minSupported: '0.4.0' } });
+    expect(derive(unsigned(floored)).tier).toBe('available');
+  });
+
+  it('below the floor, verified -> blocked; Continue anyway -> available', () => {
+    const floored = manifest({ android: { latest: '0.4.0', minSupported: '0.4.0' } });
+    expect(derive(verified(floored)).tier).toBe('blocked');
+    expect(derive(verified(floored), { blockOverridden: true }).tier).toBe('available');
+  });
+
+  it('Continue anyway lands on available even when promote is notify (no second prompt)', () => {
+    const floored = manifest({
+      promote: 'notify',
+      android: { latest: '0.4.0', minSupported: '0.4.0' },
+    });
+    expect(derive(verified(floored), { blockOverridden: true }).tier).toBe('available');
+  });
+
+  it('floor without latest still blocks, with latestVersion null', () => {
+    const floored = manifest({ android: { latest: null, minSupported: '0.4.0' } });
+    const ui = derive(verified(floored));
+    expect(ui.tier).toBe('blocked');
+    expect(ui.latestVersion).toBeNull();
+  });
+
+  it('unparseable current version derives no version tier (fail open)', () => {
+    expect(derive(verified(manifest()), { currentVersion: 'dev' }).tier).toBe('none');
+  });
+
+  it('uses the matching platform section only', () => {
+    const iosOnly = manifest({ android: null });
+    expect(derive(verified(iosOnly)).tier).toBe('none');
+    expect(derive(verified(iosOnly), { platform: 'ios' }).tier).toBe('available');
+    expect(derive(verified(iosOnly), { platform: 'windows' }).tier).toBe('none');
+  });
+});
+
+describe('deriveUpdateUiState — notices', () => {
+  it('shows a verified, undismissed, unexpired notice (even when up to date)', () => {
+    const ui = derive(verified(manifest({ notice: notice() })), { currentVersion: '0.4.0' });
+    expect(ui.tier).toBe('none');
+    expect(ui.notice?.id).toBe('n1');
+  });
+
+  it('never shows notices from unsigned manifests', () => {
+    expect(derive(unsigned(manifest({ notice: notice() }))).notice).toBeNull();
+  });
+
+  it('filters dismissed ids and expired notices', () => {
+    const m = manifest({ notice: notice() });
+    expect(derive(verified(m), { dismissedNoticeIds: ['n1'] }).notice).toBeNull();
+    const expired = manifest({ notice: notice({ expiresMs: NOW - 1 }) });
+    expect(derive(verified(expired)).notice).toBeNull();
+    const live = manifest({ notice: notice({ expiresMs: NOW + 1 }) });
+    expect(derive(verified(live)).notice?.id).toBe('n1');
+  });
+});
+
+describe('pickLocalizedText', () => {
+  const map = { en: 'english', 'zh-CN': 'simplified', zh: 'chinese', fa: 'persian' };
+
+  it('prefers the exact tag', () => {
+    expect(pickLocalizedText(map, 'zh-CN')).toBe('simplified');
+    expect(pickLocalizedText(map, 'fa')).toBe('persian');
+  });
+
+  it('falls back to the primary subtag, then English', () => {
+    expect(pickLocalizedText(map, 'zh-TW')).toBe('chinese');
+    expect(pickLocalizedText(map, 'ru')).toBe('english');
+  });
+});

--- a/__tests__/helpers/updateManifest.ts
+++ b/__tests__/helpers/updateManifest.ts
@@ -1,0 +1,75 @@
+/**
+ * Update-manifest fixtures shared across suites (NOT a test file — excluded via
+ * `testPathIgnorePatterns`). Envelopes are signed with the PUBLIC test seed (32 bytes of 0x55)
+ * from testdata/update_manifest_vectors.json; the production seed stays offline.
+ */
+import * as ed from '@noble/ed25519';
+import { sha512 } from '@noble/hashes/sha2.js';
+
+import type { ManifestSigningKey } from '../../src/net/updateManifestClient';
+import vectors from '../../testdata/update_manifest_vectors.json';
+import { base64ToBytes, bytesToBase64, deriveKeyId, utf8Bytes } from './signing';
+
+// Same wiring as updateManifestClient.ts — @noble/ed25519's sync API needs an explicit SHA-512.
+ed.etc.sha512Sync = (...messages: Uint8Array[]) => sha512(ed.etc.concatBytes(...messages));
+
+/** The whole shared-vector file, typed structurally via resolveJsonModule. */
+export const manifestVectors = vectors;
+
+/** The test key in pinned-key shape, for `setManifestSigningKeysForTests`. */
+export const TEST_MANIFEST_KEY: ManifestSigningKey = {
+  keyId: vectors.test_key.key_id,
+  publicKeyHex: vectors.test_key.public_key_hex,
+};
+
+/** A second PUBLIC test seed (32 bytes of 0x43) whose key is never pinned anywhere. */
+export const UNPINNED_SEED_B64 = 'Q0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0M=';
+
+/** Builds a payload JSON string with sane defaults; override any top-level field. */
+export function manifestPayload(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    schema: 1,
+    generated_at: '2026-07-22T00:00:00Z',
+    android: { latest: '9.9.9', latest_code: 999, min_supported: '0.0.0' },
+    ios: { latest: '9.9.9', min_supported: '0.0.0' },
+    promote: 'silent',
+    notice: null,
+    ...overrides,
+  });
+}
+
+/**
+ * Wraps a payload JSON string in an envelope: signed with the test seed by default, a different
+ * seed via `seedB64`, an overridden sig key_id via `keyId`, or unsigned via `omitSig`.
+ */
+export function envelopeFor(
+  payloadJson: string,
+  options: { seedB64?: string; keyId?: string; omitSig?: boolean; sig?: string } = {},
+): string {
+  const payloadBytes = utf8Bytes(payloadJson);
+  const payloadB64 = bytesToBase64(payloadBytes);
+  if (options.omitSig) {
+    return JSON.stringify({ schema: 1, payload_b64: payloadB64 });
+  }
+  if (options.sig !== undefined) {
+    return JSON.stringify({ schema: 1, payload_b64: payloadB64, sig: options.sig });
+  }
+  const seed = base64ToBytes(options.seedB64 ?? vectors.test_key.seed_b64);
+  const keyId = options.keyId ?? deriveKeyId(ed.getPublicKey(seed));
+  const signature = ed.sign(payloadBytes, seed);
+  return JSON.stringify({
+    schema: 1,
+    payload_b64: payloadB64,
+    sig: `ed25519;${keyId};${bytesToBase64(signature)}`,
+  });
+}
+
+/** The Response surface fetchUpdateManifest actually touches. */
+export interface MockManifestResponse {
+  status: number;
+  text(): Promise<string>;
+}
+
+export function manifestResponse(body: string, status: number = 200): MockManifestResponse {
+  return { status, text: async () => body };
+}

--- a/__tests__/screens/SettingsScreen.test.tsx
+++ b/__tests__/screens/SettingsScreen.test.tsx
@@ -31,7 +31,13 @@ jest.mock('react-native-safe-area-context', () => ({
 }));
 
 jest.mock('../../src/state/useVpnState', () => ({
-  useVpnState: () => ({ isConnected: false }),
+  useVpnState: () => ({
+    isConnected: false,
+    // Only the slice SettingsScreen reads from state; the update row stays hidden at tier 'none'.
+    state: {
+      update: { tier: 'none', latestVersion: null, verified: false, notice: null },
+    },
+  }),
 }));
 
 jest.mock('../../src/native/OpenRungApkShare', () => ({

--- a/docs/UPDATE_MANIFEST.md
+++ b/docs/UPDATE_MANIFEST.md
@@ -12,8 +12,12 @@ Client pieces: `src/net/updateManifestClient.ts` (fetch + verify + decode),
 `src/model/updateStatus.ts` (tier derivation), `src/state/updateCheck.ts` (orchestration),
 `src/screens/UpdateRequiredScreen.tsx` + `src/components/UpdateBanner.tsx` (UI).
 Publishing pieces: `release/update-policy.json` (operator knobs, see `release/README.md`),
-`scripts/update-manifest.mjs` (generate/sign/check), `.github/workflows/release.yml` (per-release)
-and `.github/workflows/update-manifest.yml` (policy-edit broadcast).
+`scripts/update-manifest.mjs` (generate/sign/check), and `.github/workflows/update-manifest.yml` —
+the **one** publisher, invoked by policy edits on main, by manual dispatch, and (via
+`workflow_call`) by `release.yml` after each release. Every invocation runs behind a shared
+concurrency mutex and generates from **latest main**, so publishers can never race each other and
+a stale checkout can never be the source; `release.yml` itself only fail-fast-validates the
+policy/seed and never generates the published manifest.
 
 ## The forever contract
 
@@ -65,21 +69,24 @@ raw 32-byte public key — advisory routing only, all pinned keys are tried.
 The manifest must never advertise a build that is not actually downloadable, so `latest` is
 sourced per platform:
 
-- **android.latest** — release path: the working-tree package.json version, safe because the
-  manifest is attached to the *same* GitHub release as that APK (they publish atomically).
-  Broadcast path (`update-manifest.yml`): the latest **release tag**, never main — so a version
-  bump whose release is still building or failed cannot be advertised early. `latest_code` is
-  only present on the release path (elsewhere it is unknowable and set to null; informational
-  only, clients ignore it).
+- **android.latest** — always the latest **release tag** (resolved at publish time), never a
+  package.json version: a version bump whose release is still building or failed cannot be
+  advertised before the APK exists. After a release completes, `release.yml` calls the publisher,
+  which resolves the just-created tag. `latest_code` is present only when the tag matches the
+  generating checkout's package.json version (otherwise unknowable and null; informational only,
+  clients ignore it).
 - **ios.latest** — always `ios_latest` from `release/update-policy.json`: iOS/TestFlight uploads
   are manual, so the operator records what is actually live and bumps it by policy PR after each
   TestFlight upload. CI rejects `ios_latest` above package.json and any `min_supported` above the
   advertised latest (a floor above what users can install would block them with no fix).
 
-`min_supported`, `promote` and `notice` come from `release/update-policy.json`. `generated_at`
-drives rollback monotonicity: a client never replaces a cached *verified* manifest with an older
-*verified* one, so replaying a stale signed manifest cannot lower a raised floor. Unsigned
-envelopes can never displace a verified cache at all.
+`min_supported`, `promote` and `notice` come from `release/update-policy.json`. `generated_at` is
+the generating checkout's HEAD **committer time**, not wall clock — git history is the ordering
+authority, so any late publish from a stale checkout carries an honestly-older stamp. It drives
+rollback monotonicity: a client never replaces a cached *verified* manifest with an older
+*verified* one, so neither a replayed signed manifest nor a stale-checkout publish can lower a
+raised floor for clients that already saw the newer one. Unsigned envelopes can never displace a
+verified cache at all.
 
 ## Client tier ladder (src/model/updateStatus.ts)
 

--- a/docs/UPDATE_MANIFEST.md
+++ b/docs/UPDATE_MANIFEST.md
@@ -62,7 +62,20 @@ raw 32-byte public key — advisory routing only, all pinned keys are tried.
 }
 ```
 
-`latest`/`latest_code` are filled from package.json / build.gradle at generation time;
+The manifest must never advertise a build that is not actually downloadable, so `latest` is
+sourced per platform:
+
+- **android.latest** — release path: the working-tree package.json version, safe because the
+  manifest is attached to the *same* GitHub release as that APK (they publish atomically).
+  Broadcast path (`update-manifest.yml`): the latest **release tag**, never main — so a version
+  bump whose release is still building or failed cannot be advertised early. `latest_code` is
+  only present on the release path (elsewhere it is unknowable and set to null; informational
+  only, clients ignore it).
+- **ios.latest** — always `ios_latest` from `release/update-policy.json`: iOS/TestFlight uploads
+  are manual, so the operator records what is actually live and bumps it by policy PR after each
+  TestFlight upload. CI rejects `ios_latest` above package.json and any `min_supported` above the
+  advertised latest (a floor above what users can install would block them with no fix).
+
 `min_supported`, `promote` and `notice` come from `release/update-policy.json`. `generated_at`
 drives rollback monotonicity: a client never replaces a cached *verified* manifest with an older
 *verified* one, so replaying a stale signed manifest cannot lower a raised floor. Unsigned
@@ -124,6 +137,9 @@ candidate), so caching/proxying is safe.
 ## Runbooks
 
 - **Routine release:** do nothing. `promote` stays `silent`; users see only the passive row.
+- **After uploading an iOS build to TestFlight:** bump `ios_latest` in
+  `release/update-policy.json` (PR to main) — until then the manifest keeps advertising the
+  previous iOS version, by design.
 - **Important release** (security fix, protocol change): set `promote: "notify"` in
   `release/update-policy.json` in the version-bump PR; set it back to `silent` in the next one.
 - **Broadcast a notice / raise the floor:** edit `release/update-policy.json`, PR to main —

--- a/docs/UPDATE_MANIFEST.md
+++ b/docs/UPDATE_MANIFEST.md
@@ -85,12 +85,15 @@ sourced per platform:
   advertised latest (a floor above what users can install would block them with no fix).
 
 `min_supported`, `promote` and `notice` come from `release/update-policy.json`. `generated_at` is
-the generating checkout's HEAD **committer time**, not wall clock — git history is the ordering
-authority, so any late publish from a stale checkout carries an honestly-older stamp. It drives
-rollback monotonicity: a client never replaces a cached *verified* manifest with an older
-*verified* one, so neither a replayed signed manifest nor a stale-checkout publish can lower a
-raised floor for clients that already saw the newer one. Unsigned envelopes can never displace a
-verified cache at all.
+the newest timestamp among **all** manifest inputs — the generating checkout's HEAD committer
+time and the resolved latest release's `published_at` — never plain wall clock. Both inputs are
+monotone, so any input change strictly increases the stamp, which gives clients two guarantees:
+a late publish from stale inputs carries an honestly-older stamp (rollback monotonicity — a
+client never replaces a cached *verified* manifest except with a strictly newer one, so neither
+a replayed signed manifest nor a stale publish can lower a raised floor), and an **equal** stamp
+implies an **identical** manifest (same policy commit, same release), so clients can stop the
+candidate walk on ties and keep their cache without flapping between fronts. Unsigned envelopes
+can never displace a verified cache at all.
 
 ## Client tier ladder (src/model/updateStatus.ts)
 

--- a/docs/UPDATE_MANIFEST.md
+++ b/docs/UPDATE_MANIFEST.md
@@ -1,0 +1,134 @@
+# In-app update manifest
+
+The update check exists because of a hard lesson: a breaking change once shipped and old app
+versions simply stopped working, with **no way to tell users to update**. The manifest is the
+standing channel that fixes that for every version from now on. It is one mechanism serving three
+features: the update check, the kill-switch floor (`min_supported`), and freeform operator
+broadcasts (`notice`). Checking happens silently on every cold start and app foreground (throttled
+to 6h); what the user *sees* is decided entirely by the manifest contents — so routine daily
+releases produce zero prompts.
+
+Client pieces: `src/net/updateManifestClient.ts` (fetch + verify + decode),
+`src/model/updateStatus.ts` (tier derivation), `src/state/updateCheck.ts` (orchestration),
+`src/screens/UpdateRequiredScreen.tsx` + `src/components/UpdateBanner.tsx` (UI).
+Publishing pieces: `release/update-policy.json` (operator knobs, see `release/README.md`),
+`scripts/update-manifest.mjs` (generate/sign/check), `.github/workflows/release.yml` (per-release)
+and `.github/workflows/update-manifest.yml` (policy-edit broadcast).
+
+## The forever contract
+
+Every shipped client keeps checking these URLs with this schema for as long as it is installed —
+that is the entire point. Therefore:
+
+- **URLs are immutable.** `AppConfig.UPDATE_MANIFEST_URLS`:
+  1. `https://broker.openrung.org/api/v1/app-manifest` (Cloudflare front — censorship-resistant)
+  2. `https://d2r7mdpyevvs1m.cloudfront.net/api/v1/app-manifest` (independent second front)
+  3. `https://github.com/openrung/openrung-mobile-app/releases/latest/download/update-manifest.json`
+     (zero-infrastructure fallback; works from the first release, but github.com is unreliable in
+     several target regions)
+  Candidates are walked in order, fail-open, preferring the first **verified** envelope — an
+  unsigned-but-decodable copy is kept only as a fallback, so one front serving a sig-stripped
+  copy cannot shadow the signed copy on a later front. New URLs may be **added** in new app
+  versions; existing ones must keep serving (or 404 — a 404 is just a failed candidate) forever.
+- **Schema stays 1, changes are additive-only.** Clients ignore unknown fields and null out
+  invalid optional ones. Never rename, retype, or repurpose an existing field; add a new one.
+
+## Envelope format
+
+```json
+{
+  "schema": 1,
+  "payload_b64": "<standard base64 of the exact UTF-8 payload bytes>",
+  "sig": "ed25519;<key_id>;<base64 signature>"
+}
+```
+
+The signature covers the exact decoded `payload_b64` bytes (no JSON canonicalization anywhere).
+`sig` is optional: an unsigned envelope decodes but is capped client-side at the passive Settings
+row. A **present-but-invalid** signature fails that candidate entirely, so a tampered CDN copy
+loses to a clean copy from the next candidate. `key_id` = first 8 bytes (hex) of SHA-256 over the
+raw 32-byte public key — advisory routing only, all pinned keys are tried.
+
+## Payload format
+
+```json
+{
+  "schema": 1,
+  "generated_at": "2026-07-22T12:00:00.000Z",
+  "android": { "latest": "0.4.0", "latest_code": 12, "min_supported": "0.2.0" },
+  "ios":     { "latest": "0.4.0", "min_supported": "0.2.0" },
+  "promote": "silent",
+  "notice": null
+}
+```
+
+`latest`/`latest_code` are filled from package.json / build.gradle at generation time;
+`min_supported`, `promote` and `notice` come from `release/update-policy.json`. `generated_at`
+drives rollback monotonicity: a client never replaces a cached *verified* manifest with an older
+*verified* one, so replaying a stale signed manifest cannot lower a raised floor. Unsigned
+envelopes can never displace a verified cache at all.
+
+## Client tier ladder (src/model/updateStatus.ts)
+
+| Condition (per-platform section) | Verified required | UI |
+| --- | --- | --- |
+| up to date / no manifest | — | nothing |
+| behind `latest` | no | passive "Update available" row in Settings |
+| behind `latest`, `promote: "notify"` | yes | + one dismissible home banner per version |
+| below `min_supported` | yes | full-screen "Update required" (with session-scoped "Continue anyway") |
+| `notice` present, undismissed, unexpired | yes | dismissible home card (`level`: info/warn) |
+
+Hard rules, in priority order:
+
+1. **Fail open.** Network/storage/parse failures leave the app exactly as it was. The check never
+   gates startup, rendering, or connect. All-candidates-fail = no update UI, retry in 15 min.
+2. **Only a verified manifest can prompt or block.** Unsigned tops out at the passive row.
+3. **Update destinations are pinned constants** (`AppConfig.UPDATE_URL_ANDROID`,
+   `AppConfig.TESTFLIGHT_URL`) — never manifest-supplied, so even a signed manifest cannot
+   redirect users to a hostile download. `notice.url` (https-only, verified manifests only) is the
+   single server-supplied link, behind an explicit "Learn more".
+4. **"Continue anyway" stays.** A custom-broker user on an "unsupported" build may still work;
+   informing beats bricking (availability-first design).
+
+## Serving the fronts (server-side TODO)
+
+Until the two front routes exist, clients silently fall through to the GitHub asset — the system
+works end-to-end from the first release. To light up the fronts, serve the R2 object
+`openrung-downloads/app/update-manifest.json` at `/api/v1/app-manifest` on both:
+
+- **Cloudflare Worker** (broker.openrung.org): bind the `openrung-downloads` bucket and return the
+  object on that path with `content-type: application/json` and `cache-control: max-age=300`.
+  Do not require any headers.
+- **CloudFront** (d2r7mdpyevvs1m.cloudfront.net): add a behavior for `/api/v1/app-manifest` with a
+  short TTL (300s), origin = the same R2 public endpoint (or proxy through the broker origin).
+
+Integrity does not depend on these fronts (the payload is signed; a tampered copy just fails that
+candidate), so caching/proxying is safe.
+
+## Signing key
+
+- Generate: `node scripts/update-manifest.mjs keygen` → prints `seed_b64` (SECRET), the public
+  key + key_id to pin in `AppConfig.MANIFEST_SIGNING_KEYS`, and the vector message/signature pair
+  to commit to `testdata/update_manifest_vectors.json` `pinned_keys` (the CI guard verifies the
+  pin without the seed — same pattern as the relay signing keys).
+- Store `seed_b64` as the GitHub Actions secret `OPENRUNG_MANIFEST_SIGNING_SEED_B64` **and** in
+  the team password manager. It exists nowhere else.
+- This is deliberately a **separate keypair** from the relay signing keys: the manifest key can
+  hard-block app startup, so its power is scoped to exactly that.
+- Rotation / loss: keygen a new pair, pin it (keys are a list — ship a release with both pinned),
+  swap the secret, and after adoption remove the old pin. Losing the seed only degrades new
+  manifests to unsigned (passive row) until a release ships a new pin — nothing bricks.
+- The generate step refuses to sign with a seed whose public key is not in the committed
+  `pinned_keys`, so a mis-set secret cannot silently produce manifests no client trusts.
+
+## Runbooks
+
+- **Routine release:** do nothing. `promote` stays `silent`; users see only the passive row.
+- **Important release** (security fix, protocol change): set `promote: "notify"` in
+  `release/update-policy.json` in the version-bump PR; set it back to `silent` in the next one.
+- **Broadcast a notice / raise the floor:** edit `release/update-policy.json`, PR to main —
+  `update-manifest.yml` republishes within minutes. Check broker `X-OpenRung-App-Version`
+  telemetry before raising `min_supported` (how many users would you block?). CI rejects a floor
+  above the current package.json version.
+- **Kill a bad manifest fast:** revert the policy PR (or `workflow_dispatch` the publish workflow
+  after fixing). Clients re-fetch within 6h, on next foreground, or on next cold start.

--- a/docs/UPDATE_MANIFEST.md
+++ b/docs/UPDATE_MANIFEST.md
@@ -30,10 +30,14 @@ that is the entire point. Therefore:
   3. `https://github.com/openrung/openrung-mobile-app/releases/latest/download/update-manifest.json`
      (zero-infrastructure fallback; works from the first release, but github.com is unreliable in
      several target regions)
-  Candidates are walked in order, fail-open, preferring the first **verified** envelope — an
-  unsigned-but-decodable copy is kept only as a fallback, so one front serving a sig-stripped
-  copy cannot shadow the signed copy on a later front. New URLs may be **added** in new app
-  versions; existing ones must keep serving (or 404 — a 404 is just a failed candidate) forever.
+  Candidates are walked in order, fail-open, stopping at the first **verified** envelope **at
+  least as fresh as the cached one** (steady state: one request). A verified-but-staler copy or
+  an unsigned copy keeps the walk going and is used only as a fallback — so one front replaying
+  an old signed manifest, or serving a sig-stripped one, cannot shadow the fresher/signed copy on
+  a later front; with no cache yet, all fronts are surveyed once and the newest verified wins.
+  An all-stale or all-unsigned result against a verified cache counts as a *failed* check
+  (15-min retry), never a success. New URLs may be **added** in new app versions; existing ones
+  must keep serving (or 404 — a 404 is just a failed candidate) forever.
 - **Schema stays 1, changes are additive-only.** Clients ignore unknown fields and null out
   invalid optional ones. Never rename, retype, or repurpose an existing field; add a new one.
 

--- a/policy-floor-test.json
+++ b/policy-floor-test.json
@@ -1,1 +1,0 @@
-{"schema": 1, "min_supported": {"android": "0.3.2", "ios": "0.0.0"}, "ios_latest": "0.3.2", "promote": "silent", "notice": null}

--- a/policy-floor-test.json
+++ b/policy-floor-test.json
@@ -1,0 +1,1 @@
+{"schema": 1, "min_supported": {"android": "0.3.2", "ios": "0.0.0"}, "ios_latest": "0.3.2", "promote": "silent", "notice": null}

--- a/release/README.md
+++ b/release/README.md
@@ -14,6 +14,12 @@ serving contract: [docs/UPDATE_MANIFEST.md](../docs/UPDATE_MANIFEST.md).
   (protocol breaks), and only after checking the broker's `X-OpenRung-App-Version` telemetry for
   how many users you'd be blocking. CI rejects a floor above the current package.json version.
   Blocking requires a SIGNED manifest — see the signing-key section of docs/UPDATE_MANIFEST.md.
+- `ios_latest` — the iOS version **actually live on TestFlight** (`"x.y.z"`). iOS uploads are
+  manual, so CI cannot know this: bump it by PR right after each TestFlight upload. The manifest
+  advertises exactly this to iOS users — never the source version, which may not be built for
+  iOS yet. CI rejects a value above package.json and a `min_supported.ios` above it. (Android
+  needs no equivalent: the release path publishes the manifest atomically with the APK, and the
+  broadcast workflow reads the latest release tag.)
 - `promote` — `"silent"` (default: no UI beyond the passive Settings row) or `"notify"` (one
   dismissible home-screen banner per version). Set `notify` when cutting a release users should
   actually install (security fixes, protocol changes); set it back to `silent` afterwards.

--- a/release/README.md
+++ b/release/README.md
@@ -1,0 +1,42 @@
+# release/update-policy.json — the in-app update broadcast channel
+
+This file is the operator-controlled half of the in-app update check (the version numbers are
+filled in automatically from package.json at publish time). Editing it and merging to main is how
+you broadcast to every installed app — `.github/workflows/update-manifest.yml` republishes the
+signed manifest on every change to this file, no app release needed. Full schema, threat model and
+serving contract: [docs/UPDATE_MANIFEST.md](../docs/UPDATE_MANIFEST.md).
+
+## Fields
+
+- `min_supported.{android,ios}` — the kill-switch floor (`"x.y.z"`). Clients BELOW this version
+  show the full-screen "Update required" screen (with a "Continue anyway" escape hatch for
+  self-hosted-broker users). Raise it only for versions that genuinely cannot work anymore
+  (protocol breaks), and only after checking the broker's `X-OpenRung-App-Version` telemetry for
+  how many users you'd be blocking. CI rejects a floor above the current package.json version.
+  Blocking requires a SIGNED manifest — see the signing-key section of docs/UPDATE_MANIFEST.md.
+- `promote` — `"silent"` (default: no UI beyond the passive Settings row) or `"notify"` (one
+  dismissible home-screen banner per version). Set `notify` when cutting a release users should
+  actually install (security fixes, protocol changes); set it back to `silent` afterwards.
+- `notice` — `null`, or a freeform broadcast shown as a dismissible card on the home screen:
+
+```json
+{
+  "id": "2026-07-relay-migration",
+  "level": "warn",
+  "title": { "en": "Relay network changing", "fa": "…" },
+  "body": { "en": "Update before Aug 1 or the app will stop connecting.", "fa": "…" },
+  "url": null,
+  "expires": "2026-08-01T00:00:00Z"
+}
+```
+
+  Dismissal is keyed by `id` — to re-show a notice, change the `id`. `title`/`body` are
+  `{locale: text}` maps; `en` is required, other app locales (`zh-CN`, `zh-TW`, `fa`, `ru`, `ar`,
+  `tr`, `vi`, `my`) fall back to English when missing. `url` (https only) adds a "Learn more"
+  button. `expires` (ISO-8601, optional) auto-hides the notice client-side.
+
+Validate locally before pushing:
+
+```bash
+node scripts/update-manifest.mjs check
+```

--- a/release/update-policy.json
+++ b/release/update-policy.json
@@ -1,0 +1,9 @@
+{
+  "schema": 1,
+  "min_supported": {
+    "android": "0.0.0",
+    "ios": "0.0.0"
+  },
+  "promote": "silent",
+  "notice": null
+}

--- a/release/update-policy.json
+++ b/release/update-policy.json
@@ -4,6 +4,7 @@
     "android": "0.0.0",
     "ios": "0.0.0"
   },
+  "ios_latest": "0.3.2",
   "promote": "silent",
   "notice": null
 }

--- a/scripts/update-manifest.mjs
+++ b/scripts/update-manifest.mjs
@@ -35,6 +35,7 @@ import {
   sign as ed25519Sign,
   verify as ed25519Verify,
 } from 'node:crypto';
+import { execSync } from 'node:child_process';
 import { readFileSync, writeFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, isAbsolute, join } from 'node:path';
@@ -208,12 +209,36 @@ function loadVectors() {
   return JSON.parse(read(VECTORS_PATH));
 }
 
+/**
+ * generated_at = the generating checkout's HEAD committer time, NOT wall-clock. Git history is
+ * the ordering authority for policy content: clients keep the manifest with the newest
+ * generated_at, so a stale checkout that publishes late (e.g. a long release build racing a
+ * policy edit) carries an honestly-older stamp and cached clients reject the rollback — a
+ * wall-clock stamp would instead make the stale content look newest. Same-commit re-publishes
+ * carry equal stamps, which clients accept (last-write-wins between identical-policy sources).
+ */
+function generatedAtIso() {
+  try {
+    const iso = execSync('git log -1 --format=%cI', { cwd: root, encoding: 'utf8' }).trim();
+    if (Number.isNaN(Date.parse(iso))) {
+      throw new Error(`unparseable committer date ${JSON.stringify(iso)}`);
+    }
+    return iso;
+  } catch (error) {
+    console.warn(
+      `⚠ could not read the HEAD committer time (${error.message ?? error}) — ` +
+        'falling back to wall-clock generated_at (rollback ordering is weaker for this manifest).',
+    );
+    return new Date().toISOString();
+  }
+}
+
 // --- generate ---------------------------------------------------------------------------------
 
 function buildPayload(version, versionCode, policy, androidLatest) {
   return {
     schema: 1,
-    generated_at: new Date().toISOString(),
+    generated_at: generatedAtIso(),
     android: {
       latest: androidLatest,
       // versionCode is read from the working tree, which only describes the advertised build

--- a/scripts/update-manifest.mjs
+++ b/scripts/update-manifest.mjs
@@ -1,0 +1,378 @@
+#!/usr/bin/env node
+// Update-manifest tooling: generates (and optionally Ed25519-signs) the signed envelope the app's
+// in-app update check consumes, validates the committed release/update-policy.json, and guards the
+// committed test vectors in testdata/update_manifest_vectors.json.
+//
+// The manifest URL and schema are a FOREVER CONTRACT with every shipped client (see
+// docs/UPDATE_MANIFEST.md): schema stays 1, changes are additive-only, and clients ignore fields
+// they don't know. Do not "clean up" old fields.
+//
+// Uses only node:crypto (no node_modules) so it runs in workflows without `npm ci`.
+//
+// Modes:
+//   node scripts/update-manifest.mjs generate --out update-manifest.json
+//       Builds the envelope from package.json (version), android/app/build.gradle (versionCode)
+//       and release/update-policy.json. Signs it when OPENRUNG_MANIFEST_SIGNING_SEED_B64 is set
+//       (the base64 32-byte Ed25519 seed); otherwise emits an unsigned envelope with a warning —
+//       unsigned manifests can never hard-block clients, only surface the passive update row.
+//   node scripts/update-manifest.mjs check
+//       CI guard: validates release/update-policy.json and the committed test vectors. Run by
+//       .github/workflows/version-check.yml on every PR.
+//   node scripts/update-manifest.mjs keygen [--name active]
+//       Prints a fresh keypair as JSON: seed_b64 (SECRET — GitHub secret + password manager only,
+//       never committed), public_key_hex + key_id (pin in src/config.ts MANIFEST_SIGNING_KEYS),
+//       and the vector_message/vector_signature_b64 pair to commit to testdata pinned_keys so CI
+//       can guard the pin without the seed.
+
+import {
+  createHash,
+  createPrivateKey,
+  createPublicKey,
+  randomBytes,
+  sign as ed25519Sign,
+  verify as ed25519Verify,
+} from 'node:crypto';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, isAbsolute, join } from 'node:path';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const read = (p) => readFileSync(join(root, p), 'utf8');
+
+const POLICY_PATH = 'release/update-policy.json';
+const VECTORS_PATH = 'testdata/update_manifest_vectors.json';
+const SEED_ENV = 'OPENRUNG_MANIFEST_SIGNING_SEED_B64';
+
+// --- Ed25519 over raw 32-byte seeds via node:crypto DER framing -------------------------------
+
+const PKCS8_PREFIX = Buffer.from('302e020100300506032b657004220420', 'hex');
+const SPKI_PREFIX = Buffer.from('302a300506032b6570032100', 'hex');
+
+function privateKeyFromSeed(seed) {
+  if (seed.length !== 32) {
+    throw new Error(`Ed25519 seed must be 32 bytes, got ${seed.length}`);
+  }
+  return createPrivateKey({ key: Buffer.concat([PKCS8_PREFIX, seed]), format: 'der', type: 'pkcs8' });
+}
+
+function publicKeyRawFromSeed(seed) {
+  const spki = createPublicKey(privateKeyFromSeed(seed)).export({ format: 'der', type: 'spki' });
+  return Buffer.from(spki.subarray(spki.length - 32));
+}
+
+function publicKeyFromRaw(raw) {
+  return createPublicKey({ key: Buffer.concat([SPKI_PREFIX, raw]), format: 'der', type: 'spki' });
+}
+
+/** key_id = lowercase hex of the first 8 bytes of SHA-256 over the raw public key (SPEC v1 §4.2). */
+function keyIdOf(rawPublicKey) {
+  return createHash('sha256').update(rawPublicKey).digest('hex').slice(0, 16);
+}
+
+function signBytes(seed, bytes) {
+  return ed25519Sign(null, bytes, privateKeyFromSeed(seed));
+}
+
+function verifyBytes(rawPublicKey, bytes, signature) {
+  try {
+    return ed25519Verify(null, bytes, publicKeyFromRaw(rawPublicKey), signature);
+  } catch {
+    return false;
+  }
+}
+
+// --- Shared validation ------------------------------------------------------------------------
+
+const SEMVER_RE = /^\d+\.\d+\.\d+$/;
+
+function semverTriple(value) {
+  return SEMVER_RE.test(value) ? value.split('.').map(Number) : null;
+}
+
+function semverLte(a, b) {
+  const ta = semverTriple(a);
+  const tb = semverTriple(b);
+  if (!ta || !tb) {
+    return false;
+  }
+  for (let i = 0; i < 3; i++) {
+    if (ta[i] !== tb[i]) {
+      return ta[i] < tb[i];
+    }
+  }
+  return true;
+}
+
+function isLocalizedMap(value) {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const entries = Object.entries(value);
+  return (
+    typeof value.en === 'string' &&
+    value.en.trim().length > 0 &&
+    entries.every(([, text]) => typeof text === 'string' && text.trim().length > 0)
+  );
+}
+
+/** Validates release/update-policy.json; returns a list of human-readable problems. */
+function validatePolicy(policy, currentVersion) {
+  const errors = [];
+  if (policy.schema !== 1) {
+    errors.push(`policy schema must be 1, got ${JSON.stringify(policy.schema)}`);
+  }
+  for (const platform of ['android', 'ios']) {
+    const min = policy.min_supported?.[platform];
+    if (typeof min !== 'string' || !SEMVER_RE.test(min)) {
+      errors.push(`min_supported.${platform} must be "x.y.z", got ${JSON.stringify(min)}`);
+    } else if (!semverLte(min, currentVersion)) {
+      // A floor above the version being released would block even fully-updated users.
+      errors.push(
+        `min_supported.${platform} (${min}) is above the current app version (${currentVersion})`,
+      );
+    }
+  }
+  if (policy.promote !== 'silent' && policy.promote !== 'notify') {
+    errors.push(`promote must be "silent" or "notify", got ${JSON.stringify(policy.promote)}`);
+  }
+  const notice = policy.notice;
+  if (notice !== null && notice !== undefined) {
+    if (typeof notice !== 'object' || Array.isArray(notice)) {
+      errors.push('notice must be null or an object');
+    } else {
+      if (typeof notice.id !== 'string' || notice.id.trim().length === 0 || notice.id.length > 64) {
+        errors.push('notice.id must be a non-empty string (max 64 chars)');
+      }
+      if (notice.level !== 'info' && notice.level !== 'warn') {
+        errors.push(`notice.level must be "info" or "warn", got ${JSON.stringify(notice.level)}`);
+      }
+      if (!isLocalizedMap(notice.title)) {
+        errors.push('notice.title must be a {locale: text} map with a non-empty "en" entry');
+      }
+      if (!isLocalizedMap(notice.body)) {
+        errors.push('notice.body must be a {locale: text} map with a non-empty "en" entry');
+      }
+      if (notice.url != null && !/^https:\/\//.test(notice.url)) {
+        errors.push('notice.url must be null or an https:// URL');
+      }
+      if (notice.expires != null && Number.isNaN(Date.parse(notice.expires))) {
+        errors.push(`notice.expires must be null or ISO-8601, got ${JSON.stringify(notice.expires)}`);
+      }
+    }
+  }
+  return errors;
+}
+
+// --- Inputs -----------------------------------------------------------------------------------
+
+function currentAppVersion() {
+  return JSON.parse(read('package.json')).version;
+}
+
+function currentVersionCode() {
+  const match = read('android/app/build.gradle').match(/versionCode\s+(\d+)/);
+  if (!match) {
+    throw new Error('android/app/build.gradle: versionCode not found');
+  }
+  return Number(match[1]);
+}
+
+function loadPolicy() {
+  return JSON.parse(read(POLICY_PATH));
+}
+
+function loadVectors() {
+  return JSON.parse(read(VECTORS_PATH));
+}
+
+// --- generate ---------------------------------------------------------------------------------
+
+function buildPayload(version, versionCode, policy) {
+  return {
+    schema: 1,
+    generated_at: new Date().toISOString(),
+    android: {
+      latest: version,
+      latest_code: versionCode,
+      min_supported: policy.min_supported.android,
+    },
+    ios: {
+      latest: version,
+      min_supported: policy.min_supported.ios,
+    },
+    promote: policy.promote,
+    notice: policy.notice ?? null,
+  };
+}
+
+function generate(outPath) {
+  const version = currentAppVersion();
+  const policy = loadPolicy();
+  const policyErrors = validatePolicy(policy, version);
+  if (policyErrors.length) {
+    console.error(`✖ ${POLICY_PATH} is invalid:`);
+    for (const e of policyErrors) console.error(`  - ${e}`);
+    process.exit(1);
+  }
+
+  const payload = buildPayload(version, currentVersionCode(), policy);
+  const payloadBytes = Buffer.from(JSON.stringify(payload), 'utf8');
+  const envelope = { schema: 1, payload_b64: payloadBytes.toString('base64') };
+
+  const seedB64 = process.env[SEED_ENV] ?? '';
+  if (seedB64.trim().length > 0) {
+    const seed = Buffer.from(seedB64.trim(), 'base64');
+    const rawPublic = publicKeyRawFromSeed(seed);
+    const keyId = keyIdOf(rawPublic);
+    // Refuse to sign with a key clients don't pin: a manifest signed by an unpinned key verifies
+    // nowhere and silently downgrades every client to the unsigned (never-blocking) tier.
+    const pinned = loadVectors().pinned_keys.some(
+      (key) => key.public_key_hex === rawPublic.toString('hex'),
+    );
+    if (!pinned) {
+      console.error(
+        `✖ ${SEED_ENV} derives public key ${rawPublic.toString('hex')} (key_id ${keyId}), ` +
+          `which is not in ${VECTORS_PATH} pinned_keys. Pin it (and src/config.ts) first.`,
+      );
+      process.exit(1);
+    }
+    const signature = signBytes(seed, payloadBytes);
+    envelope.sig = `ed25519;${keyId};${signature.toString('base64')}`;
+    // Round-trip self-check so a bad signer can never ship a broken envelope.
+    if (!verifyBytes(rawPublic, payloadBytes, signature)) {
+      console.error('✖ self-verification of the freshly signed envelope failed');
+      process.exit(1);
+    }
+    console.log(`✓ signed with key_id ${keyId}`);
+  } else {
+    console.warn(
+      `⚠ ${SEED_ENV} not set — emitting an UNSIGNED envelope. ` +
+        'Clients will show the passive update row only; they never hard-block on unsigned manifests.',
+    );
+  }
+
+  writeFileSync(isAbsolute(outPath) ? outPath : join(root, outPath), JSON.stringify(envelope, null, 2) + '\n');
+  console.log(`✓ wrote ${outPath} (version ${version}, promote ${policy.promote})`);
+}
+
+// --- check ------------------------------------------------------------------------------------
+
+function check() {
+  const errors = [];
+  const version = currentAppVersion();
+
+  let policy = null;
+  try {
+    policy = loadPolicy();
+  } catch (error) {
+    errors.push(`${POLICY_PATH}: ${error.message}`);
+  }
+  if (policy) {
+    errors.push(...validatePolicy(policy, version).map((e) => `${POLICY_PATH}: ${e}`));
+  }
+
+  let vectors = null;
+  try {
+    vectors = loadVectors();
+  } catch (error) {
+    errors.push(`${VECTORS_PATH}: ${error.message}`);
+  }
+  if (vectors) {
+    // Test key self-consistency: pubkey/key_id derive from the committed TEST seed.
+    const testSeed = Buffer.from(vectors.test_key.seed_b64, 'base64');
+    const testRaw = publicKeyRawFromSeed(testSeed);
+    if (testRaw.toString('hex') !== vectors.test_key.public_key_hex) {
+      errors.push(`${VECTORS_PATH}: test_key.public_key_hex does not derive from seed_b64`);
+    }
+    if (keyIdOf(testRaw) !== vectors.test_key.key_id) {
+      errors.push(`${VECTORS_PATH}: test_key.key_id does not derive from public key`);
+    }
+
+    // Vector envelope: payload_b64 matches payload_json byte-for-byte, sig verifies with test key.
+    const vector = vectors.vector;
+    const payloadBytes = Buffer.from(vector.payload_b64, 'base64');
+    if (payloadBytes.toString('utf8') !== vector.payload_json) {
+      errors.push(`${VECTORS_PATH}: vector.payload_b64 does not decode to vector.payload_json`);
+    }
+    const sigFields = vector.sig.split(';');
+    if (sigFields.length !== 3 || sigFields[0] !== 'ed25519' || sigFields[1] !== vectors.test_key.key_id) {
+      errors.push(`${VECTORS_PATH}: vector.sig is not "ed25519;<test key_id>;<base64>"`);
+    } else if (!verifyBytes(testRaw, payloadBytes, Buffer.from(sigFields[2], 'base64'))) {
+      errors.push(`${VECTORS_PATH}: vector.sig does not verify against test_key`);
+    }
+    const envelope = JSON.parse(vector.envelope_json);
+    if (envelope.schema !== 1 || envelope.payload_b64 !== vector.payload_b64 || envelope.sig !== vector.sig) {
+      errors.push(`${VECTORS_PATH}: vector.envelope_json disagrees with payload_b64/sig`);
+    }
+
+    // Pinned production keys: key_id derives, and the committed vector signature verifies — so a
+    // truncated or typo'd pin fails CI immediately, without the offline seed (same guard idea as
+    // the relay-list pinned-key CI guard).
+    for (const key of vectors.pinned_keys) {
+      const raw = Buffer.from(key.public_key_hex, 'hex');
+      if (raw.length !== 32) {
+        errors.push(`${VECTORS_PATH}: pinned key "${key.name}" public_key_hex is not 32 bytes`);
+        continue;
+      }
+      if (keyIdOf(raw) !== key.key_id) {
+        errors.push(`${VECTORS_PATH}: pinned key "${key.name}" key_id does not derive from public key`);
+      }
+      const message = Buffer.from(key.vector_message, 'utf8');
+      const signature = Buffer.from(key.vector_signature_b64, 'base64');
+      if (!verifyBytes(raw, message, signature)) {
+        errors.push(`${VECTORS_PATH}: pinned key "${key.name}" vector signature does not verify`);
+      }
+    }
+  }
+
+  if (errors.length) {
+    console.error('✖ update-manifest check failed:');
+    for (const e of errors) console.error(`  - ${e}`);
+    process.exit(1);
+  }
+  console.log(`✓ ${POLICY_PATH} and ${VECTORS_PATH} are valid (app version ${version}).`);
+}
+
+// --- keygen -----------------------------------------------------------------------------------
+
+function keygen(name) {
+  const seed = randomBytes(32);
+  const raw = publicKeyRawFromSeed(seed);
+  const message = `openrung-manifest-key-vector:${name}`;
+  console.log(
+    JSON.stringify(
+      {
+        seed_b64: seed.toString('base64'),
+        public_key_hex: raw.toString('hex'),
+        key_id: keyIdOf(raw),
+        vector_message: message,
+        vector_signature_b64: signBytes(seed, Buffer.from(message, 'utf8')).toString('base64'),
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+// --- CLI --------------------------------------------------------------------------------------
+
+const [mode, ...rest] = process.argv.slice(2);
+const flag = (label, fallback) => {
+  const index = rest.indexOf(label);
+  return index >= 0 && rest[index + 1] ? rest[index + 1] : fallback;
+};
+
+switch (mode) {
+  case 'generate':
+    generate(flag('--out', 'update-manifest.json'));
+    break;
+  case 'check':
+    check();
+    break;
+  case 'keygen':
+    keygen(flag('--name', 'active'));
+    break;
+  default:
+    console.error('usage: update-manifest.mjs <generate [--out file] | check | keygen [--name n]>');
+    process.exit(1);
+}

--- a/scripts/update-manifest.mjs
+++ b/scripts/update-manifest.mjs
@@ -10,11 +10,14 @@
 // Uses only node:crypto (no node_modules) so it runs in workflows without `npm ci`.
 //
 // Modes:
-//   node scripts/update-manifest.mjs generate --out update-manifest.json
+//   node scripts/update-manifest.mjs generate --out update-manifest.json [--android-latest x.y.z]
 //       Builds the envelope from package.json (version), android/app/build.gradle (versionCode)
 //       and release/update-policy.json. Signs it when OPENRUNG_MANIFEST_SIGNING_SEED_B64 is set
 //       (the base64 32-byte Ed25519 seed); otherwise emits an unsigned envelope with a warning —
 //       unsigned manifests can never hard-block clients, only surface the passive update row.
+//       --android-latest overrides the advertised Android version (broadcast workflow passes the
+//       latest RELEASE tag so a still-building/failed release is never advertised); iOS latest
+//       always comes from the policy file's ios_latest (TestFlight uploads are manual).
 //   node scripts/update-manifest.mjs check
 //       CI guard: validates release/update-policy.json and the committed test vectors. Run by
 //       .github/workflows/version-check.yml on every PR.
@@ -132,6 +135,26 @@ function validatePolicy(policy, currentVersion) {
       );
     }
   }
+  // iOS releases are manual (TestFlight), so nothing in CI knows what is actually live; the
+  // operator records it here and the manifest advertises exactly that — never an unbuilt version.
+  const iosLatest = policy.ios_latest;
+  if (typeof iosLatest !== 'string' || !SEMVER_RE.test(iosLatest)) {
+    errors.push(
+      `ios_latest must be "x.y.z" (the version actually live on TestFlight), got ${JSON.stringify(iosLatest)}`,
+    );
+  } else {
+    if (!semverLte(iosLatest, currentVersion)) {
+      errors.push(
+        `ios_latest (${iosLatest}) is above the current app version (${currentVersion}) — cannot advertise an unbuilt iOS release`,
+      );
+    }
+    const minIos = policy.min_supported?.ios;
+    if (typeof minIos === 'string' && SEMVER_RE.test(minIos) && !semverLte(minIos, iosLatest)) {
+      errors.push(
+        `min_supported.ios (${minIos}) is above ios_latest (${iosLatest}) — would block users with no available fix`,
+      );
+    }
+  }
   if (policy.promote !== 'silent' && policy.promote !== 'notify') {
     errors.push(`promote must be "silent" or "notify", got ${JSON.stringify(policy.promote)}`);
   }
@@ -187,17 +210,23 @@ function loadVectors() {
 
 // --- generate ---------------------------------------------------------------------------------
 
-function buildPayload(version, versionCode, policy) {
+function buildPayload(version, versionCode, policy, androidLatest) {
   return {
     schema: 1,
     generated_at: new Date().toISOString(),
     android: {
-      latest: version,
-      latest_code: versionCode,
+      latest: androidLatest,
+      // versionCode is read from the working tree, which only describes the advertised build
+      // when the advertised version IS the working-tree version (release path). In broadcast
+      // mode (androidLatest from the release tag) the code is unknowable here; null it rather
+      // than lie. Informational only — clients ignore it.
+      latest_code: androidLatest === version ? versionCode : null,
       min_supported: policy.min_supported.android,
     },
     ios: {
-      latest: version,
+      // Manual TestFlight pipeline: advertise what the operator recorded as actually live,
+      // never the source version (which may not be built for iOS yet).
+      latest: policy.ios_latest,
       min_supported: policy.min_supported.ios,
     },
     promote: policy.promote,
@@ -205,7 +234,7 @@ function buildPayload(version, versionCode, policy) {
   };
 }
 
-function generate(outPath) {
+function generate(outPath, androidLatestOverride) {
   const version = currentAppVersion();
   const policy = loadPolicy();
   const policyErrors = validatePolicy(policy, version);
@@ -215,7 +244,25 @@ function generate(outPath) {
     process.exit(1);
   }
 
-  const payload = buildPayload(version, currentVersionCode(), policy);
+  // Android latest: the release path (no override) advertises the working-tree version — the
+  // manifest is attached to the same GitHub release as that APK, so they publish atomically.
+  // The broadcast workflow passes --android-latest <latest release tag> so a version bump on
+  // main whose release is still building (or failed) is never advertised before it exists.
+  if (androidLatestOverride != null && !SEMVER_RE.test(androidLatestOverride)) {
+    console.error(`✖ --android-latest must be "x.y.z", got ${JSON.stringify(androidLatestOverride)}`);
+    process.exit(1);
+  }
+  const androidLatest = androidLatestOverride ?? version;
+  if (!semverLte(policy.min_supported.android, androidLatest)) {
+    console.error(
+      `✖ min_supported.android (${policy.min_supported.android}) is above the published android ` +
+        `latest (${androidLatest}) — would block users with no available fix. Wait for the ` +
+        `release of the new version to finish, then re-run.`,
+    );
+    process.exit(1);
+  }
+
+  const payload = buildPayload(version, currentVersionCode(), policy, androidLatest);
   const payloadBytes = Buffer.from(JSON.stringify(payload), 'utf8');
   const envelope = { schema: 1, payload_b64: payloadBytes.toString('base64') };
 
@@ -364,7 +411,7 @@ const flag = (label, fallback) => {
 
 switch (mode) {
   case 'generate':
-    generate(flag('--out', 'update-manifest.json'));
+    generate(flag('--out', 'update-manifest.json'), flag('--android-latest', null));
     break;
   case 'check':
     check();
@@ -373,6 +420,8 @@ switch (mode) {
     keygen(flag('--name', 'active'));
     break;
   default:
-    console.error('usage: update-manifest.mjs <generate [--out file] | check | keygen [--name n]>');
+    console.error(
+      'usage: update-manifest.mjs <generate [--out file] [--android-latest x.y.z] | check | keygen [--name n]>',
+    );
     process.exit(1);
 }

--- a/scripts/update-manifest.mjs
+++ b/scripts/update-manifest.mjs
@@ -15,9 +15,11 @@
 //       and release/update-policy.json. Signs it when OPENRUNG_MANIFEST_SIGNING_SEED_B64 is set
 //       (the base64 32-byte Ed25519 seed); otherwise emits an unsigned envelope with a warning —
 //       unsigned manifests can never hard-block clients, only surface the passive update row.
-//       --android-latest overrides the advertised Android version (broadcast workflow passes the
-//       latest RELEASE tag so a still-building/failed release is never advertised); iOS latest
-//       always comes from the policy file's ios_latest (TestFlight uploads are manual).
+//       --android-latest overrides the advertised Android version (the publisher workflow passes
+//       the latest RELEASE tag so a still-building/failed release is never advertised); iOS
+//       latest always comes from the policy file's ios_latest (TestFlight uploads are manual).
+//       --release-published-at (the resolved release's published_at) folds the release input
+//       into generated_at so equal stamps always mean identical manifests — see generatedAtIso.
 //   node scripts/update-manifest.mjs check
 //       CI guard: validates release/update-policy.json and the committed test vectors. Run by
 //       .github/workflows/version-check.yml on every PR.
@@ -210,35 +212,48 @@ function loadVectors() {
 }
 
 /**
- * generated_at = the generating checkout's HEAD committer time, NOT wall-clock. Git history is
- * the ordering authority for policy content: clients keep the manifest with the newest
- * generated_at, so a stale checkout that publishes late (e.g. a long release build racing a
- * policy edit) carries an honestly-older stamp and cached clients reject the rollback — a
- * wall-clock stamp would instead make the stale content look newest. Same-commit re-publishes
- * carry equal stamps, which clients accept (last-write-wins between identical-policy sources).
+ * generated_at = the NEWEST timestamp among ALL manifest inputs — the generating checkout's HEAD
+ * committer time and (when the workflow passes it) the resolved latest release's published_at.
+ * Never plain wall-clock: the inputs' own history is the ordering authority, so a stale-input
+ * publish that lands late carries an honestly-older stamp and cached clients reject the
+ * rollback. Because BOTH inputs are monotone (new commits and new releases only move forward),
+ * any input change strictly increases the stamp — which gives clients the invariant that EQUAL
+ * generated_at implies an identical manifest (same policy commit, same release), so they can
+ * safely stop walking / keep their cache on ties. A wall-clock stamp would break the rollback
+ * direction; a commit-time-only stamp would break the tie invariant (same commit, new release).
  */
-function generatedAtIso() {
+function generatedAtIso(releasePublishedAtIso) {
+  let headIso;
   try {
-    const iso = execSync('git log -1 --format=%cI', { cwd: root, encoding: 'utf8' }).trim();
-    if (Number.isNaN(Date.parse(iso))) {
-      throw new Error(`unparseable committer date ${JSON.stringify(iso)}`);
+    headIso = execSync('git log -1 --format=%cI', { cwd: root, encoding: 'utf8' }).trim();
+    if (Number.isNaN(Date.parse(headIso))) {
+      throw new Error(`unparseable committer date ${JSON.stringify(headIso)}`);
     }
-    return iso;
   } catch (error) {
     console.warn(
       `⚠ could not read the HEAD committer time (${error.message ?? error}) — ` +
         'falling back to wall-clock generated_at (rollback ordering is weaker for this manifest).',
     );
-    return new Date().toISOString();
+    headIso = new Date().toISOString();
   }
+  if (releasePublishedAtIso == null) {
+    return headIso;
+  }
+  if (Number.isNaN(Date.parse(releasePublishedAtIso))) {
+    console.error(
+      `✖ --release-published-at must be ISO-8601, got ${JSON.stringify(releasePublishedAtIso)}`,
+    );
+    process.exit(1);
+  }
+  return Date.parse(releasePublishedAtIso) > Date.parse(headIso) ? releasePublishedAtIso : headIso;
 }
 
 // --- generate ---------------------------------------------------------------------------------
 
-function buildPayload(version, versionCode, policy, androidLatest) {
+function buildPayload(version, versionCode, policy, androidLatest, generatedAt) {
   return {
     schema: 1,
-    generated_at: generatedAtIso(),
+    generated_at: generatedAt,
     android: {
       latest: androidLatest,
       // versionCode is read from the working tree, which only describes the advertised build
@@ -259,7 +274,7 @@ function buildPayload(version, versionCode, policy, androidLatest) {
   };
 }
 
-function generate(outPath, androidLatestOverride) {
+function generate(outPath, androidLatestOverride, releasePublishedAt) {
   const version = currentAppVersion();
   const policy = loadPolicy();
   const policyErrors = validatePolicy(policy, version);
@@ -287,7 +302,13 @@ function generate(outPath, androidLatestOverride) {
     process.exit(1);
   }
 
-  const payload = buildPayload(version, currentVersionCode(), policy, androidLatest);
+  const payload = buildPayload(
+    version,
+    currentVersionCode(),
+    policy,
+    androidLatest,
+    generatedAtIso(releasePublishedAt),
+  );
   const payloadBytes = Buffer.from(JSON.stringify(payload), 'utf8');
   const envelope = { schema: 1, payload_b64: payloadBytes.toString('base64') };
 
@@ -436,7 +457,11 @@ const flag = (label, fallback) => {
 
 switch (mode) {
   case 'generate':
-    generate(flag('--out', 'update-manifest.json'), flag('--android-latest', null));
+    generate(
+      flag('--out', 'update-manifest.json'),
+      flag('--android-latest', null),
+      flag('--release-published-at', null),
+    );
     break;
   case 'check':
     check();

--- a/src/components/UpdateBanner.tsx
+++ b/src/components/UpdateBanner.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { Pressable, StyleSheet, Text, View, type StyleProp, type ViewStyle } from 'react-native';
+
+import { monoFont, palette, tokens } from '../theme';
+
+/**
+ * Dismissible glass card for the home-screen overlay: the "update available" banner (notify tier)
+ * and operator broadcast notices both render through this. Purely presentational — the caller
+ * supplies already-localized text and the actions.
+ */
+export interface UpdateBannerProps {
+  title: string;
+  body: string;
+  /** 'warn' switches the title/accents to the working-yellow tone. Default 'info' (green). */
+  level?: 'info' | 'warn';
+  /** Optional primary action ("UPDATE", "Learn more"); hidden when label is absent. */
+  primaryLabel?: string;
+  onPrimary?: () => void;
+  dismissLabel: string;
+  onDismiss: () => void;
+  style?: StyleProp<ViewStyle>;
+}
+
+export function UpdateBanner({
+  title,
+  body,
+  level = 'info',
+  primaryLabel,
+  onPrimary,
+  dismissLabel,
+  onDismiss,
+  style,
+}: UpdateBannerProps): React.JSX.Element {
+  const accent = level === 'warn' ? tokens.working : palette.terminalGreen;
+  return (
+    <View style={[styles.card, level === 'warn' && styles.cardWarn, style]}>
+      <Text style={[styles.title, { color: accent }]}>{title}</Text>
+      <Text style={styles.body}>{body}</Text>
+      <View style={styles.actions}>
+        {primaryLabel != null && onPrimary != null ? (
+          <Pressable
+            onPress={onPrimary}
+            style={({ pressed }) => [styles.primaryButton, pressed && styles.pressed]}
+            accessibilityRole="button"
+          >
+            <Text style={styles.primaryLabel}>{primaryLabel}</Text>
+          </Pressable>
+        ) : null}
+        <Pressable
+          onPress={onDismiss}
+          style={({ pressed }) => [styles.dismissButton, pressed && styles.pressed]}
+          accessibilityRole="button"
+        >
+          <Text style={styles.dismissLabel}>{dismissLabel}</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderRadius: tokens.radiusMd,
+    backgroundColor: tokens.glass,
+    borderWidth: 1,
+    borderColor: tokens.glassBorder,
+    padding: 14,
+    gap: 8,
+  },
+  cardWarn: {
+    borderColor: tokens.working,
+  },
+  title: {
+    fontFamily: monoFont,
+    fontWeight: 'bold',
+    fontSize: 14,
+  },
+  body: {
+    color: palette.bodyText,
+    fontFamily: monoFont,
+    fontSize: 13,
+    lineHeight: 18,
+  },
+  actions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 18,
+    marginTop: 2,
+  },
+  primaryButton: {
+    height: 36,
+    borderRadius: 18,
+    paddingHorizontal: 18,
+    backgroundColor: palette.terminalGreen,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  primaryLabel: {
+    color: palette.onGreenText,
+    fontFamily: monoFont,
+    fontWeight: 'bold',
+    fontSize: 13,
+  },
+  dismissButton: {
+    paddingVertical: 8,
+  },
+  dismissLabel: {
+    color: palette.dimText,
+    fontFamily: monoFont,
+    fontSize: 13,
+  },
+  pressed: {
+    opacity: 0.85,
+  },
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -138,6 +138,51 @@ export const AppConfig = {
    */
   MAP_TILES_URL: 'https://demotiles.maplibre.org/tiles/tiles.json',
   MAP_GLYPHS_URL: 'https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf',
+
+  /**
+   * Ordered candidates for the in-app update manifest (docs/UPDATE_MANIFEST.md), tried
+   * sequentially with a per-attempt timeout, fail-open: all-fail just means "no update UI".
+   * The two broker fronts come first because they are the censorship-resistant path (same
+   * two-provider reasoning as DEFAULT_BROKER_URLS; the routes are served per the docs contract);
+   * the GitHub release asset is the zero-infrastructure fallback — it works from the first
+   * release that ships a manifest, but github.com is unreliable in several target regions.
+   * These URLs are a FOREVER CONTRACT with shipped clients: never repurpose or break them.
+   */
+  UPDATE_MANIFEST_URLS: [
+    'https://broker.openrung.org/api/v1/app-manifest',
+    'https://d2r7mdpyevvs1m.cloudfront.net/api/v1/app-manifest',
+    'https://github.com/openrung/openrung-mobile-app/releases/latest/download/update-manifest.json',
+  ],
+
+  /**
+   * Where the "Update" buttons send Android users. Deliberately a pinned constant — update
+   * destinations NEVER come from the manifest, so even a validly-signed (let alone forged)
+   * manifest cannot redirect users to a hostile download. iOS uses TESTFLIGHT_URL.
+   */
+  UPDATE_URL_ANDROID: 'https://github.com/openrung/openrung-mobile-app/releases/latest',
+
+  /** Minimum interval between successful update-manifest checks (cold start + app foreground). */
+  UPDATE_CHECK_INTERVAL_MS: 6 * 3_600_000,
+
+  /** Minimum interval between retries after a failed check (in-memory, per app session). */
+  UPDATE_CHECK_RETRY_MS: 15 * 60_000,
+
+  /**
+   * Pinned Ed25519 public keys for update-manifest signature verification — same derivations and
+   * CI guard pattern as RELAY_SIGNING_KEYS, but a DELIBERATELY separate keypair: the manifest can
+   * hard-block app startup, so its signing key is scoped to exactly that power and nothing else.
+   * The client only ever hard-blocks ("Update required") on a manifest that verifies against one
+   * of these keys; unsigned or unverifiable manifests are capped at the passive update row. MUST
+   * stay in sync with the `pinned_keys` block of testdata/update_manifest_vectors.json (CI guard
+   * in updateManifest.test.ts + scripts/update-manifest.mjs check). Rotation: keygen mode of
+   * scripts/update-manifest.mjs, pin the new key here, ship a release, then swap the secret.
+   */
+  MANIFEST_SIGNING_KEYS: [
+    {
+      keyId: 'a71d7615b7af163b', // active (seed in GitHub secret OPENRUNG_MANIFEST_SIGNING_SEED_B64)
+      publicKeyHex: '3443068d4cb27dd474dee11155c365a44df6a24c560b8ae2cb019487b555bfc7',
+    },
+  ],
 } as const;
 
 /** App version reported in X-OpenRung-App-Version (production uses BuildConfig.VERSION_NAME). */

--- a/src/i18n/strings/ar.ts
+++ b/src/i18n/strings/ar.ts
@@ -134,4 +134,21 @@ export const ar: Partial<Strings> = {
     'يتدفّق كل شيء عبر نفق VLESS/REALITY يبدو كأنه TLS عادي، ويعمل VPN بوضع fail-closed: لا مرحل، لا مرور.',
   aboutFootnote:
     'OpenRung برمجية حرة (GPL-3.0-or-later). بناه متطوّعون، للجميع.',
+
+  // --- In-app update check (manifest banner / blocking screen / broadcast notice) ---
+  updateRequiredTitle: 'التحديث مطلوب',
+  updateRequiredBody:
+    'لم يعد بإمكان هذا الإصدار من OpenRung الاتصال بشبكة المُرحّلات. ثبّت أحدث إصدار للمتابعة.',
+  updateVersionTransition: (current: string, latest: string) => `v${current} -> v${latest}`,
+  updateActionNow: 'تحديث',
+  updateActionLater: 'لاحقًا',
+  updateContinueAnyway: 'المتابعة على أي حال',
+  updateBannerTitle: 'يتوفر تحديث',
+  updateBannerBody: (latest: string) =>
+    `يتضمّن الإصدار ${latest} إصلاحات مهمة. حدّث عندما تستطيع.`,
+  updateSettingTitle: 'يتوفر تحديث',
+  updateSettingSubtitle: (current: string, latest: string) =>
+    `لديك v${current}؛ وصدر v${latest}. اضغط للحصول عليه.`,
+  noticeDismiss: 'تجاهل',
+  noticeLearnMore: 'معرفة المزيد',
 };

--- a/src/i18n/strings/en.ts
+++ b/src/i18n/strings/en.ts
@@ -119,6 +119,23 @@ export const en = {
   telemetryLocationsLabel: 'locations',
   telemetryCountriesLabel: 'countries',
   telemetryUptimeLabel: 'uptime',
+
+  // --- In-app update check (manifest banner / blocking screen / broadcast notice) ---
+  updateRequiredTitle: 'Update required',
+  updateRequiredBody:
+    'This version of OpenRung can no longer connect to the relay network. Install the latest release to keep going.',
+  updateVersionTransition: (current: string, latest: string) => `v${current} -> v${latest}`,
+  updateActionNow: 'UPDATE',
+  updateActionLater: 'Later',
+  updateContinueAnyway: 'Continue anyway',
+  updateBannerTitle: 'Update available',
+  updateBannerBody: (latest: string) =>
+    `Version ${latest} includes important fixes. Update when you can.`,
+  updateSettingTitle: 'Update available',
+  updateSettingSubtitle: (current: string, latest: string) =>
+    `You have v${current}; v${latest} is out. Tap to get it.`,
+  noticeDismiss: 'Dismiss',
+  noticeLearnMore: 'Learn more',
 };
 
 export type Strings = typeof en;

--- a/src/i18n/strings/fa.ts
+++ b/src/i18n/strings/fa.ts
@@ -134,4 +134,21 @@ export const fa: Partial<Strings> = {
     'همه‌چیز از طریق یک تونل VLESS/REALITY جریان می‌یابد که شبیه TLS معمولی به نظر می‌رسد، و VPN در حالت fail-closed است: بدون رله، بدون ترافیک.',
   aboutFootnote:
     'OpenRung نرم‌افزار آزاد است (GPL-3.0-or-later). ساخته‌شده توسط داوطلبان، برای همه.',
+
+  // --- In-app update check (manifest banner / blocking screen / broadcast notice) ---
+  updateRequiredTitle: 'به‌روزرسانی لازم است',
+  updateRequiredBody:
+    'این نسخه از OpenRung دیگر نمی‌تواند به شبکهٔ رله‌ها متصل شود. برای ادامه، آخرین نسخه را نصب کنید.',
+  updateVersionTransition: (current: string, latest: string) => `v${current} -> v${latest}`,
+  updateActionNow: 'به‌روزرسانی',
+  updateActionLater: 'بعداً',
+  updateContinueAnyway: 'به هر حال ادامه دهید',
+  updateBannerTitle: 'به‌روزرسانی موجود است',
+  updateBannerBody: (latest: string) =>
+    `نسخهٔ ${latest} شامل اصلاحات مهمی است. در اولین فرصت به‌روزرسانی کنید.`,
+  updateSettingTitle: 'به‌روزرسانی موجود است',
+  updateSettingSubtitle: (current: string, latest: string) =>
+    `شما نسخهٔ v${current} را دارید؛ نسخهٔ v${latest} منتشر شده است. برای دریافت ضربه بزنید.`,
+  noticeDismiss: 'بستن',
+  noticeLearnMore: 'بیشتر بدانید',
 };

--- a/src/i18n/strings/my.ts
+++ b/src/i18n/strings/my.ts
@@ -146,4 +146,21 @@ export const my: Partial<Strings> = {
     'အရာအားလုံးသည် သာမန် TLS နှင့် တူသော VLESS/REALITY ဥမင်မှတစ်ဆင့် စီးဆင်းသွားပြီး VPN သည် fail-closed ဖြစ်သည်: ရီလေးမရှိလျှင် ဒေတာအသွားအလာ မရှိပါ။',
   aboutFootnote:
     'OpenRung သည် အခမဲ့ဆော့ဖ်ဝဲ (GPL-3.0-or-later) ဖြစ်သည်။ စေတနာ့ဝန်ထမ်းများက အားလုံးအတွက် တည်ဆောက်ထားသည်။',
+
+  // --- In-app update check (manifest banner / blocking screen / broadcast notice) ---
+  updateRequiredTitle: 'အပ်ဒိတ် လုပ်ရန် လိုအပ်သည်',
+  updateRequiredBody:
+    'ဤ OpenRung ဗားရှင်းသည် ရီလေး ကွန်ရက်သို့ ချိတ်ဆက်၍ မရတော့ပါ။ ဆက်လက်အသုံးပြုနိုင်ရန် နောက်ဆုံးထွက် ဗားရှင်းကို ထည့်သွင်းပါ။',
+  updateVersionTransition: (current: string, latest: string) => `v${current} -> v${latest}`,
+  updateActionNow: 'အပ်ဒိတ်လုပ်မည်',
+  updateActionLater: 'နောက်မှ',
+  updateContinueAnyway: 'မည်သို့ပင်ဖြစ်စေ ဆက်လုပ်မည်',
+  updateBannerTitle: 'အပ်ဒိတ် ရနိုင်ပါပြီ',
+  updateBannerBody: (latest: string) =>
+    `ဗားရှင်း ${latest} တွင် အရေးကြီးသော ပြင်ဆင်ချက်များ ပါဝင်သည်။ အဆင်ပြေချိန်တွင် အပ်ဒိတ်လုပ်ပါ။`,
+  updateSettingTitle: 'အပ်ဒိတ် ရနိုင်ပါပြီ',
+  updateSettingSubtitle: (current: string, latest: string) =>
+    `သင် v${current} ကို သုံးနေပြီး v${latest} ထွက်ရှိပြီးဖြစ်သည်။ ရယူရန် တို့ပါ။`,
+  noticeDismiss: 'ပိတ်မည်',
+  noticeLearnMore: 'ပိုမိုလေ့လာရန်',
 };

--- a/src/i18n/strings/ru.ts
+++ b/src/i18n/strings/ru.ts
@@ -133,4 +133,21 @@ export const ru: Partial<Strings> = {
     'Всё проходит через туннель VLESS/REALITY, который выглядит как обычный TLS, а VPN работает fail-closed: нет ретранслятора, нет трафика.',
   aboutFootnote:
     'OpenRung — свободное программное обеспечение (GPL-3.0-or-later). Создано волонтёрами для всех.',
+
+  // --- In-app update check (manifest banner / blocking screen / broadcast notice) ---
+  updateRequiredTitle: 'Требуется обновление',
+  updateRequiredBody:
+    'Эта версия OpenRung больше не может подключаться к сети ретрансляторов. Установите последний выпуск, чтобы продолжить пользоваться приложением.',
+  updateVersionTransition: (current: string, latest: string) => `v${current} -> v${latest}`,
+  updateActionNow: 'ОБНОВИТЬ',
+  updateActionLater: 'Позже',
+  updateContinueAnyway: 'Всё равно продолжить',
+  updateBannerTitle: 'Доступно обновление',
+  updateBannerBody: (latest: string) =>
+    `Версия ${latest} содержит важные исправления. Обновитесь при возможности.`,
+  updateSettingTitle: 'Доступно обновление',
+  updateSettingSubtitle: (current: string, latest: string) =>
+    `У вас v${current}; вышла v${latest}. Нажмите, чтобы установить.`,
+  noticeDismiss: 'Закрыть',
+  noticeLearnMore: 'Подробнее',
 };

--- a/src/i18n/strings/tr.ts
+++ b/src/i18n/strings/tr.ts
@@ -137,4 +137,21 @@ export const tr: Partial<Strings> = {
     'Her şey, sıradan TLS gibi görünen bir VLESS/REALITY tüneli üzerinden akar ve VPN fail-closed çalışır: röle yoksa trafik yok.',
   aboutFootnote:
     'OpenRung özgür bir yazılımdır (GPL-3.0-or-later). Gönüllüler tarafından, herkes için geliştirildi.',
+
+  // --- In-app update check (manifest banner / blocking screen / broadcast notice) ---
+  updateRequiredTitle: 'Güncelleme gerekli',
+  updateRequiredBody:
+    "OpenRung'un bu sürümü artık röle ağına bağlanamıyor. Devam edebilmek için en son sürümü yükleyin.",
+  updateVersionTransition: (current: string, latest: string) => `v${current} -> v${latest}`,
+  updateActionNow: 'GÜNCELLE',
+  updateActionLater: 'Daha sonra',
+  updateContinueAnyway: 'Yine de devam et',
+  updateBannerTitle: 'Güncelleme mevcut',
+  updateBannerBody: (latest: string) =>
+    `${latest} sürümü önemli düzeltmeler içeriyor. Fırsat bulduğunuzda güncelleyin.`,
+  updateSettingTitle: 'Güncelleme mevcut',
+  updateSettingSubtitle: (current: string, latest: string) =>
+    `v${current} kullanıyorsunuz; v${latest} yayında. İndirmek için dokunun.`,
+  noticeDismiss: 'Kapat',
+  noticeLearnMore: 'Daha fazla bilgi',
 };

--- a/src/i18n/strings/vi.ts
+++ b/src/i18n/strings/vi.ts
@@ -131,4 +131,21 @@ export const vi: Partial<Strings> = {
     'Mọi thứ đều đi qua một đường hầm VLESS/REALITY trông như TLS thông thường, và VPN ở chế độ fail-closed: không có relay, không có lưu lượng.',
   aboutFootnote:
     'OpenRung là phần mềm tự do (GPL-3.0-or-later). Được xây dựng bởi tình nguyện viên, cho mọi người.',
+
+  // --- In-app update check (manifest banner / blocking screen / broadcast notice) ---
+  updateRequiredTitle: 'Cần cập nhật',
+  updateRequiredBody:
+    'Phiên bản OpenRung này không còn kết nối được với mạng lưới relay. Hãy cài bản mới nhất để tiếp tục sử dụng.',
+  updateVersionTransition: (current: string, latest: string) => `v${current} -> v${latest}`,
+  updateActionNow: 'CẬP NHẬT',
+  updateActionLater: 'Để sau',
+  updateContinueAnyway: 'Vẫn tiếp tục',
+  updateBannerTitle: 'Có bản cập nhật',
+  updateBannerBody: (latest: string) =>
+    `Phiên bản ${latest} có các bản sửa lỗi quan trọng. Hãy cập nhật khi có thể.`,
+  updateSettingTitle: 'Có bản cập nhật',
+  updateSettingSubtitle: (current: string, latest: string) =>
+    `Bạn đang dùng v${current}; v${latest} đã ra mắt. Nhấn để tải về.`,
+  noticeDismiss: 'Bỏ qua',
+  noticeLearnMore: 'Tìm hiểu thêm',
 };

--- a/src/i18n/strings/zh-CN.ts
+++ b/src/i18n/strings/zh-CN.ts
@@ -131,4 +131,21 @@ export const zhCN: Partial<Strings> = {
     '所有流量都通过一条看起来像普通 TLS 的 VLESS/REALITY 隧道传输，并且 VPN 采用失败关闭：没有中继，就没有流量。',
   aboutFootnote:
     'OpenRung 是自由软件（GPL-3.0-or-later）。由志愿者打造，为所有人服务。',
+
+  // --- In-app update check (manifest banner / blocking screen / broadcast notice) ---
+  updateRequiredTitle: '需要更新',
+  updateRequiredBody:
+    '当前版本的 OpenRung 已无法连接中继网络。请安装最新版本以继续使用。',
+  updateVersionTransition: (current: string, latest: string) => `v${current} -> v${latest}`,
+  updateActionNow: '立即更新',
+  updateActionLater: '稍后',
+  updateContinueAnyway: '仍然继续',
+  updateBannerTitle: '有可用更新',
+  updateBannerBody: (latest: string) =>
+    `版本 ${latest} 包含重要修复。方便时更新即可。`,
+  updateSettingTitle: '有可用更新',
+  updateSettingSubtitle: (current: string, latest: string) =>
+    `当前为 v${current}，最新版 v${latest} 已发布。点按获取。`,
+  noticeDismiss: '关闭',
+  noticeLearnMore: '了解更多',
 };

--- a/src/i18n/strings/zh-TW.ts
+++ b/src/i18n/strings/zh-TW.ts
@@ -123,4 +123,21 @@ export const zhTW: Partial<Strings> = {
     '一切都會流經看起來就像一般 TLS 的 VLESS/REALITY 通道，而 VPN 採用失敗關閉：沒有中繼，就沒有流量。',
   aboutFootnote:
     'OpenRung 是自由軟體（GPL-3.0-or-later）。由志願者打造，獻給每一個人。',
+
+  // --- In-app update check (manifest banner / blocking screen / broadcast notice) ---
+  updateRequiredTitle: '需要更新',
+  updateRequiredBody:
+    '此版本的 OpenRung 已無法連線至中繼網路。請安裝最新版本以繼續使用。',
+  updateVersionTransition: (current: string, latest: string) => `v${current} -> v${latest}`,
+  updateActionNow: '更新',
+  updateActionLater: '稍後',
+  updateContinueAnyway: '仍要繼續',
+  updateBannerTitle: '有可用更新',
+  updateBannerBody: (latest: string) =>
+    `${latest} 版包含重要修正。方便時更新即可。`,
+  updateSettingTitle: '有可用更新',
+  updateSettingSubtitle: (current: string, latest: string) =>
+    `你目前使用 v${current}；v${latest} 已推出。點選即可取得。`,
+  noticeDismiss: '關閉',
+  noticeLearnMore: '瞭解更多',
 };

--- a/src/model/updateStatus.ts
+++ b/src/model/updateStatus.ts
@@ -1,0 +1,110 @@
+import type { DecodedUpdateManifest, UpdateNotice } from '../net/updateManifestClient';
+import { compareVersions } from '../net/updateManifestClient';
+
+/**
+ * Pure derivation of the update-check UI state from a decoded manifest. The tier ladder is the
+ * whole UX policy — checking is silent and constant, PROMPTING is rationed here:
+ *
+ * - 'none'      — up to date (or no usable manifest): zero UI.
+ * - 'available' — behind the latest release: passive Settings row only. This is the default for
+ *                 routine releases, and the ceiling for UNVERIFIED manifests: without a pinned-key
+ *                 signature the manifest gets no banner, no notice and never a block.
+ * - 'notify'    — behind AND the operator set promote="notify" (verified only): one dismissible
+ *                 home-screen banner per version, then back to 'available'.
+ * - 'blocked'   — below the min_supported floor (verified only): full-screen "Update required".
+ *                 "Continue anyway" (session-scoped `blockOverridden`) drops it to 'available',
+ *                 honouring the availability-first design — a custom-broker user on an
+ *                 "unsupported" build may still work fine.
+ */
+
+export type UpdateTier = 'none' | 'available' | 'notify' | 'blocked';
+
+export interface UpdateUiState {
+  tier: UpdateTier;
+  /** Latest version per the manifest (null when unknown). */
+  latestVersion: string | null;
+  /** Whether the manifest carried a valid pinned-key signature. */
+  verified: boolean;
+  /** The notice to show (already filtered: verified, undismissed, unexpired), or null. */
+  notice: UpdateNotice | null;
+}
+
+export const INITIAL_UPDATE_UI: UpdateUiState = {
+  tier: 'none',
+  latestVersion: null,
+  verified: false,
+  notice: null,
+};
+
+export interface DeriveUpdateInputs {
+  decoded: DecodedUpdateManifest | null;
+  /** react-native Platform.OS; anything but 'android'/'ios' derives no version tier. */
+  platform: string;
+  currentVersion: string;
+  /** Version string whose 'notify' banner the user already dismissed (persisted). */
+  dismissedBannerVersion: string | null;
+  /** Notice ids the user already dismissed (persisted). */
+  dismissedNoticeIds: readonly string[];
+  /** Session-scoped "Continue anyway" on the blocking screen. */
+  blockOverridden: boolean;
+  nowMs: number;
+}
+
+export function deriveUpdateUiState(inputs: DeriveUpdateInputs): UpdateUiState {
+  const { decoded } = inputs;
+  if (decoded === null) {
+    return INITIAL_UPDATE_UI;
+  }
+  const { manifest, verified } = decoded;
+  const info =
+    inputs.platform === 'ios' ? manifest.ios : inputs.platform === 'android' ? manifest.android : null;
+
+  const behind =
+    info?.latest != null && compareVersions(inputs.currentVersion, info.latest) === -1;
+  const belowFloor =
+    verified &&
+    info?.minSupported != null &&
+    compareVersions(inputs.currentVersion, info.minSupported) === -1;
+
+  let tier: UpdateTier;
+  if (belowFloor) {
+    // "Continue anyway" lands on the passive row, never the banner — the user just declined the
+    // strongest prompt this session; a second, weaker prompt would only nag.
+    tier = inputs.blockOverridden ? 'available' : 'blocked';
+  } else if (behind) {
+    tier =
+      verified &&
+      manifest.promote === 'notify' &&
+      info?.latest != null &&
+      inputs.dismissedBannerVersion !== info.latest
+        ? 'notify'
+        : 'available';
+  } else {
+    tier = 'none';
+  }
+
+  const notice =
+    verified &&
+    manifest.notice !== null &&
+    !inputs.dismissedNoticeIds.includes(manifest.notice.id) &&
+    (manifest.notice.expiresMs === null || manifest.notice.expiresMs > inputs.nowMs)
+      ? manifest.notice
+      : null;
+
+  return { tier, latestVersion: info?.latest ?? null, verified, notice };
+}
+
+/**
+ * Picks the best translation from a server-sent {locale: text} map for a resolved app language
+ * tag: exact tag, then primary subtag, then English. Decoding guarantees 'en' exists.
+ */
+export function pickLocalizedText(map: Record<string, string>, resolvedTag: string): string {
+  if (typeof map[resolvedTag] === 'string') {
+    return map[resolvedTag];
+  }
+  const primary = resolvedTag.split('-')[0];
+  if (typeof map[primary] === 'string') {
+    return map[primary];
+  }
+  return map.en;
+}

--- a/src/net/updateManifestClient.ts
+++ b/src/net/updateManifestClient.ts
@@ -388,29 +388,56 @@ async function fetchAttempt(url: string): Promise<FetchedUpdateManifest> {
   }
 }
 
+export interface FetchManifestOptions {
+  /**
+   * generatedAtMs of the caller's cached VERIFIED manifest, if any. A verified candidate at
+   * least this fresh ends the walk immediately (the steady state: every front serves the same
+   * manifest, so the first request suffices). A verified-but-STALER candidate does not — the
+   * walk continues, so one front replaying an old signed manifest cannot shadow the fresher copy
+   * on a later front. Null/absent (no verified cache yet) surveys every candidate once and takes
+   * the newest, so a stale first front cannot pin fresh installs either.
+   */
+  atLeastGeneratedAtMs?: number | null;
+}
+
 /**
- * Tries each candidate URL in order (10s per attempt) and returns the first VERIFIED envelope; an
- * unsigned-but-decodable envelope is remembered as a fallback but the walk continues, so a front
- * serving a sig-stripped copy cannot shadow the signed copy on a later front. Returns the
- * unsigned fallback only when no candidate verifies, and null when every candidate fails. Never
- * throws: this is a background check and MUST fail open — no update UI is always an acceptable
- * outcome, a blocked or delayed app never is. Sequential (not the discovery stagger-race) because
- * latency is irrelevant here and order keeps the censorship-resistant fronts preferred.
+ * Tries each candidate URL in order (10s per attempt) and returns the best envelope under a
+ * strict preference order: first verified candidate fresh enough for `atLeastGeneratedAtMs`
+ * (walk ends), else the newest verified candidate seen, else the first unsigned-but-decodable
+ * candidate (a front serving a sig-stripped copy cannot shadow the signed copy on a later
+ * front), else null when every candidate fails. Never throws: this is a background check and
+ * MUST fail open — no update UI is always an acceptable outcome, a blocked or delayed app never
+ * is. Sequential (not the discovery stagger-race) because latency is irrelevant here and order
+ * keeps the censorship-resistant fronts preferred.
  */
 export async function fetchUpdateManifest(
   urls: readonly string[] = AppConfig.UPDATE_MANIFEST_URLS,
+  options: FetchManifestOptions = {},
 ): Promise<FetchedUpdateManifest | null> {
+  const floor = options.atLeastGeneratedAtMs ?? null;
+  let bestVerified: FetchedUpdateManifest | null = null;
   let unsignedFallback: FetchedUpdateManifest | null = null;
   for (const url of urls) {
     try {
       const fetched = await fetchAttempt(url);
-      if (fetched.decoded.verified) {
+      if (!fetched.decoded.verified) {
+        unsignedFallback = unsignedFallback ?? fetched;
+        continue;
+      }
+      if (floor !== null && fetched.decoded.manifest.generatedAtMs >= floor) {
         return fetched;
       }
-      unsignedFallback = unsignedFallback ?? fetched;
+      if (
+        bestVerified === null ||
+        fetched.decoded.manifest.generatedAtMs > bestVerified.decoded.manifest.generatedAtMs
+      ) {
+        bestVerified = fetched;
+      }
+      // Verified but staler than the cache (or no cache to compare against): keep walking — a
+      // later front may hold a fresher signed copy.
     } catch {
       // Failed candidate (network, HTTP status, tampered signature, bad envelope) — try the next.
     }
   }
-  return unsignedFallback;
+  return bestVerified ?? unsignedFallback;
 }

--- a/src/net/updateManifestClient.ts
+++ b/src/net/updateManifestClient.ts
@@ -1,0 +1,416 @@
+/* eslint-disable no-bitwise -- the base64/UTF-8 codecs below are inherently byte-twiddling */
+import * as ed from '@noble/ed25519';
+import { sha512 } from '@noble/hashes/sha2.js';
+import { Platform } from 'react-native';
+
+import { APP_VERSION, AppConfig } from '../config';
+
+// Hermes has no SubtleCrypto, so @noble/ed25519's async (WebCrypto-hashed) path is unavailable;
+// wiring the pure-JS SHA-512 enables the sync verify path (same wiring as brokerClient.ts).
+ed.etc.sha512Sync = (...messages: Uint8Array[]) => sha512(ed.etc.concatBytes(...messages));
+
+/**
+ * In-app update manifest client (docs/UPDATE_MANIFEST.md). Fetches the signed envelope from the
+ * ordered candidate URLs, verifies the detached Ed25519 signature over the exact payload bytes
+ * against the pinned MANIFEST_SIGNING_KEYS, and decodes the payload LENIENTLY: the manifest URL +
+ * schema are a forever-contract with shipped clients, so unknown fields are ignored and invalid
+ * optional fields degrade to null instead of failing the whole document.
+ *
+ * Trust model: `verified` is the only trust signal. An unsigned envelope still decodes
+ * (verified=false) — the derivation layer caps it at the passive "update available" tier — but a
+ * PRESENT-and-invalid signature throws, so a tampered copy on one CDN front fails that candidate
+ * and a clean copy from the next one can win. Nothing here ever blocks the app on its own:
+ * all-candidates-fail just returns null (fail open, per the availability-first design).
+ */
+
+const REQUEST_TIMEOUT_MS = 10_000;
+
+export interface UpdatePlatformInfo {
+  /** Latest released version ("x.y.z"), or null if absent/unparseable. */
+  latest: string | null;
+  /** Versions below this cannot work anymore ("x.y.z"); null = no floor. */
+  minSupported: string | null;
+}
+
+export interface UpdateNotice {
+  /** Dismissal key — re-broadcast by changing the id. */
+  id: string;
+  level: 'info' | 'warn';
+  /** {locale: text}; 'en' is guaranteed present. */
+  title: Record<string, string>;
+  body: Record<string, string>;
+  /** Optional https "Learn more" target (only ever opened from VERIFIED manifests). */
+  url: string | null;
+  /** Epoch ms after which the notice is hidden client-side; null = no expiry. */
+  expiresMs: number | null;
+}
+
+export interface UpdateManifest {
+  /** Epoch ms the manifest was generated (0 when absent) — used for rollback monotonicity. */
+  generatedAtMs: number;
+  android: UpdatePlatformInfo | null;
+  ios: UpdatePlatformInfo | null;
+  promote: 'silent' | 'notify';
+  notice: UpdateNotice | null;
+}
+
+export interface DecodedUpdateManifest {
+  manifest: UpdateManifest;
+  /** True only when a signature was present AND verified against a pinned key. */
+  verified: boolean;
+  keyIdUsed: string | null;
+}
+
+export interface ManifestSigningKey {
+  keyId: string;
+  publicKeyHex: string;
+}
+
+// Pinned-key override for tests only (same convention as setRelaySigningKeysForTests).
+let signingKeysOverride: readonly ManifestSigningKey[] | null = null;
+
+export function setManifestSigningKeysForTests(keys: readonly ManifestSigningKey[] | null): void {
+  signingKeysOverride = keys;
+}
+
+function pinnedSigningKeys(): readonly ManifestSigningKey[] {
+  return signingKeysOverride ?? AppConfig.MANIFEST_SIGNING_KEYS;
+}
+
+function manifestFailure(reason: string): Error {
+  return new Error(`update manifest: invalid (${reason})`);
+}
+
+// --- byte codecs ------------------------------------------------------------------------------
+// Duplicated from brokerClient.ts internals (which are deliberately unexported and spec-pinned):
+// Hermes has no atob, and TextDecoder may be absent.
+
+const BASE64_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+
+/** Strict standard-base64 (padded) decoder; throws on any deviation. */
+function base64ToBytes(encoded: string): Uint8Array {
+  if (encoded.length === 0 || encoded.length % 4 !== 0) {
+    throw manifestFailure('not valid base64');
+  }
+  const padding = encoded.endsWith('==') ? 2 : encoded.endsWith('=') ? 1 : 0;
+  const out = new Uint8Array((encoded.length / 4) * 3 - padding);
+  let buffer = 0;
+  let bits = 0;
+  let outIndex = 0;
+  for (let i = 0; i < encoded.length - padding; i++) {
+    const value = BASE64_ALPHABET.indexOf(encoded[i]);
+    if (value < 0) {
+      throw manifestFailure('not valid base64');
+    }
+    buffer = (buffer << 6) | value;
+    bits += 6;
+    if (bits >= 8) {
+      bits -= 8;
+      out[outIndex++] = (buffer >> bits) & 0xff;
+    }
+  }
+  return out;
+}
+
+type TextCodecGlobals = {
+  TextDecoder?: new (label?: string, options?: { fatal?: boolean }) => {
+    decode(input: Uint8Array): string;
+  };
+};
+
+/** Strict UTF-8 decode of the VERIFIED payload bytes; invalid UTF-8 throws. */
+function decodeUtf8(bytes: Uint8Array): string {
+  const codecs = globalThis as TextCodecGlobals;
+  if (codecs.TextDecoder) {
+    try {
+      return new codecs.TextDecoder('utf-8', { fatal: true }).decode(bytes);
+    } catch {
+      throw manifestFailure('payload is not valid UTF-8');
+    }
+  }
+  let out = '';
+  let i = 0;
+  const fail = () => manifestFailure('payload is not valid UTF-8');
+  while (i < bytes.length) {
+    const b0 = bytes[i++];
+    if (b0 < 0x80) {
+      out += String.fromCharCode(b0);
+      continue;
+    }
+    let extra: number;
+    let codePoint: number;
+    let min: number;
+    if (b0 >= 0xc2 && b0 <= 0xdf) {
+      extra = 1;
+      codePoint = b0 & 0x1f;
+      min = 0x80;
+    } else if (b0 >= 0xe0 && b0 <= 0xef) {
+      extra = 2;
+      codePoint = b0 & 0x0f;
+      min = 0x800;
+    } else if (b0 >= 0xf0 && b0 <= 0xf4) {
+      extra = 3;
+      codePoint = b0 & 0x07;
+      min = 0x10000;
+    } else {
+      throw fail();
+    }
+    if (i + extra > bytes.length) {
+      throw fail();
+    }
+    for (let k = 0; k < extra; k++) {
+      const next = bytes[i++];
+      if ((next & 0xc0) !== 0x80) {
+        throw fail();
+      }
+      codePoint = (codePoint << 6) | (next & 0x3f);
+    }
+    if (codePoint < min || codePoint > 0x10ffff || (codePoint >= 0xd800 && codePoint <= 0xdfff)) {
+      throw fail();
+    }
+    out += String.fromCodePoint(codePoint);
+  }
+  return out;
+}
+
+// --- version comparison -----------------------------------------------------------------------
+
+const SEMVER_RE = /^\d+\.\d+\.\d+$/;
+
+/**
+ * Strict "x.y.z" comparison: -1 / 0 / 1, or null when either side is unparseable — callers must
+ * treat null as "no conclusion" (fail open), never as "behind".
+ */
+export function compareVersions(a: string, b: string): -1 | 0 | 1 | null {
+  if (!SEMVER_RE.test(a) || !SEMVER_RE.test(b)) {
+    return null;
+  }
+  const ta = a.split('.').map(Number);
+  const tb = b.split('.').map(Number);
+  for (let i = 0; i < 3; i++) {
+    if (ta[i] !== tb[i]) {
+      return ta[i] < tb[i] ? -1 : 1;
+    }
+  }
+  return 0;
+}
+
+// --- decoding ---------------------------------------------------------------------------------
+
+function asSemver(value: unknown): string | null {
+  return typeof value === 'string' && SEMVER_RE.test(value) ? value : null;
+}
+
+function decodePlatform(value: unknown): UpdatePlatformInfo | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return null;
+  }
+  const record = value as Record<string, unknown>;
+  const latest = asSemver(record.latest);
+  const minSupported = asSemver(record.min_supported);
+  return latest === null && minSupported === null ? null : { latest, minSupported };
+}
+
+function decodeLocalizedMap(value: unknown): Record<string, string> | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return null;
+  }
+  const out: Record<string, string> = {};
+  for (const [locale, text] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof text === 'string' && text.trim().length > 0) {
+      out[locale] = text;
+    }
+  }
+  return typeof out.en === 'string' ? out : null;
+}
+
+function decodeNotice(value: unknown): UpdateNotice | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return null;
+  }
+  const record = value as Record<string, unknown>;
+  const id = typeof record.id === 'string' && record.id.trim().length > 0 ? record.id : null;
+  const title = decodeLocalizedMap(record.title);
+  const body = decodeLocalizedMap(record.body);
+  if (id === null || title === null || body === null) {
+    return null;
+  }
+  const expiresMs =
+    typeof record.expires === 'string' && !Number.isNaN(Date.parse(record.expires))
+      ? Date.parse(record.expires)
+      : null;
+  return {
+    id,
+    // Forward-compat: an unknown future level renders as the mildest style instead of vanishing.
+    level: record.level === 'warn' ? 'warn' : 'info',
+    title,
+    body,
+    url: typeof record.url === 'string' && record.url.startsWith('https://') ? record.url : null,
+    expiresMs,
+  };
+}
+
+/** Parses `ed25519;<key_id>;<base64_std_signature>` (same 3-field format as the relay header). */
+function parseSigField(value: string): { keyId: string; signature: Uint8Array } {
+  const fields = value.split(';');
+  if (fields.length !== 3 || fields[0] !== 'ed25519') {
+    throw manifestFailure('malformed sig field');
+  }
+  const signature = base64ToBytes(fields[2]);
+  if (signature.length !== 64) {
+    throw manifestFailure('signature must be 64 bytes');
+  }
+  return { keyId: fields[1], signature };
+}
+
+/**
+ * Decodes (and, when a signature is present, verifies) one raw envelope body. Throws on anything
+ * structurally broken or on a signature that FAILS verification — the fetch loop treats a throw
+ * as "this candidate is bad, try the next". A missing signature is not an error: it yields
+ * verified=false, which the derivation layer caps at the passive tier.
+ */
+export function decodeUpdateEnvelope(raw: string): DecodedUpdateManifest {
+  let envelope: unknown;
+  try {
+    envelope = JSON.parse(raw);
+  } catch {
+    throw manifestFailure('envelope is not JSON');
+  }
+  if (typeof envelope !== 'object' || envelope === null || Array.isArray(envelope)) {
+    throw manifestFailure('envelope is not an object');
+  }
+  const envelopeRecord = envelope as Record<string, unknown>;
+  if (envelopeRecord.schema !== 1) {
+    throw manifestFailure(`unsupported envelope schema ${JSON.stringify(envelopeRecord.schema)}`);
+  }
+  if (typeof envelopeRecord.payload_b64 !== 'string') {
+    throw manifestFailure('payload_b64 missing');
+  }
+  const payloadBytes = base64ToBytes(envelopeRecord.payload_b64);
+
+  let verified = false;
+  let keyIdUsed: string | null = null;
+  const sigField = envelopeRecord.sig;
+  if (sigField !== undefined && sigField !== null) {
+    // A PRESENT sig field must be a well-formed signature: an empty or non-string sig is a
+    // mangled/stripped copy, and failing this candidate lets a clean copy on the next front win.
+    // Only a genuinely ABSENT sig decodes as unsigned.
+    if (typeof sigField !== 'string' || sigField.length === 0) {
+      throw manifestFailure('malformed sig field');
+    }
+    const { keyId, signature } = parseSigField(sigField);
+    // The sig key_id is advisory routing only: try the matching pinned key first, then the rest.
+    const keys = pinnedSigningKeys();
+    const ordered = [
+      ...keys.filter(key => key.keyId === keyId),
+      ...keys.filter(key => key.keyId !== keyId),
+    ];
+    for (const key of ordered) {
+      try {
+        if (ed.verify(signature, payloadBytes, ed.etc.hexToBytes(key.publicKeyHex))) {
+          keyIdUsed = key.keyId;
+          break;
+        }
+      } catch {
+        // Malformed point/scalar encodings throw in @noble/ed25519; same as verify=false.
+      }
+    }
+    if (keyIdUsed === null) {
+      throw manifestFailure('signature does not verify against any pinned key');
+    }
+    verified = true;
+  }
+
+  // Parse the SAME buffer the signature covered.
+  let payload: unknown;
+  try {
+    payload = JSON.parse(decodeUtf8(payloadBytes));
+  } catch (error) {
+    throw error instanceof Error && error.message.startsWith('update manifest')
+      ? error
+      : manifestFailure('payload is not JSON');
+  }
+  if (typeof payload !== 'object' || payload === null || Array.isArray(payload)) {
+    throw manifestFailure('payload is not an object');
+  }
+  const record = payload as Record<string, unknown>;
+  if (record.schema !== 1) {
+    throw manifestFailure(`unsupported payload schema ${JSON.stringify(record.schema)}`);
+  }
+
+  const generatedAt =
+    typeof record.generated_at === 'string' ? Date.parse(record.generated_at) : Number.NaN;
+  return {
+    manifest: {
+      generatedAtMs: Number.isNaN(generatedAt) ? 0 : generatedAt,
+      android: decodePlatform(record.android),
+      ios: decodePlatform(record.ios),
+      promote: record.promote === 'notify' ? 'notify' : 'silent',
+      notice: decodeNotice(record.notice),
+    },
+    verified,
+    keyIdUsed,
+  };
+}
+
+// --- fetching ---------------------------------------------------------------------------------
+
+export interface FetchedUpdateManifest {
+  url: string;
+  /** The raw envelope body — persisted verbatim so hydration re-verifies the signature. */
+  raw: string;
+  decoded: DecodedUpdateManifest;
+}
+
+async function fetchAttempt(url: string): Promise<FetchedUpdateManifest> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        'X-OpenRung-App-Version': APP_VERSION,
+        'X-OpenRung-RN': Platform.OS,
+        // Same OkHttp-cache reasoning as the relay list: without this, the platform HTTP cache
+        // replays a stale manifest and a freshly published floor/notice never arrives.
+        'Cache-Control': 'no-cache, no-store',
+        Pragma: 'no-cache',
+      },
+      signal: controller.signal,
+    });
+    if (response.status < 200 || response.status > 299) {
+      throw manifestFailure(`HTTP ${response.status}`);
+    }
+    const raw = await response.text();
+    return { url, raw, decoded: decodeUpdateEnvelope(raw) };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Tries each candidate URL in order (10s per attempt) and returns the first VERIFIED envelope; an
+ * unsigned-but-decodable envelope is remembered as a fallback but the walk continues, so a front
+ * serving a sig-stripped copy cannot shadow the signed copy on a later front. Returns the
+ * unsigned fallback only when no candidate verifies, and null when every candidate fails. Never
+ * throws: this is a background check and MUST fail open — no update UI is always an acceptable
+ * outcome, a blocked or delayed app never is. Sequential (not the discovery stagger-race) because
+ * latency is irrelevant here and order keeps the censorship-resistant fronts preferred.
+ */
+export async function fetchUpdateManifest(
+  urls: readonly string[] = AppConfig.UPDATE_MANIFEST_URLS,
+): Promise<FetchedUpdateManifest | null> {
+  let unsignedFallback: FetchedUpdateManifest | null = null;
+  for (const url of urls) {
+    try {
+      const fetched = await fetchAttempt(url);
+      if (fetched.decoded.verified) {
+        return fetched;
+      }
+      unsignedFallback = unsignedFallback ?? fetched;
+    } catch {
+      // Failed candidate (network, HTTP status, tampered signature, bad envelope) — try the next.
+    }
+  }
+  return unsignedFallback;
+}

--- a/src/screens/MainScreen.tsx
+++ b/src/screens/MainScreen.tsx
@@ -22,7 +22,7 @@
  * through everywhere except the actual controls.
  */
 import React, { useCallback, useEffect, useRef } from 'react';
-import { Animated, StyleSheet, Text, View } from 'react-native';
+import { Animated, Linking, Platform, StyleSheet, Text, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { ConnectCard } from '../components/ConnectCard';
@@ -32,9 +32,13 @@ import { MapStatusChip } from '../components/MapStatusChip';
 import { OceanTelemetry } from '../components/OceanTelemetry';
 import { RecentsSection } from '../components/RecentsSection';
 import { RelayList } from '../components/RelayList';
+import { UpdateBanner } from '../components/UpdateBanner';
 import { ViewModeToggle } from '../components/ViewModeToggle';
-import { useStrings } from '../i18n';
+import { AppConfig } from '../config';
+import { resolveLanguage, useLanguage, useStrings } from '../i18n';
+import { pickLocalizedText } from '../model/updateStatus';
 import { hydrateHomeViewMode, refreshDirectory, setHomeViewMode } from '../state/store';
+import { dismissUpdateBanner, dismissUpdateNotice } from '../state/updateCheck';
 import { useVpnState } from '../state/useVpnState';
 import { monoFont, palette, tokens } from '../theme';
 
@@ -69,9 +73,12 @@ function Wordmark(): React.JSX.Element {
 
 export function MainScreen(): React.JSX.Element {
   const insets = useSafeAreaInsets();
+  const s = useStrings();
+  const { languageTag } = useLanguage();
   const { state, isConnected, isWorking, disconnect, prepareAndConnect } = useVpnState();
-  const { native, directoryStatus, availableRegions, homeViewMode, connectedAtMs } = state;
+  const { native, directoryStatus, availableRegions, homeViewMode, connectedAtMs, update } = state;
   const isListMode = homeViewMode === 'list';
+  const locale = resolveLanguage(languageTag);
 
   // Populate the exit-node map directory when the home screen is shown (no-op once loaded)
   // and restore the persisted map/list presentation.
@@ -117,6 +124,23 @@ export function MainScreen(): React.JSX.Element {
     refreshDirectory(true);
   }, []);
 
+  const onOpenUpdate = useCallback(() => {
+    // Pinned destination only — never a manifest-supplied URL (see AppConfig.UPDATE_URL_ANDROID).
+    const url = Platform.OS === 'ios' ? AppConfig.TESTFLIGHT_URL : AppConfig.UPDATE_URL_ANDROID;
+    Linking.openURL(url).catch(() => {
+      // Best-effort: ignore devices without a browser handler.
+    });
+  }, []);
+
+  const notice = update.notice;
+  const onOpenNoticeUrl = useCallback(() => {
+    if (notice?.url != null) {
+      Linking.openURL(notice.url).catch(() => {
+        // Best-effort.
+      });
+    }
+  }, [notice]);
+
   return (
     <View style={styles.root}>
       <View
@@ -159,6 +183,31 @@ export function MainScreen(): React.JSX.Element {
             style={styles.headerChip}
           />
         </View>
+
+        {update.tier === 'notify' && update.latestVersion != null ? (
+          <UpdateBanner
+            style={styles.updateBanner}
+            title={s.updateBannerTitle}
+            body={s.updateBannerBody(update.latestVersion)}
+            primaryLabel={s.updateActionNow}
+            onPrimary={onOpenUpdate}
+            dismissLabel={s.updateActionLater}
+            onDismiss={dismissUpdateBanner}
+          />
+        ) : notice != null ? (
+          // Broadcast notice (verified manifests only; one card at a time — the update banner
+          // outranks it, and the notice returns once the banner is dismissed or acted on).
+          <UpdateBanner
+            style={styles.updateBanner}
+            level={notice.level}
+            title={pickLocalizedText(notice.title, locale)}
+            body={pickLocalizedText(notice.body, locale)}
+            primaryLabel={notice.url != null ? s.noticeLearnMore : undefined}
+            onPrimary={notice.url != null ? onOpenNoticeUrl : undefined}
+            dismissLabel={s.noticeDismiss}
+            onDismiss={() => dismissUpdateNotice(notice.id)}
+          />
+        ) : null}
 
         <ViewModeToggle mode={homeViewMode} onChange={setHomeViewMode} style={styles.viewToggle} />
 
@@ -238,6 +287,9 @@ const styles = StyleSheet.create({
     fontFamily: monoFont,
     fontSize: 11,
     letterSpacing: 1.2,
+  },
+  updateBanner: {
+    marginTop: 14,
   },
   viewToggle: {
     marginTop: 14,

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -10,6 +10,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Alert,
+  Linking,
   Modal,
   Platform,
   Pressable,
@@ -22,7 +23,7 @@ import {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { SettingPanel } from '../components/SettingPanel';
-import { AppConfig } from '../config';
+import { APP_VERSION, AppConfig } from '../config';
 import { languageOptions, useLanguage, useStrings } from '../i18n';
 import {
   apkShareErrorCode,
@@ -53,7 +54,8 @@ const isTestFlightShareAvailable =
 export function SettingsScreen({ onOpenDebug }: SettingsScreenProps): React.JSX.Element {
   const s = useStrings();
   const insets = useSafeAreaInsets();
-  const { isConnected } = useVpnState();
+  const { state, isConnected } = useVpnState();
+  const { update } = state;
 
   const [speedTestRunning, setSpeedTestRunning] = useState(false);
   const [speedTestResult, setSpeedTestResult] = useState<SpeedTestResult | null>(null);
@@ -94,6 +96,14 @@ export function SettingsScreen({ onOpenDebug }: SettingsScreenProps): React.JSX.
       Alert.alert(s.shareApkErrorTitle, message);
     });
   }, [s]);
+
+  const onOpenUpdate = useCallback(() => {
+    // Pinned destination only — never a manifest-supplied URL (see AppConfig.UPDATE_URL_ANDROID).
+    const url = Platform.OS === 'ios' ? AppConfig.TESTFLIGHT_URL : AppConfig.UPDATE_URL_ANDROID;
+    Linking.openURL(url).catch(() => {
+      // Best-effort: ignore devices without a browser handler.
+    });
+  }, []);
 
   const onShareTestFlight = useCallback(() => {
     Share.share(
@@ -177,6 +187,15 @@ export function SettingsScreen({ onOpenDebug }: SettingsScreenProps): React.JSX.
       <Text style={styles.title}>{s.settingsTitle}</Text>
 
       <Text style={styles.sectionHeader}>{s.settingsGeneralHeader.toUpperCase()}</Text>
+      {update.tier !== 'none' && update.latestVersion != null ? (
+        // Passive update row: present at every tier above 'none' — for 'available' (routine
+        // releases, and the ceiling for unsigned manifests) it is the ONLY update UI.
+        <SettingPanel
+          title={s.updateSettingTitle}
+          subtitle={s.updateSettingSubtitle(APP_VERSION, update.latestVersion)}
+          onPress={onOpenUpdate}
+        />
+      ) : null}
       <SettingPanel
         title={s.languageSettingTitle}
         subtitle={s.languageSettingSubtitle}

--- a/src/screens/UpdateRequiredScreen.tsx
+++ b/src/screens/UpdateRequiredScreen.tsx
@@ -1,0 +1,131 @@
+import React, { useCallback } from 'react';
+import { Linking, Platform, Pressable, StyleSheet, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { APP_VERSION, AppConfig } from '../config';
+import { useStrings } from '../i18n';
+import { continueDespiteBlock } from '../state/updateCheck';
+import { useAppState } from '../state/store';
+import { monoFont, palette, tokens } from '../theme';
+
+/**
+ * Full-screen "Update required" gate, shown only when a VERIFIED manifest says this version is
+ * below the supported floor (see model/updateStatus.ts). The update destination is always the
+ * pinned AppConfig constant — never manifest-supplied. "Continue anyway" is the deliberate,
+ * session-scoped escape hatch per the availability-first design: a user pointing the app at
+ * their own broker may still work on an "unsupported" build, and informing beats bricking.
+ */
+export function UpdateRequiredScreen(): React.JSX.Element {
+  const s = useStrings();
+  const insets = useSafeAreaInsets();
+  const { update } = useAppState();
+
+  const onUpdate = useCallback(() => {
+    const url = Platform.OS === 'ios' ? AppConfig.TESTFLIGHT_URL : AppConfig.UPDATE_URL_ANDROID;
+    Linking.openURL(url).catch(() => {
+      // Best-effort: ignore devices without a browser handler.
+    });
+  }, []);
+
+  return (
+    <View
+      style={[
+        styles.root,
+        { paddingTop: insets.top + 24, paddingBottom: insets.bottom + 24 },
+      ]}
+    >
+      <View style={styles.body}>
+        <Text style={styles.title}>{s.updateRequiredTitle}</Text>
+        <Text style={styles.message}>{s.updateRequiredBody}</Text>
+        {update.latestVersion != null ? (
+          <Text style={styles.versions}>
+            {s.updateVersionTransition(APP_VERSION, update.latestVersion)}
+          </Text>
+        ) : null}
+      </View>
+      <View style={styles.footer}>
+        <Pressable
+          onPress={onUpdate}
+          style={({ pressed }) => [styles.updateButton, pressed && styles.pressed]}
+          accessibilityRole="button"
+        >
+          <Text style={styles.updateLabel}>{s.updateActionNow}</Text>
+        </Pressable>
+        <Pressable
+          onPress={continueDespiteBlock}
+          style={({ pressed }) => [styles.continueButton, pressed && styles.pressed]}
+          accessibilityRole="button"
+        >
+          <Text style={styles.continueLabel}>{s.updateContinueAnyway}</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: palette.screen,
+    paddingHorizontal: tokens.edge,
+  },
+  body: {
+    flex: 1,
+    justifyContent: 'center',
+    gap: 14,
+  },
+  title: {
+    color: palette.terminalGreen,
+    fontFamily: monoFont,
+    fontWeight: 'bold',
+    fontSize: 24,
+    letterSpacing: 0.5,
+    textShadowColor: tokens.glowSoft,
+    textShadowRadius: 12,
+  },
+  message: {
+    color: palette.bodyText,
+    fontFamily: monoFont,
+    fontSize: 14,
+    lineHeight: 21,
+  },
+  versions: {
+    color: palette.dimText,
+    fontFamily: monoFont,
+    fontSize: 13,
+  },
+  footer: {
+    gap: 10,
+  },
+  updateButton: {
+    height: 52,
+    borderRadius: 26,
+    backgroundColor: palette.terminalGreen,
+    alignItems: 'center',
+    justifyContent: 'center',
+    shadowColor: tokens.glow,
+    shadowOpacity: 1,
+    shadowRadius: 14,
+    shadowOffset: { width: 0, height: 0 },
+    elevation: 6,
+  },
+  updateLabel: {
+    color: palette.onGreenText,
+    fontFamily: monoFont,
+    fontWeight: 'bold',
+    fontSize: 15,
+    letterSpacing: 1,
+  },
+  continueButton: {
+    alignItems: 'center',
+    paddingVertical: 10,
+  },
+  continueLabel: {
+    color: palette.dimText,
+    fontFamily: monoFont,
+    fontSize: 13,
+  },
+  pressed: {
+    opacity: 0.85,
+  },
+});

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -2,6 +2,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useSyncExternalStore } from 'react';
 import { AppConfig } from '../config';
 import type { DirectoryStatus, ExitNodeRegion, HomeViewMode } from '../model/exitNode';
+import { INITIAL_UPDATE_UI, type UpdateUiState } from '../model/updateStatus';
 import { firstReachable } from '../net/brokerClient';
 import { loadExitNodeDirectory } from '../net/exitNodeDirectory';
 import type { NativeVpnState } from '../native/types';
@@ -26,6 +27,8 @@ export interface AppState {
    * uptime readout.
    */
   connectedAtMs: number | null;
+  /** In-app update check UI tier, derived and written by state/updateCheck.ts. */
+  update: UpdateUiState;
 }
 
 export const LANGUAGE_STORAGE_KEY = 'openrung.language';
@@ -48,6 +51,7 @@ function initialState(): AppState {
     languageTag: '',
     homeViewMode: 'map',
     connectedAtMs: null,
+    update: INITIAL_UPDATE_UI,
   };
 }
 
@@ -176,6 +180,11 @@ export async function hydrateHomeViewMode(): Promise<void> {
   } catch {
     // Best-effort: keep the in-memory default ('map').
   }
+}
+
+/** Mirrors the derived update-check UI state into the store (called by state/updateCheck.ts). */
+export function applyUpdateUiState(update: UpdateUiState): void {
+  setState({ ...state, update });
 }
 
 /** Test-only: resets the store to its initial state. */

--- a/src/state/updateCheck.ts
+++ b/src/state/updateCheck.ts
@@ -111,8 +111,11 @@ async function hydrate(): Promise<void> {
 /**
  * Replacement trust ladder — the fetched manifest replaces the cached one only when that never
  * DOWNGRADES trust or rolls history back:
- * - verified fetch: accepted unless the cache is verified AND newer (anti-replay monotonicity on
- *   the SIGNED generated_at; a replayed older signed manifest cannot roll back a raised floor).
+ * - verified fetch over verified cache: STRICTLY newer generated_at only. The publisher stamps
+ *   generated_at with the newest of ALL its inputs (latest-main commit time, latest release
+ *   published_at), so an equal stamp means an identical manifest — replacing would be a no-op —
+ *   and on any equal-but-different edge, first-writer-wins avoids cache flapping between fronts.
+ *   A replayed OLDER signed manifest can never roll back a raised floor.
  * - unsigned fetch: accepted only while the cache is absent or itself unsigned. Once any verified
  *   manifest has been seen, an unsigned body (e.g. a front stripping the sig) can never displace
  *   it. Unsigned-over-unsigned is last-write-wins: an unsigned generated_at proves nothing, and
@@ -123,7 +126,7 @@ function shouldReplaceCache(fetched: DecodedUpdateManifest): boolean {
     return true;
   }
   if (fetched.verified) {
-    return !(decoded.verified && fetched.manifest.generatedAtMs < decoded.manifest.generatedAtMs);
+    return !decoded.verified || fetched.manifest.generatedAtMs > decoded.manifest.generatedAtMs;
   }
   return !decoded.verified;
 }

--- a/src/state/updateCheck.ts
+++ b/src/state/updateCheck.ts
@@ -1,0 +1,258 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { AppState, Platform, type NativeEventSubscription } from 'react-native';
+
+import { APP_VERSION, AppConfig } from '../config';
+import { deriveUpdateUiState } from '../model/updateStatus';
+import {
+  decodeUpdateEnvelope,
+  fetchUpdateManifest,
+  type DecodedUpdateManifest,
+  type UpdatePlatformInfo,
+} from '../net/updateManifestClient';
+import { applyUpdateUiState } from './store';
+
+/**
+ * Update-check orchestration: hydrates the persisted manifest, refreshes it on cold start and on
+ * every return to foreground (throttled), and mirrors the derived UI tier into the store. The
+ * whole service is fail-open by construction — every network or storage failure leaves the app
+ * exactly as it was, and the check never gates startup or connect.
+ *
+ * The raw envelope is persisted VERBATIM and re-verified on every hydrate: AsyncStorage is not
+ * trusted storage, so "verified" is never a persisted bit — it is recomputed from the signature
+ * each launch against the currently pinned keys.
+ */
+
+export const UPDATE_MANIFEST_STORAGE_KEY = 'openrung.updateManifest';
+export const UPDATE_CHECKED_AT_STORAGE_KEY = 'openrung.updateManifestCheckedAt';
+export const UPDATE_DISMISSED_BANNER_STORAGE_KEY = 'openrung.updateDismissedBanner';
+export const UPDATE_DISMISSED_NOTICES_STORAGE_KEY = 'openrung.updateDismissedNotices';
+
+/** Dismissed-notice ids kept, newest last — bounds storage while far exceeding realistic use. */
+const MAX_DISMISSED_NOTICE_IDS = 20;
+
+let decoded: DecodedUpdateManifest | null = null;
+let lastSuccessAtMs = 0; // persisted (UPDATE_CHECKED_AT_STORAGE_KEY)
+let lastAttemptAtMs = 0; // in-memory: failed-attempt backoff resets each app session
+let dismissedBannerVersion: string | null = null;
+let dismissedNoticeIds: string[] = [];
+let blockOverridden = false; // session-scoped "Continue anyway"
+let fetchInFlight = false;
+let started = false;
+let appStateSubscription: NativeEventSubscription | null = null;
+
+function platformInfo(candidate: DecodedUpdateManifest | null): UpdatePlatformInfo | null {
+  if (candidate === null) {
+    return null;
+  }
+  return Platform.OS === 'ios'
+    ? candidate.manifest.ios
+    : Platform.OS === 'android'
+      ? candidate.manifest.android
+      : null;
+}
+
+function recompute(): void {
+  applyUpdateUiState(
+    deriveUpdateUiState({
+      decoded,
+      platform: Platform.OS,
+      currentVersion: APP_VERSION,
+      dismissedBannerVersion,
+      dismissedNoticeIds,
+      blockOverridden,
+      nowMs: Date.now(),
+    }),
+  );
+}
+
+async function hydrate(): Promise<void> {
+  try {
+    const [raw, checkedAt, banner, notices] = await Promise.all([
+      AsyncStorage.getItem(UPDATE_MANIFEST_STORAGE_KEY),
+      AsyncStorage.getItem(UPDATE_CHECKED_AT_STORAGE_KEY),
+      AsyncStorage.getItem(UPDATE_DISMISSED_BANNER_STORAGE_KEY),
+      AsyncStorage.getItem(UPDATE_DISMISSED_NOTICES_STORAGE_KEY),
+    ]);
+    // Never clobber a manifest a concurrently-completed refresh already installed: the fetched
+    // copy went through the shouldReplaceCache ladder, the persisted one would bypass it.
+    if (raw !== null && decoded === null) {
+      try {
+        decoded = decodeUpdateEnvelope(raw);
+      } catch {
+        // Cache no longer decodes/verifies (corruption, key rotation): drop it.
+        AsyncStorage.removeItem(UPDATE_MANIFEST_STORAGE_KEY).catch(() => {});
+      }
+    }
+    const checkedAtMs = checkedAt !== null ? Number(checkedAt) : Number.NaN;
+    if (Number.isFinite(checkedAtMs) && checkedAtMs > 0) {
+      // Clamp to now: a timestamp persisted under a fast-forwarded clock must not freeze the 6h
+      // throttle (and thereby all floor/notice delivery) until wall-clock catches up. Max with
+      // the in-memory value so hydration never rolls back a success recorded this session.
+      lastSuccessAtMs = Math.max(lastSuccessAtMs, Math.min(checkedAtMs, Date.now()));
+    }
+    if (banner !== null && banner.length > 0) {
+      dismissedBannerVersion = banner;
+    }
+    if (notices !== null) {
+      try {
+        const parsed: unknown = JSON.parse(notices);
+        if (Array.isArray(parsed) && parsed.every(id => typeof id === 'string')) {
+          dismissedNoticeIds = parsed;
+        }
+      } catch {
+        // Corrupt list: keep the empty default (worst case a dismissed notice reappears once).
+      }
+    }
+  } catch {
+    // Storage unavailable: run from in-memory defaults.
+  }
+}
+
+/**
+ * Replacement trust ladder — the fetched manifest replaces the cached one only when that never
+ * DOWNGRADES trust or rolls history back:
+ * - verified fetch: accepted unless the cache is verified AND newer (anti-replay monotonicity on
+ *   the SIGNED generated_at; a replayed older signed manifest cannot roll back a raised floor).
+ * - unsigned fetch: accepted only while the cache is absent or itself unsigned. Once any verified
+ *   manifest has been seen, an unsigned body (e.g. a front stripping the sig) can never displace
+ *   it. Unsigned-over-unsigned is last-write-wins: an unsigned generated_at proves nothing, and
+ *   its blast radius is capped at the passive tier anyway.
+ */
+function shouldReplaceCache(fetched: DecodedUpdateManifest): boolean {
+  if (decoded === null) {
+    return true;
+  }
+  if (fetched.verified) {
+    return !(decoded.verified && fetched.manifest.generatedAtMs < decoded.manifest.generatedAtMs);
+  }
+  return !decoded.verified;
+}
+
+/**
+ * Refreshes the manifest if due (6h after a success, 15min after a failed attempt; `force` skips
+ * both). Never throws, never blocks callers on the network.
+ */
+export async function refreshUpdateManifest(force: boolean = false): Promise<void> {
+  const now = Date.now();
+  if (fetchInFlight) {
+    return;
+  }
+  if (!force) {
+    // Negative deltas (a timestamp from a clock that has since been set back) count as due:
+    // one extra fetch self-heals the bogus stamp instead of freezing the cadence.
+    const sinceSuccess = now - lastSuccessAtMs;
+    if (lastSuccessAtMs > 0 && sinceSuccess >= 0 && sinceSuccess < AppConfig.UPDATE_CHECK_INTERVAL_MS) {
+      return;
+    }
+    const sinceAttempt = now - lastAttemptAtMs;
+    if (lastAttemptAtMs > 0 && sinceAttempt >= 0 && sinceAttempt < AppConfig.UPDATE_CHECK_RETRY_MS) {
+      return;
+    }
+  }
+  fetchInFlight = true;
+  lastAttemptAtMs = now;
+  try {
+    const fetched = await fetchUpdateManifest();
+    if (fetched === null) {
+      return; // all candidates failed — fail open, retry after UPDATE_CHECK_RETRY_MS
+    }
+    if (!fetched.decoded.verified && decoded !== null && decoded.verified) {
+      // Best copy anywhere was sig-stripped while we hold a verified manifest: treat it as a
+      // FAILED check (15-min retry cadence), not a success — otherwise a sig-stripping front
+      // could freeze floor/notice delivery behind the 6h success throttle.
+      return;
+    }
+    lastSuccessAtMs = Date.now();
+    AsyncStorage.setItem(UPDATE_CHECKED_AT_STORAGE_KEY, String(lastSuccessAtMs)).catch(() => {});
+    if (shouldReplaceCache(fetched.decoded)) {
+      decoded = fetched.decoded;
+      AsyncStorage.setItem(UPDATE_MANIFEST_STORAGE_KEY, fetched.raw).catch(() => {});
+      recompute();
+    }
+  } catch {
+    // fetchUpdateManifest never throws by contract; this is belt-and-braces fail-open.
+  } finally {
+    fetchInFlight = false;
+  }
+}
+
+/**
+ * Starts the update check (idempotent): hydrate persisted state, derive once, refresh if due, and
+ * re-check on every app foreground. Returns a cleanup for the mounting effect.
+ */
+export function startUpdateCheck(): () => void {
+  if (started) {
+    return () => {};
+  }
+  started = true;
+  (async () => {
+    await hydrate();
+    recompute();
+    // Foreground re-checks only start once hydration has seeded the throttle state — an early
+    // 'active' event must not bypass the persisted 6h throttle or race the cache hydration.
+    if (started) {
+      appStateSubscription = AppState.addEventListener('change', status => {
+        if (status === 'active') {
+          refreshUpdateManifest().catch(() => {});
+        }
+      });
+    }
+    await refreshUpdateManifest();
+  })().catch(() => {
+    // Every stage above is fail-open already; this guards the chain itself.
+  });
+  return () => {
+    appStateSubscription?.remove();
+    appStateSubscription = null;
+    started = false;
+  };
+}
+
+/** "Later" on the notify banner: never re-prompt for this latest version. */
+export function dismissUpdateBanner(): void {
+  const latest = platformInfo(decoded)?.latest;
+  if (latest == null) {
+    return;
+  }
+  dismissedBannerVersion = latest;
+  AsyncStorage.setItem(UPDATE_DISMISSED_BANNER_STORAGE_KEY, latest).catch(() => {
+    // Best-effort: worst case the banner shows again next launch.
+  });
+  recompute();
+}
+
+/** Dismisses a broadcast notice by id (re-broadcastable by changing the id server-side). */
+export function dismissUpdateNotice(id: string): void {
+  if (!dismissedNoticeIds.includes(id)) {
+    dismissedNoticeIds = [...dismissedNoticeIds.slice(-(MAX_DISMISSED_NOTICE_IDS - 1)), id];
+    AsyncStorage.setItem(
+      UPDATE_DISMISSED_NOTICES_STORAGE_KEY,
+      JSON.stringify(dismissedNoticeIds),
+    ).catch(() => {});
+  }
+  recompute();
+}
+
+/**
+ * "Continue anyway" on the blocking screen — session-scoped, deliberately not persisted: the
+ * availability-first escape hatch (a custom-broker user on an "unsupported" build may still work)
+ * without letting one tap silence a real kill-switch forever.
+ */
+export function continueDespiteBlock(): void {
+  blockOverridden = true;
+  recompute();
+}
+
+/** Test-only: clears all module state (mirror of resetStoreForTests). */
+export function resetUpdateCheckForTests(): void {
+  decoded = null;
+  lastSuccessAtMs = 0;
+  lastAttemptAtMs = 0;
+  dismissedBannerVersion = null;
+  dismissedNoticeIds = [];
+  blockOverridden = false;
+  fetchInFlight = false;
+  started = false;
+  appStateSubscription?.remove();
+  appStateSubscription = null;
+}

--- a/src/state/updateCheck.ts
+++ b/src/state/updateCheck.ts
@@ -152,14 +152,26 @@ export async function refreshUpdateManifest(force: boolean = false): Promise<voi
   fetchInFlight = true;
   lastAttemptAtMs = now;
   try {
-    const fetched = await fetchUpdateManifest();
+    const fetched = await fetchUpdateManifest(AppConfig.UPDATE_MANIFEST_URLS, {
+      // The cached verified generated_at is the freshness floor: the walk stops at the first
+      // front at least this fresh and keeps going past staler (replayed) signed copies.
+      atLeastGeneratedAtMs: decoded !== null && decoded.verified ? decoded.manifest.generatedAtMs : null,
+    });
     if (fetched === null) {
       return; // all candidates failed — fail open, retry after UPDATE_CHECK_RETRY_MS
     }
-    if (!fetched.decoded.verified && decoded !== null && decoded.verified) {
-      // Best copy anywhere was sig-stripped while we hold a verified manifest: treat it as a
-      // FAILED check (15-min retry cadence), not a success — otherwise a sig-stripping front
-      // could freeze floor/notice delivery behind the 6h success throttle.
+    const cached = decoded;
+    const trustDowngrade = cached !== null && cached.verified && !fetched.decoded.verified;
+    const staleReplay =
+      cached !== null &&
+      cached.verified &&
+      fetched.decoded.verified &&
+      fetched.decoded.manifest.generatedAtMs < cached.manifest.generatedAtMs;
+    if (trustDowngrade || staleReplay) {
+      // Best copy anywhere was sig-stripped, or every verified copy was OLDER than our cache
+      // (a replayed signed manifest): treat it as a FAILED check (15-min retry cadence), not a
+      // success — otherwise a bad front could freeze floor/notice delivery behind the 6h
+      // success throttle.
       return;
     }
     lastSuccessAtMs = Date.now();

--- a/src/state/updateCheck.ts
+++ b/src/state/updateCheck.ts
@@ -29,6 +29,8 @@ export const UPDATE_DISMISSED_NOTICES_STORAGE_KEY = 'openrung.updateDismissedNot
 
 /** Dismissed-notice ids kept, newest last — bounds storage while far exceeding realistic use. */
 const MAX_DISMISSED_NOTICE_IDS = 20;
+/** React Native timers use a signed 32-bit millisecond delay; longer waits are rescheduled. */
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
 
 let decoded: DecodedUpdateManifest | null = null;
 let lastSuccessAtMs = 0; // persisted (UPDATE_CHECKED_AT_STORAGE_KEY)
@@ -39,6 +41,7 @@ let blockOverridden = false; // session-scoped "Continue anyway"
 let fetchInFlight = false;
 let started = false;
 let appStateSubscription: NativeEventSubscription | null = null;
+let noticeExpiryTimer: ReturnType<typeof setTimeout> | null = null;
 
 function platformInfo(candidate: DecodedUpdateManifest | null): UpdatePlatformInfo | null {
   if (candidate === null) {
@@ -51,18 +54,37 @@ function platformInfo(candidate: DecodedUpdateManifest | null): UpdatePlatformIn
       : null;
 }
 
+function clearNoticeExpiryTimer(): void {
+  if (noticeExpiryTimer !== null) {
+    clearTimeout(noticeExpiryTimer);
+    noticeExpiryTimer = null;
+  }
+}
+
 function recompute(): void {
-  applyUpdateUiState(
-    deriveUpdateUiState({
-      decoded,
-      platform: Platform.OS,
-      currentVersion: APP_VERSION,
-      dismissedBannerVersion,
-      dismissedNoticeIds,
-      blockOverridden,
-      nowMs: Date.now(),
-    }),
-  );
+  clearNoticeExpiryTimer();
+  const nowMs = Date.now();
+  const update = deriveUpdateUiState({
+    decoded,
+    platform: Platform.OS,
+    currentVersion: APP_VERSION,
+    dismissedBannerVersion,
+    dismissedNoticeIds,
+    blockOverridden,
+    nowMs,
+  });
+  applyUpdateUiState(update);
+
+  const expiresMs = update.notice?.expiresMs;
+  if (expiresMs != null) {
+    // Hide the notice at expiry even while the app remains active. Very distant expiries are
+    // revisited in bounded chunks because native timer delays overflow past signed 32-bit ms.
+    const delayMs = Math.max(1, Math.min(expiresMs - nowMs, MAX_TIMER_DELAY_MS));
+    noticeExpiryTimer = setTimeout(() => {
+      noticeExpiryTimer = null;
+      recompute();
+    }, delayMs);
+  }
 }
 
 async function hydrate(): Promise<void> {
@@ -84,10 +106,12 @@ async function hydrate(): Promise<void> {
       }
     }
     const checkedAtMs = checkedAt !== null ? Number(checkedAt) : Number.NaN;
-    if (Number.isFinite(checkedAtMs) && checkedAtMs > 0) {
+    if (decoded !== null && Number.isFinite(checkedAtMs) && checkedAtMs > 0) {
       // Clamp to now: a timestamp persisted under a fast-forwarded clock must not freeze the 6h
-      // throttle (and thereby all floor/notice delivery) until wall-clock catches up. Max with
-      // the in-memory value so hydration never rolls back a success recorded this session.
+      // throttle (and thereby all floor/notice delivery) until wall-clock catches up. Only honor
+      // it alongside a usable envelope: the body and stamp are separate best-effort writes, so a
+      // missing/corrupt body must fetch immediately. Max with the in-memory value so hydration
+      // never rolls back a success recorded this session.
       lastSuccessAtMs = Math.max(lastSuccessAtMs, Math.min(checkedAtMs, Date.now()));
     }
     if (banner !== null && banner.length > 0) {
@@ -208,6 +232,9 @@ export function startUpdateCheck(): () => void {
     if (started) {
       appStateSubscription = AppState.addEventListener('change', status => {
         if (status === 'active') {
+          // Native timers may be suspended in the background; expire notices synchronously on
+          // foreground even when the network refresh is still inside its six-hour throttle.
+          recompute();
           refreshUpdateManifest().catch(() => {});
         }
       });
@@ -219,6 +246,7 @@ export function startUpdateCheck(): () => void {
   return () => {
     appStateSubscription?.remove();
     appStateSubscription = null;
+    clearNoticeExpiryTimer();
     started = false;
   };
 }
@@ -270,4 +298,5 @@ export function resetUpdateCheckForTests(): void {
   started = false;
   appStateSubscription?.remove();
   appStateSubscription = null;
+  clearNoticeExpiryTimer();
 }

--- a/testdata/update_manifest_vectors.json
+++ b/testdata/update_manifest_vectors.json
@@ -1,0 +1,24 @@
+{
+  "schema": 1,
+  "comment": "Update-manifest signing vectors. test_key seed is 32 bytes of 0x55 — TEST ONLY, never a production key. pinned_keys mirrors src/config.ts MANIFEST_SIGNING_KEYS; each entry carries a vector signature so CI can guard the pin without the offline seed. Checked by scripts/update-manifest.mjs check and __tests__/core/updateManifest.test.ts.",
+  "test_key": {
+    "seed_b64": "VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVU=",
+    "public_key_hex": "c6822637c7d310ec57627be00ba259d253749f4aaf644470cffbe53a35f73242",
+    "key_id": "b4c1ece898ece24e"
+  },
+  "vector": {
+    "payload_json": "{\"schema\":1,\"generated_at\":\"2026-07-22T00:00:00Z\",\"android\":{\"latest\":\"9.9.9\",\"latest_code\":999,\"min_supported\":\"0.2.0\"},\"ios\":{\"latest\":\"9.9.9\",\"min_supported\":\"0.2.0\"},\"promote\":\"notify\",\"notice\":{\"id\":\"vector-notice\",\"level\":\"info\",\"title\":{\"en\":\"Vector notice\",\"fa\":\"اعلان آزمایشی\"},\"body\":{\"en\":\"Test-only manifest vector.\"},\"url\":null,\"expires\":null}}",
+    "payload_b64": "eyJzY2hlbWEiOjEsImdlbmVyYXRlZF9hdCI6IjIwMjYtMDctMjJUMDA6MDA6MDBaIiwiYW5kcm9pZCI6eyJsYXRlc3QiOiI5LjkuOSIsImxhdGVzdF9jb2RlIjo5OTksIm1pbl9zdXBwb3J0ZWQiOiIwLjIuMCJ9LCJpb3MiOnsibGF0ZXN0IjoiOS45LjkiLCJtaW5fc3VwcG9ydGVkIjoiMC4yLjAifSwicHJvbW90ZSI6Im5vdGlmeSIsIm5vdGljZSI6eyJpZCI6InZlY3Rvci1ub3RpY2UiLCJsZXZlbCI6ImluZm8iLCJ0aXRsZSI6eyJlbiI6IlZlY3RvciBub3RpY2UiLCJmYSI6Itin2LnZhNin2YYg2KLYstmF2KfbjNi024wifSwiYm9keSI6eyJlbiI6IlRlc3Qtb25seSBtYW5pZmVzdCB2ZWN0b3IuIn0sInVybCI6bnVsbCwiZXhwaXJlcyI6bnVsbH19",
+    "sig": "ed25519;b4c1ece898ece24e;0EcgHAmyOQSQljKVh8Mttefut77rFvaCqx83S1WjmCwLEDa1khQJKVHtZ7OMkJpR3Ko6BJjsjzAcqag5ES8yCg==",
+    "envelope_json": "{\"schema\":1,\"payload_b64\":\"eyJzY2hlbWEiOjEsImdlbmVyYXRlZF9hdCI6IjIwMjYtMDctMjJUMDA6MDA6MDBaIiwiYW5kcm9pZCI6eyJsYXRlc3QiOiI5LjkuOSIsImxhdGVzdF9jb2RlIjo5OTksIm1pbl9zdXBwb3J0ZWQiOiIwLjIuMCJ9LCJpb3MiOnsibGF0ZXN0IjoiOS45LjkiLCJtaW5fc3VwcG9ydGVkIjoiMC4yLjAifSwicHJvbW90ZSI6Im5vdGlmeSIsIm5vdGljZSI6eyJpZCI6InZlY3Rvci1ub3RpY2UiLCJsZXZlbCI6ImluZm8iLCJ0aXRsZSI6eyJlbiI6IlZlY3RvciBub3RpY2UiLCJmYSI6Itin2LnZhNin2YYg2KLYstmF2KfbjNi024wifSwiYm9keSI6eyJlbiI6IlRlc3Qtb25seSBtYW5pZmVzdCB2ZWN0b3IuIn0sInVybCI6bnVsbCwiZXhwaXJlcyI6bnVsbH19\",\"sig\":\"ed25519;b4c1ece898ece24e;0EcgHAmyOQSQljKVh8Mttefut77rFvaCqx83S1WjmCwLEDa1khQJKVHtZ7OMkJpR3Ko6BJjsjzAcqag5ES8yCg==\"}"
+  },
+  "pinned_keys": [
+    {
+      "name": "active",
+      "public_key_hex": "3443068d4cb27dd474dee11155c365a44df6a24c560b8ae2cb019487b555bfc7",
+      "key_id": "a71d7615b7af163b",
+      "vector_message": "openrung-manifest-key-vector:active",
+      "vector_signature_b64": "IztpNj5fHTOsnjL3YMTH/4sBl7HqK6wxe9kFv32faN+HMbM030glmskUM40xpxuuL/pPKLPWBD+iw5hkZFCDDw=="
+    }
+  ]
+}


### PR DESCRIPTION
## Why

A past protocol break bricked old app versions with **no way to notify users to update**. This adds the standing channel that fixes that for every version from the next release on: one mechanism serving the update check, a supported-version kill switch, and freeform operator broadcasts.

## What changed

**Publishing** — CI generates and Ed25519-signs `update-manifest.json`:
- `release.yml`: fail-fast policy/seed validation before the ~30-min build, then generate + attach to the release + R2 mirror (`openrung-downloads/app/update-manifest.json`).
- New `update-manifest.yml`: editing `release/update-policy.json` on main republishes the manifest onto the *latest* release asset + R2 — broadcasts and floor raises need **no app release** and carry a git audit trail. Push-only triggers keep the seed secret away from fork PRs; only a genuine HTTP 404 (no release yet) skips, other `gh` failures fail the run.
- `scripts/update-manifest.mjs` (node:crypto only, no `npm ci` needed): `generate` / `check` / `keygen`. `version-check.yml` now runs `check` on every PR. Generate refuses to sign with a seed whose public key isn't pinned.

**Client** — fetch is silent, throttled (6h success / 15min failure, clock-skew-clamped), and fail-open by construction; it never gates startup or connect:
- `src/net/updateManifestClient.ts`: sequential candidate walk (broker fronts → CloudFront → GitHub latest asset) preferring the first **verified** envelope — a sig-stripped copy on one front can't shadow the signed copy on the next. Signature verified over exact payload bytes against a dedicated pinned key (deliberately separate from the relay keys); present-but-invalid sig fails the candidate; lenient additive-only payload decoding (forever-contract, schema 1).
- `src/model/updateStatus.ts` tier ladder: nothing → passive Settings row (`available`, also the ceiling for **unsigned** manifests) → one dismissible home banner per `promote:"notify"` release → full-screen "Update required" below `min_supported` (**verified only**, with a session-scoped "Continue anyway" per the availability-first design — self-hosted-broker users may still work).
- `src/state/updateCheck.ts`: hydrate-then-fetch orchestration, foreground re-checks (listener registered only after hydration to avoid throttle-bypass races), replay/rollback monotonicity on signed `generated_at`, unsigned never displaces a verified cache.
- Update buttons open **pinned constants** (`releases/latest` page / TestFlight link) — never manifest-supplied URLs. Notices: per-locale text with en fallback, dismissal keyed by id, optional expiry, https-only "Learn more" (verified manifests only).
- UI: `UpdateRequiredScreen`, `UpdateBanner` (home overlay), Settings row; 12 new strings translated in all 9 locales (coverage-test enforced).

**Docs**: `docs/UPDATE_MANIFEST.md` (envelope/payload contract, tier table, threat model, key rotation, server-side front-route spec), `release/README.md` (operator runbook), RELEASE.md §9.

## Review

A multi-agent adversarial review (6 dimensions, every finding independently verified) confirmed 10 defects; all are fixed and regression-tested — notably a hydrate/foreground race that could bypass the throttle and roll back a fresh manifest, a clock-skew cadence freeze, sig-strip suppression of verified copies, and CI validating the policy only after the full build.

Validation: 218 jest tests across 14 suites, `tsc --noEmit`, eslint, `update-manifest.mjs check`, and an end-to-end signed+unsigned generate → client-decode round trip.

## Reviewer notes / follow-ups

- **Action required before the manifest can prompt or block**: set the GitHub secret `OPENRUNG_MANIFEST_SIGNING_SEED_B64` (seed generated this session, key_id `a71d7615b7af163b`; pinned in `src/config.ts` + `testdata/update_manifest_vectors.json`). Without it, manifests ship unsigned → passive row only.
- Server-side (openrung repo, not blocking): serve the R2 object at `/api/v1/app-manifest` on both fronts; clients fall through to the GitHub asset until then.
- Honest limitation: versions ≤ 0.3.2 shipped without the checker and remain unreachable — this pays off starting with the next release.
- The manifest URLs + schema are a forever-contract with shipped clients (additive-only; see docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)