### PR TITLE
fix(android): bound punch_failed.reason to the shared failure taxonomy

### DIFF
--- a/android/app/src/main/java/com/openrung/net/PunchNativeFailureReason.kt
+++ b/android/app/src/main/java/com/openrung/net/PunchNativeFailureReason.kt
@@ -1,0 +1,49 @@
+package com.openrung.net
+
+/**
+ * Closed taxonomy for establishment failures returned by the Go binding. Never forward the
+ * binding's raw reason to telemetry: declined messages and future native values are unbounded.
+ * Mirrors iOS `PunchNativeFailureReason` so `punch_failed.reason` stays identical across platforms.
+ */
+enum class PunchNativeFailureReason(val wireValue: String) {
+    CLIENT("client"),
+    CONFIGURATION("config"),
+    SOCKET("socket"),
+    SOCKET_PROTECTION("protect"),
+    NONCE("nonce"),
+    DISCOVERY("discovery"),
+    REQUEST("request"),
+    DECLINED("declined"),
+    SESSION("session"),
+    TOKEN("token"),
+    CERTIFICATE("certificate"),
+    PUNCH("punch"),
+    QUIC("quic"),
+    BRIDGE("bridge"),
+    TRANSPORT("transport"),
+    CANCELLED("cancelled");
+
+    companion object {
+        fun fromNative(nativeReason: String): PunchNativeFailureReason {
+            val normalized = nativeReason.trim().lowercase()
+            if (normalized.startsWith("declined:")) return DECLINED
+            return when (normalized) {
+                "client" -> CLIENT
+                "config" -> CONFIGURATION
+                "socket" -> SOCKET
+                "protect" -> SOCKET_PROTECTION
+                "nonce" -> NONCE
+                "discovery" -> DISCOVERY
+                "request" -> REQUEST
+                "session" -> SESSION
+                "token" -> TOKEN
+                "certificate" -> CERTIFICATE
+                "punch" -> PUNCH
+                "quic" -> QUIC
+                "bridge", "adapter" -> BRIDGE
+                "cancelled" -> CANCELLED
+                else -> TRANSPORT
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/openrung/vpn/OpenRungVpnService.kt
+++ b/android/app/src/main/java/com/openrung/vpn/OpenRungVpnService.kt
@@ -30,6 +30,7 @@ import com.openrung.net.NatPunchResult
 import com.openrung.net.NatPunchSession
 import com.openrung.net.NativeWssFrontSetValidator
 import com.openrung.net.PhysicalNetworkEpochMonitor
+import com.openrung.net.PunchNativeFailureReason
 import com.openrung.net.RelayRanker
 import com.openrung.net.RelayReachability
 import com.openrung.net.SingBoxConfiguration
@@ -734,7 +735,9 @@ class OpenRungVpnService : VpnService() {
 
         if (!result.succeeded) {
             closePunchSession(session)
-            val reason = result.reason.ifBlank { "unknown" }
+            // Bounded taxonomy only: punchcore can emit unbounded `declined:<message>` reasons.
+            // The raw text survives solely in the truncated failure_detail attribute.
+            val reason = PunchNativeFailureReason.fromNative(result.reason).wireValue
             recordPunchFailure(relay, reason, result.natClass, result.errorText)
             OpenRungStatusStore.appendLog(getString(R.string.log_punch_failed, reason))
             return null
@@ -769,7 +772,7 @@ class OpenRungVpnService : VpnService() {
             relayId = relay.id,
             attributes = buildMap {
                 put("reason", reason)
-                if (natClass.isNotBlank()) put("nat_class", natClass)
+                if (natClass.isNotBlank()) put("nat_class", natClass.take(64))
                 if (detail.isNotBlank()) put("failure_detail", detail.take(256))
             },
         )

--- a/android/app/src/test/java/com/openrung/net/PunchNativeFailureReasonTest.kt
+++ b/android/app/src/test/java/com/openrung/net/PunchNativeFailureReasonTest.kt
@@ -1,0 +1,58 @@
+package com.openrung.net
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+/** Mirrors iOS `testNativeFailureReasonsMapToABoundedTaxonomy` in PunchNativeClientTests. */
+class PunchNativeFailureReasonTest {
+    @Test
+    fun `native failure reasons map to a bounded taxonomy`() {
+        assertEquals(
+            PunchNativeFailureReason.CONFIGURATION,
+            PunchNativeFailureReason.fromNative("config"),
+        )
+        assertEquals(
+            PunchNativeFailureReason.SOCKET_PROTECTION,
+            PunchNativeFailureReason.fromNative("protect"),
+        )
+        assertEquals(
+            PunchNativeFailureReason.DECLINED,
+            PunchNativeFailureReason.fromNative("declined:relay busy"),
+        )
+        assertEquals(
+            PunchNativeFailureReason.TRANSPORT,
+            PunchNativeFailureReason.fromNative("new-server-value"),
+        )
+        assertEquals(
+            PunchNativeFailureReason.BRIDGE,
+            PunchNativeFailureReason.fromNative("adapter"),
+        )
+        assertEquals(
+            PunchNativeFailureReason.CANCELLED,
+            PunchNativeFailureReason.fromNative(" Cancelled\n"),
+        )
+        assertEquals(
+            PunchNativeFailureReason.TRANSPORT,
+            PunchNativeFailureReason.fromNative(""),
+        )
+
+        // Distinct declined payloads collapse to one wire value and never leak into telemetry.
+        val first = PunchNativeFailureReason.fromNative("declined:secret-a")
+        val second = PunchNativeFailureReason.fromNative("declined:secret-b")
+        assertEquals("declined", first.wireValue)
+        assertEquals("declined", second.wireValue)
+        assertEquals(first, second)
+        assertFalse(first.wireValue.contains("secret"))
+
+        // The wire vocabulary is the closed set shared with iOS's PunchNativeFailureReason.
+        assertEquals(
+            setOf(
+                "client", "config", "socket", "protect", "nonce", "discovery", "request",
+                "declined", "session", "token", "certificate", "punch", "quic", "bridge",
+                "transport", "cancelled",
+            ),
+            PunchNativeFailureReason.entries.map { it.wireValue }.toSet(),
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Android forwarded the raw native NAT-punch failure reason into telemetry (`OpenRungVpnService.attemptDirectPunch`), so punchcore's unbounded `declined:<message>` strings became high-cardinality `punch_failed.reason` attributes.
- Ports iOS's closed `PunchNativeFailureReason` taxonomy (introduced in PR #67) to Kotlin: `declined:` payloads collapse to a single `declined` value, `adapter` aliases to `bridge`, and any unknown/blank native value maps to `transport`. The raw text survives only in the truncated (256-char) `failure_detail` attribute.
- Also bounds `nat_class` to 64 chars in `recordPunchFailure`, matching the iOS counterpart.

Parity notes: a blank native reason now records as `transport` instead of the old `unknown`, and a bare `declined` (no colon) also maps to `transport` — both exactly match the iOS mapping.

## Testing
- New `PunchNativeFailureReasonTest` mirrors iOS's `testNativeFailureReasonsMapToABoundedTaxonomy` (prefix collapse, no payload leakage, unknown fallback, closed wire-value set shared with iOS).
- Full Android unit suite green: 27 suites, 0 failures (`:app:testDebugUnitTest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)