### PR TITLE
CI: announce published releases in the Telegram channels

### DIFF
--- a/.github/scripts/telegram_announce.py
+++ b/.github/scripts/telegram_announce.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""Announce a release in the OpenRung Telegram channels.
+
+CANONICAL COPY: openrung/openrung-telegram-bot (private), at
+deploy/github-actions/. Deployed copies live in the public release repos at
+.github/scripts/telegram_announce.py — keep all copies in sync.
+
+The script never invents copy. It posts exactly the per-language text an
+author wrote, because these channels serve people in Russia, Iran and China
+who are making risk decisions: machine-mangled Farsi or an over-promising
+claim costs trust that is very hard to win back. Announcement copy comes from
+one of two places, checked in this order:
+
+  1. An HTML comment block in the release body (hand-written release notes —
+     how the desktop repo publishes):
+
+         <!--telegram
+         [en]
+         🔄 <b>OpenRung Desktop 0.1.4</b>
+         • Something a user can feel
+         [ru]
+         ...
+         [fa]
+         ...
+         [zh]
+         ...
+         -->
+
+  2. A committed file, .github/telegram/<tag>.md, holding the same
+     [lang] sections without the surrounding comment (for repos whose release
+     notes are CI-generated, e.g. the mobile app: commit the copy in the
+     version-bump PR and it is present at the tag when the release fires).
+
+Text is sent with Telegram's HTML parse mode, so sections may use <b>, <i>,
+<code> and <a href>. Bare "&", "<" and ">" must be escaped as &amp; &lt; &gt;
+or Telegram rejects the message (a loud, visible CI failure — not a silent
+mangled post).
+
+Preamble directives may appear before the first [lang] section:
+
+    preview = on     # keep link previews (use when the preview IS the point,
+                     # e.g. an Apple TestFlight card); default is off
+
+To deliberately ship a release with no announcement (internal or hotfix
+builds), put <!--telegram:skip--> in the release body or commit
+.github/telegram/<tag>.skip. Silence must be explicit: with neither copy nor
+skip marker the job FAILS, which is what stops releases going out unannounced.
+
+Environment:
+    TELEGRAM_BOT_TOKEN  bot credential (required unless DRY_RUN=true)
+    RELEASE_TAG         e.g. v0.3.4                             (required)
+    RELEASE_BODY        release notes; may be empty             (optional)
+    DRY_RUN             "true" renders and validates, sends nothing
+    GITHUB_STEP_SUMMARY path for the run summary                (optional)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+
+# Public channel handles. Language -> channel.
+CHANNELS = {
+    "en": "@openrung_official",
+    "ru": "@openrung_ru",
+    "fa": "@openrung_fa",
+    "zh": "@openrung_zh",
+}
+
+API_BASE = os.environ.get("TELEGRAM_API_BASE", "https://api.telegram.org")
+
+BLOCK_RE = re.compile(r"<!--\s*telegram\s*\n(.*?)-->", re.S | re.I)
+SKIP_RE = re.compile(r"<!--\s*telegram:skip\s*-->", re.I)
+SECTION_RE = re.compile(r"^\[(en|ru|fa|zh)\][ \t]*$", re.I | re.M)
+PREVIEW_RE = re.compile(r"^\s*preview\s*=\s*(on|off)\s*$", re.I | re.M)
+
+TEMPLATE = """<!--telegram
+[en]
+\U0001F504 <b>OpenRung ... </b>
+• What changed, in terms a user can feel
+
+[ru]
+...
+
+[fa]
+...
+
+[zh]
+...
+-->"""
+
+
+class AnnounceError(RuntimeError):
+    """Fatal, actionable problem — reported and exits non-zero."""
+
+
+def log(msg: str) -> None:
+    print(msg, flush=True)
+
+
+def notice(msg: str) -> None:
+    log(f"::notice::{msg}")
+
+
+def warn(msg: str) -> None:
+    log(f"::warning::{msg}")
+
+
+def parse_sections(block: str) -> tuple[dict[str, str], bool]:
+    """Split a block into {lang: text} plus the link-preview setting."""
+    preamble = SECTION_RE.split(block, maxsplit=1)[0]
+    preview_match = PREVIEW_RE.search(preamble)
+    preview = bool(preview_match) and preview_match.group(1).lower() == "on"
+
+    parts = SECTION_RE.split(block)
+    # parts == [preamble, lang, body, lang, body, ...]
+    sections: dict[str, str] = {}
+    for lang, body in zip(parts[1::2], parts[2::2]):
+        lang = lang.lower()
+        body = body.strip()
+        if not body:
+            continue
+        if lang in sections:
+            raise AnnounceError(f"duplicate [{lang}] section in the announcement block")
+        sections[lang] = body
+    return sections, preview
+
+
+def load_copy(tag: str, body: str) -> tuple[dict[str, str], bool, str]:
+    """Find announcement copy in the release body, else in the committed file."""
+    match = BLOCK_RE.search(body)
+    if match:
+        sections, preview = parse_sections(match.group(1))
+        if sections:
+            return sections, preview, "release body"
+        raise AnnounceError(
+            "found a <!--telegram--> block in the release body but no [en]/[ru]/[fa]/[zh] sections"
+        )
+
+    path = os.path.join(".github", "telegram", f"{tag}.md")
+    if os.path.exists(path):
+        with open(path, encoding="utf-8") as fh:
+            sections, preview = parse_sections(fh.read())
+        if not sections:
+            raise AnnounceError(f"{path} contains no [en]/[ru]/[fa]/[zh] sections")
+        return sections, preview, path
+
+    raise AnnounceError(
+        f"no announcement copy for {tag}.\n"
+        f"Add a block to the release notes:\n\n{TEMPLATE}\n\n"
+        f"or commit {path} with the same [lang] sections (no comment wrapper).\n"
+        "Deliberately silent release? Put <!--telegram:skip--> in the release body "
+        f"or commit .github/telegram/{tag}.skip"
+    )
+
+
+def skip_requested(tag: str, body: str) -> bool:
+    return bool(SKIP_RE.search(body)) or os.path.exists(
+        os.path.join(".github", "telegram", f"{tag}.skip")
+    )
+
+
+def call(token: str, method: str, payload: dict) -> dict:
+    """POST one Bot API method, retrying once on 429.
+
+    Errors are scrubbed of the token: this runs in CI, where anything printed
+    is retained in logs that outlive the run.
+    """
+    req = urllib.request.Request(
+        f"{API_BASE}/bot{token}/{method}",
+        data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    for attempt in (1, 2):
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                result = json.load(resp)
+            if result.get("ok"):
+                return result["result"]
+            retry_after = (result.get("parameters") or {}).get("retry_after")
+            if retry_after and attempt == 1:
+                time.sleep(min(int(retry_after), 30))
+                continue
+            raise AnnounceError(
+                f"{method} rejected by Telegram: "
+                f"{result.get('error_code')} {result.get('description')}"
+            )
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", "replace")[:400]
+            if exc.code == 429 and attempt == 1:
+                time.sleep(5)
+                continue
+            raise AnnounceError(
+                f"{method} HTTP {exc.code}: {detail.replace(token, '<token>')}"
+            ) from None
+        except urllib.error.URLError as exc:
+            raise AnnounceError(
+                f"{method} network error: {str(exc.reason).replace(token, '<token>')}"
+            ) from None
+    raise AnnounceError(f"{method} failed after retry")
+
+
+def summarize(rows: list[str], tag: str, source: str, dry_run: bool) -> None:
+    path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not path:
+        return
+    head = "Dry run — nothing sent" if dry_run else "Posted"
+    with open(path, "a", encoding="utf-8") as fh:
+        fh.write(f"### Telegram announcement — {tag}\n\n")
+        fh.write(f"{head}. Copy source: `{source}`\n\n")
+        fh.write("| Language | Channel | Message |\n|---|---|---|\n")
+        fh.write("\n".join(rows) + "\n")
+
+
+def main() -> int:
+    tag = os.environ.get("RELEASE_TAG", "").strip()
+    if not tag:
+        raise AnnounceError("RELEASE_TAG is empty")
+    body = os.environ.get("RELEASE_BODY", "")
+    dry_run = os.environ.get("DRY_RUN", "").lower() == "true"
+
+    if skip_requested(tag, body):
+        notice(f"{tag}: announcement explicitly skipped — nothing posted.")
+        return 0
+
+    sections, preview, source = load_copy(tag, body)
+    notice(f"{tag}: announcement copy from {source} ({', '.join(sorted(sections))}).")
+
+    missing = [lang for lang in CHANNELS if lang not in sections]
+    if missing:
+        # Posting some languages beats posting none, but a channel silently
+        # missing its release note is worth shouting about.
+        warn(
+            f"{tag}: no copy for {', '.join(missing)} — "
+            f"{', '.join(CHANNELS[m] for m in missing)} will not be posted."
+        )
+
+    token = os.environ.get("TELEGRAM_BOT_TOKEN", "")
+    if not token and not dry_run:
+        raise AnnounceError("TELEGRAM_BOT_TOKEN is empty (set the repo secret)")
+
+    rows: list[str] = []
+    for lang, channel in CHANNELS.items():
+        text = sections.get(lang)
+        if not text:
+            continue
+        if dry_run:
+            log(f"\n--- {channel} ({lang}) ---\n{text}\n")
+            rows.append(f"| {lang} | {channel} | _dry run_ |")
+            continue
+        payload = {
+            "chat_id": channel,
+            "text": text,
+            "parse_mode": "HTML",
+            "link_preview_options": {"is_disabled": not preview},
+        }
+        msg = call(token, "sendMessage", payload)
+        link = f"https://t.me/{channel.lstrip('@')}/{msg['message_id']}"
+        log(f"{channel}: posted -> {link}")
+        rows.append(f"| {lang} | {channel} | [{msg['message_id']}]({link}) |")
+        time.sleep(0.5)  # be gentle; nowhere near Telegram's limits
+
+    summarize(rows, tag, source, dry_run)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except AnnounceError as err:
+        log(f"::error::{err}")
+        sys.exit(1)

--- a/.github/telegram/README.md
+++ b/.github/telegram/README.md
@@ -1,0 +1,49 @@
+# Telegram release announcements
+
+Copy for the four OpenRung Telegram channels (`@openrung_official`,
+`@openrung_ru`, `@openrung_fa`, `@openrung_zh`), posted by
+[`telegram-announce.yml`](../workflows/telegram-announce.yml) when a release is
+published.
+
+**In this repo, put the copy in `<tag>.md` here** — releases are published by
+CI with `generate_release_notes: true`, so there is no hand-written release
+body to hold it. Commit the file in the same version-bump PR that triggers the
+release (`v` prefix included, matching the tag):
+
+`.github/telegram/v0.3.5.md`
+
+```
+[en]
+🔄 <b>OpenRung for Android — update 0.3.5</b>
+• What changed, in terms a user can feel
+
+[ru]
+…
+[fa]
+…
+[zh]
+…
+```
+
+A `<!--telegram ... -->` block in the release body also works and takes
+precedence — useful when announcing after the fact: add the block with
+`gh release edit`, then run the workflow manually from the Actions tab
+(untick *dry run*).
+
+Text is sent with Telegram's HTML parse mode: `<b>`, `<i>`, `<code>` and
+`<a href>` work; bare `&`, `<` and `>` must be escaped or Telegram rejects the
+message and the job fails. Put `preview = on` above the first section to keep
+link previews (useful when the preview itself is the point, like an Apple
+TestFlight card).
+
+No announcement for a release? Say so explicitly with an empty `<tag>.skip`
+file here (or `<!--telegram:skip-->` in the release body) — otherwise the job
+fails, which is what stops releases shipping unannounced.
+
+Translations are written by hand, never machine-generated: these channels reach
+people making risk decisions about censorship circumvention, and mangled Farsi
+or an over-promising claim costs trust that is hard to win back. Write the
+English, then ask for the RU/FA/ZH versions.
+
+Because the app is sideloaded and does not auto-update, release posts usually
+end with a reminder that installing the new APK over the old one is enough.

--- a/.github/workflows/telegram-announce.yml
+++ b/.github/workflows/telegram-announce.yml
@@ -1,0 +1,91 @@
+name: telegram-announce
+
+# Announce a published release in the four OpenRung Telegram channels
+# (@openrung_official, @openrung_ru, @openrung_fa, @openrung_zh).
+#
+# CANONICAL COPY: openrung/openrung-telegram-bot (private),
+# deploy/github-actions/. Copies live in each public release repo at
+# .github/workflows/telegram-announce.yml — keep them in sync.
+#
+# Why it exists: Telegram is the distribution channel that keeps working when
+# openrung.org is blocked, so users in Russia, Iran and China learn about new
+# builds there. Announcing by hand meant several releases shipped unannounced.
+# This job cannot invent copy (translations are written by a human), but it
+# CAN refuse to let a release pass silently: with no announcement copy and no
+# explicit skip marker, it fails and GitHub emails the maintainer.
+#
+# Where the copy comes from, and the <!--telegram:skip--> escape hatch, are
+# documented at the top of .github/scripts/telegram_announce.py.
+#
+# Security: triggers only on `release: published` and manual `workflow_dispatch`
+# — never on `pull_request`, so a fork PR can never reach the bot token. Keep
+# it that way. The release body is untrusted text (anyone with write access
+# edits it), so it is passed to the script through the environment, never
+# interpolated into a shell command.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to announce (e.g. v0.3.4)'
+        required: true
+        type: string
+      dry_run:
+        description: 'Render and validate without sending'
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  # One announcement at a time per tag; never cancel a run that may be
+  # mid-post, or a channel could end up half-announced.
+  group: telegram-announce-${{ github.event.release.tag_name || inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  announce:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # Release runs check out the tag, so a .github/telegram/<tag>.md committed
+      # in the version-bump PR is present. Manual runs check out the branch they
+      # were dispatched from, so copy added after the fact is picked up.
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref_name }}
+
+      - name: Resolve release notes
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT: ${{ github.event_name }}
+          TAG_INPUT: ${{ inputs.tag }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_BODY: ${{ github.event.release.body }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" = "release" ]; then
+            tag="$RELEASE_TAG"
+            printf '%s' "$RELEASE_BODY" > /tmp/release-body.md
+          else
+            tag="$TAG_INPUT"
+            gh release view "$tag" --repo "$GITHUB_REPOSITORY" --json body -q .body > /tmp/release-body.md
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "::notice::Announcing $tag ($(wc -c < /tmp/release-body.md) bytes of release notes)."
+
+      - name: Post to Telegram channels
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          # `true` on manual runs unless explicitly unticked; automatic
+          # release runs always send.
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          RELEASE_BODY="$(cat /tmp/release-body.md)" \
+            python3 .github/scripts/telegram_announce.py


### PR DESCRIPTION
## Summary

Automates the manual step behind the last five release announcements — posting release notes to `@openrung_official`, `@openrung_ru`, `@openrung_fa` and `@openrung_zh`. Companion PR in the core repo: openrung/openrung#101 (same workflow and script; canonical copy lives in the private bot repo).

The workflow deliberately does **not** generate or translate copy — those channels reach people making risk decisions about censorship circumvention, so translations stay hand-written. What it guarantees is that a release cannot ship silently: with no copy and no explicit skip marker, the job fails and GitHub emails the maintainer. (Between 0.2.9 and 0.3.4, some releases went out with no announcement at all.)

## How copy is supplied here

Releases in this repo are published by CI with `generate_release_notes: true`, so there is no hand-written body to hold the copy. Commit it in the version-bump PR instead:

`.github/telegram/v0.3.5.md`

```
[en]
🔄 <b>OpenRung for Android — update 0.3.5</b>
• What changed, in terms a user can feel
[ru]
…
[fa]
…
[zh]
…
```

It is present at the tag when the release fires, so the announcement goes out automatically. A `<!--telegram ... -->` block in the release body also works and takes precedence — that is the after-the-fact path: `gh release edit`, then run the workflow manually with *dry run* unticked.

## Safety

- Triggers on `release: published` and `workflow_dispatch` only — never `pull_request`, so fork PRs cannot reach `secrets.TELEGRAM_BOT_TOKEN`.
- The release body is untrusted input and is passed via environment, never interpolated into a shell command.
- Manual runs default to `dry_run: true`; automatic release runs send.
- Errors are scrubbed of the bot token before printing, since CI logs outlive the run.
- `permissions: contents: read`.

## Verification

Script exercised locally against fixtures: full four-language block, missing copy (fails with an actionable template), explicit skip, file fallback with only two languages (posts those, warns about the silent channels), and `preview = on`. Live Telegram API exercised with malformed HTML: rejected with a scrubbed `400`, nothing posted.

Post-merge I will run a `workflow_dispatch` dry run to confirm CI wiring, since `workflow_dispatch` only becomes available once the workflow is on the default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)