### PR TITLE
Performance pass: event storms, main-thread VPN work, telemetry outbox, probe backoff, R8

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -31,7 +31,7 @@ import { MainScreen } from './src/screens/MainScreen';
 import { SettingsScreen } from './src/screens/SettingsScreen';
 import { SplitTunnelingScreen } from './src/screens/SplitTunnelingScreen';
 import { UpdateRequiredScreen } from './src/screens/UpdateRequiredScreen';
-import { hydrateSplitTunnel, useAppState } from './src/state/store';
+import { hydrateSplitTunnel, useAppSelector } from './src/state/store';
 import { startUpdateCheck } from './src/state/updateCheck';
 import { palette } from './src/theme';
 
@@ -65,7 +65,9 @@ function App(): React.JSX.Element {
 function AppRoutes(): React.JSX.Element {
   const [tab, setTab] = useState<AppTab>('home');
   const [subRoute, setSubRoute] = useState<SubRoute>(null);
-  const { update } = useAppState();
+  // Selector, not the whole store: AppRoutes sits above every screen, so re-rendering it on
+  // each native event (log lines during connect) would cascade through the entire tree.
+  const update = useAppSelector(current => current.update);
 
   const goBack = useCallback((): boolean => {
     if (subRoute === 'LICENSE_TEXT') {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -56,9 +56,10 @@ react {
 }
 
 /**
- * Set this to true to Run Proguard on Release builds to minify the Java bytecode.
+ * R8 shrinking/optimization for release builds. Keep rules for the reflective surfaces
+ * (libbox JNI bindings, kotlinx.serialization models) live in proguard-rules.pro.
  */
-def enableProguardInReleaseBuilds = false
+def enableProguardInReleaseBuilds = true
 
 /**
  * The preferred build flavor of JavaScriptCore (JSC)
@@ -134,6 +135,7 @@ android {
                 signingConfig signingConfigs.debug
             }
             minifyEnabled enableProguardInReleaseBuilds
+            shrinkResources enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
             // App-size trim: the RELEASE APK ships arm64-v8a ONLY (see the androidComponents
             // block after android { } and RELEASE.md §4). Broker telemetry showed ~0

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,10 +1,21 @@
-# Add project specific ProGuard rules here.
-# By default, the flags in this file are appended to flags specified
-# in /usr/local/Cellar/android-sdk/24.3.3/tools/proguard/proguard-android.txt
-# You can edit the include path and order by changing the proguardFiles
-# directive in build.gradle.
-#
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
+# OpenRung release keep rules. React Native and most third-party libraries ship their own
+# consumer rules; this file covers only the surfaces R8 cannot see into.
 
-# Add any project specific keep options here:
+# libbox (gomobile bindings): the Go runtime resolves these classes and their members through
+# JNI by name — Seq/proxy classes, PlatformInterface callbacks, punch/broker/WSS bindings.
+# Shrinking or renaming any of them breaks the tunnel engine at runtime.
+-keep class io.nekohasekai.libbox.** { *; }
+-keep class go.** { *; }
+
+# kotlinx.serialization: generated serializers are looked up reflectively via the Companion.
+# (The runtime artifact ships consumer rules; these pin this app's @Serializable models
+# explicitly so an R8 version change can never silently strip them.)
+-keepattributes *Annotation*, InnerClasses
+-dontnote kotlinx.serialization.AnnotationsKt
+-keep,includedescriptorclasses class com.openrung.**$$serializer { *; }
+-keepclassmembers class com.openrung.** {
+    *** Companion;
+}
+-keepclasseswithmembers class com.openrung.** {
+    kotlinx.serialization.KSerializer serializer(...);
+}

--- a/android/app/src/main/java/com/openrung/bridge/OpenRungVpnModule.kt
+++ b/android/app/src/main/java/com/openrung/bridge/OpenRungVpnModule.kt
@@ -25,8 +25,10 @@ import com.openrung.vpn.OpenRungVpnService
 import com.openrung.vpn.SplitTunnelStore
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 /**
@@ -46,7 +48,32 @@ class OpenRungVpnModule(
         OpenRungStatusStore.initialize(reactContext.applicationContext)
         TelemetryManager.initialize(reactContext.applicationContext)
         moduleScope.launch {
-            OpenRungStatusStore.uiState.collect { state -> emitStateChanged(state) }
+            // Log-append storms (relay ladder, recovery) coalesce into one trailing emit per
+            // window; every payload is the full latest snapshot, so nothing is lost. Any change
+            // beyond logLines (status, relay, error, recents) still emits immediately.
+            var lastEmitted: OpenRungUiState? = null
+            var pendingLogEmit: Job? = null
+            OpenRungStatusStore.uiState.collect { state ->
+                val previous = lastEmitted
+                if (state == previous) return@collect
+                val logLinesOnlyChange =
+                    previous != null && state.copy(logLines = previous.logLines) == previous
+                if (logLinesOnlyChange) {
+                    if (pendingLogEmit?.isActive != true) {
+                        pendingLogEmit = launch {
+                            delay(LOG_EMIT_COALESCE_MS)
+                            val latest = OpenRungStatusStore.uiState.value
+                            lastEmitted = latest
+                            emitStateChanged(latest)
+                        }
+                    }
+                } else {
+                    pendingLogEmit?.cancel()
+                    pendingLogEmit = null
+                    lastEmitted = state
+                    emitStateChanged(state)
+                }
+            }
         }
     }
 
@@ -217,5 +244,6 @@ class OpenRungVpnModule(
         private const val EVENT_STATE_CHANGED = "openrungStateChanged"
         private const val VPN_REQUEST_CODE = 7001
         private const val NOTIFICATION_REQUEST_CODE = 7002
+        private const val LOG_EMIT_COALESCE_MS = 250L
     }
 }

--- a/android/app/src/main/java/com/openrung/net/SingBoxConfiguration.kt
+++ b/android/app/src/main/java/com/openrung/net/SingBoxConfiguration.kt
@@ -1,5 +1,6 @@
 package com.openrung.net
 
+import com.openrung.BuildConfig
 import com.openrung.model.RelayConstants
 import com.openrung.model.RelayDescriptor
 import kotlinx.serialization.encodeToString
@@ -96,7 +97,9 @@ data class SingBoxConfiguration(
 
         return buildJsonObject {
             put("log", buildJsonObject {
-                put("level", "info")
+                // "info" logs every flow and DNS query inside the Go engine; release builds
+                // keep only warnings to stay off the per-connection hot path.
+                put("level", if (BuildConfig.DEBUG) "info" else "warn")
                 put("timestamp", true)
             })
             put("dns", buildJsonObject {

--- a/android/app/src/main/java/com/openrung/telemetry/TelemetryManager.kt
+++ b/android/app/src/main/java/com/openrung/telemetry/TelemetryManager.kt
@@ -182,6 +182,13 @@ object TelemetryManager {
 
     private fun trafficCounters(): TrafficCounters? = synchronized(lock) { sessionTraffic }
 
+    /**
+     * Cumulative session counters as last pushed by the engine (null before the first push).
+     * The tunnel health monitor compares successive values to skip probing while traffic is
+     * demonstrably flowing.
+     */
+    fun currentTrafficCounters(): TrafficCounters? = trafficCounters()
+
     fun markConnected(relayId: String) {
         synchronized(lock) {
             activeSession = activeSession?.copy(

--- a/android/app/src/main/java/com/openrung/telemetry/TelemetryManager.kt
+++ b/android/app/src/main/java/com/openrung/telemetry/TelemetryManager.kt
@@ -49,6 +49,15 @@ object TelemetryManager {
      */
     private var outboxCache: MutableList<TelemetryEvent>? = null
     private var outboxFileLines = 0
+
+    /**
+     * True while a legacy SharedPreferences outbox has been read into the cache but not yet
+     * durably written to the NDJSON file. Until the migration lands (an atomic-rename rewrite),
+     * the legacy key stays in place and appends retry the full rewrite — appending alone would
+     * create a file WITHOUT the backlog, and the file's existence is what marks the migration
+     * complete on the next launch.
+     */
+    private var legacyMigrationPending = false
     private val appConnections = ApplicationConnectionAggregator(
         windowMs = APP_CONNECTION_WINDOW_MS,
         elapsedMs = SystemClock::elapsedRealtime,
@@ -88,6 +97,7 @@ object TelemetryManager {
                 // cache — its file lives under the new instance's filesDir.
                 outboxCache = null
                 outboxFileLines = 0
+                legacyMigrationPending = false
                 cachedNetworkAttributes = null
             }
             this.context = next
@@ -352,6 +362,12 @@ object TelemetryManager {
         val sanitized = events.map(::sanitizeTelemetryEvent)
         cache.addAll(sanitized)
         while (cache.size > MAX_QUEUED_EVENTS) cache.removeAt(0)
+        if (legacyMigrationPending) {
+            // See [legacyMigrationPending]: the backlog must land as one durable rewrite before
+            // plain appends may touch the file.
+            rewriteOutboxLocked(context, cache)
+            return
+        }
         val appended = runCatching {
             outboxFile(context).appendText(
                 sanitized.joinToString(separator = "") { json.encodeToString(it) + "\n" },
@@ -393,21 +409,27 @@ object TelemetryManager {
     private fun loadOutboxLocked(context: Context): MutableList<TelemetryEvent> {
         outboxCache?.let { return it }
         val file = outboxFile(context)
-        val legacy = readLegacyOutboxLocked(context)
-        var needsRewrite = legacy != null
-        val parsed = legacy
-            ?: if (file.isFile) {
-                val lines = runCatching {
-                    file.useLines { sequence -> sequence.filter { it.isNotBlank() }.toList() }
-                }.getOrDefault(emptyList())
-                val decoded = lines.mapNotNull { line ->
-                    runCatching { json.decodeFromString<TelemetryEvent>(line) }.getOrNull()
-                }
-                needsRewrite = decoded.size != lines.size
-                decoded
-            } else {
-                emptyList()
+        var needsRewrite: Boolean
+        val parsed: List<TelemetryEvent>
+        if (file.isFile) {
+            // The file is authoritative once it exists (rewrites land via atomic rename). A
+            // legacy key still present next to it is a completed migration whose key removal
+            // didn't land — stale, so drop it without another read.
+            clearLegacyOutboxLocked(context)
+            val lines = runCatching {
+                file.useLines { sequence -> sequence.filter { it.isNotBlank() }.toList() }
+            }.getOrDefault(emptyList())
+            val decoded = lines.mapNotNull { line ->
+                runCatching { json.decodeFromString<TelemetryEvent>(line) }.getOrNull()
             }
+            needsRewrite = decoded.size != lines.size
+            parsed = decoded
+        } else {
+            val legacy = readLegacyOutboxLocked(context)
+            legacyMigrationPending = legacy != null
+            needsRewrite = legacy != null
+            parsed = legacy.orEmpty()
+        }
         val events = parsed.map(::sanitizeTelemetryEvent)
             .takeLast(MAX_QUEUED_EVENTS)
             .toMutableList()
@@ -420,26 +442,39 @@ object TelemetryManager {
         return events
     }
 
-    /** One-time migration from the pre-file SharedPreferences blob; the key is cleared after. */
+    /** Reads the pre-file SharedPreferences blob WITHOUT clearing it — the key is removed only
+     *  once the migrated file has durably landed (see [rewriteOutboxLocked]), so disk-full, an
+     *  I/O failure, or a crash mid-migration can never discard the pre-upgrade backlog. */
     private fun readLegacyOutboxLocked(context: Context): List<TelemetryEvent>? {
-        val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
-        val encoded = prefs.getString(KEY_OUTBOX, null) ?: return null
-        prefs.edit().remove(KEY_OUTBOX).apply()
+        val encoded = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+            .getString(KEY_OUTBOX, null) ?: return null
         return runCatching { json.decodeFromString<List<TelemetryEvent>>(encoded) }
             .getOrDefault(emptyList())
     }
 
-    private fun rewriteOutboxLocked(context: Context, events: List<TelemetryEvent>) {
+    private fun clearLegacyOutboxLocked(context: Context) {
+        val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        if (prefs.contains(KEY_OUTBOX)) prefs.edit().remove(KEY_OUTBOX).apply()
+    }
+
+    private fun rewriteOutboxLocked(context: Context, events: List<TelemetryEvent>): Boolean {
         val file = outboxFile(context)
-        runCatching {
+        val wrote = runCatching {
             val temp = File(file.parentFile, "$OUTBOX_FILE.tmp")
             temp.writeText(events.joinToString(separator = "") { json.encodeToString(it) + "\n" })
             if (!temp.renameTo(file)) {
                 file.writeText(events.joinToString(separator = "") { json.encodeToString(it) + "\n" })
                 temp.delete()
             }
+        }.isSuccess
+        if (wrote) {
+            outboxFileLines = events.size
+            if (legacyMigrationPending) {
+                legacyMigrationPending = false
+                clearLegacyOutboxLocked(context)
+            }
         }
-        outboxFileLines = events.size
+        return wrote
     }
 
     /** Truly process-constant attributes, built once. */

--- a/android/app/src/main/java/com/openrung/telemetry/TelemetryManager.kt
+++ b/android/app/src/main/java/com/openrung/telemetry/TelemetryManager.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.ensureActive
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import java.io.File
 import java.time.Instant
 import java.util.Locale
 import java.util.TimeZone
@@ -27,8 +28,27 @@ object TelemetryManager {
     private const val UPLOAD_BATCH_SIZE = 200
     private const val DNS_PORT = 53
     private const val APP_CONNECTION_WINDOW_MS = 15 * 60 * 1000L
+    private const val OUTBOX_FILE = "openrung_telemetry_outbox.jsonl"
+
+    /**
+     * The outbox file may carry more lines than the in-memory cap before it is compacted; past
+     * this it is rewritten from the cache, so append cost stays O(1) amortized per event.
+     */
+    private const val OUTBOX_COMPACT_THRESHOLD = 2 * MAX_QUEUED_EVENTS
 
     private val lock = Any()
+
+    /**
+     * In-memory outbox mirror (guarded by [lock]) over an append-only NDJSON file. Appending one
+     * event encodes and writes ONE line; the previous SharedPreferences blob decoded and
+     * re-encoded the entire queue (up to [MAX_QUEUED_EVENTS] events, hundreds of KB) on every
+     * append — O(n²) CPU/disk per session, worst exactly when a blocked network keeps the queue
+     * full. The file is rewritten only when uploads remove events, geo attributes are
+     * back-patched, or the tail outgrows [OUTBOX_COMPACT_THRESHOLD]; a torn final line from a
+     * process kill is skipped at load.
+     */
+    private var outboxCache: MutableList<TelemetryEvent>? = null
+    private var outboxFileLines = 0
     private val appConnections = ApplicationConnectionAggregator(
         windowMs = APP_CONNECTION_WINDOW_MS,
         elapsedMs = SystemClock::elapsedRealtime,
@@ -62,7 +82,15 @@ object TelemetryManager {
             // Unconditional: the application context is process-constant in production, and
             // holding on to the first one seen keeps Robolectric tests (fresh Application per
             // test method) writing to a stale instance's SharedPreferences.
-            this.context = context.applicationContext
+            val next = context.applicationContext
+            if (this.context !== next) {
+                // A different Application instance (Robolectric per-test) invalidates the outbox
+                // cache — its file lives under the new instance's filesDir.
+                outboxCache = null
+                outboxFileLines = 0
+                cachedNetworkAttributes = null
+            }
+            this.context = next
         }
     }
 
@@ -169,18 +197,15 @@ object TelemetryManager {
         synchronized(lock) {
             val session = activeSession ?: return
             activeSession = session.copy(geoAttributes = geoAttributes)
-            writeOutbox(
-                appContext,
-                readOutbox(appContext).map { event ->
-                    when {
-                        event.event == APPLICATION_CONNECTION_EVENT ->
-                            event.copy(attributes = emptyMap())
-                        event.sessionId == session.id ->
-                            event.copy(attributes = event.attributes + geoAttributes)
-                        else -> event
-                    }
-                },
-            )
+            transformOutboxLocked(appContext) { event ->
+                when {
+                    event.event == APPLICATION_CONNECTION_EVENT ->
+                        event.copy(attributes = emptyMap())
+                    event.sessionId == session.id ->
+                        event.copy(attributes = event.attributes + geoAttributes)
+                    else -> event
+                }
+            }
         }
         record("client_geo_resolved")
     }
@@ -280,13 +305,11 @@ object TelemetryManager {
             heartbeat = event,
             batchSize = UPLOAD_BATCH_SIZE,
             readQueued = {
-                synchronized(lock) { readOutbox(appContext) }
+                synchronized(lock) { outboxSnapshotLocked(appContext) }
             },
             send = { TelemetryClient(session.brokerUrl).send(it) },
             commit = { sentIDs ->
-                synchronized(lock) {
-                    writeOutbox(appContext, readOutbox(appContext).filterNot { it.eventId in sentIDs })
-                }
+                synchronized(lock) { removeFromOutboxLocked(appContext, sentIDs) }
             },
             flushQueued = { flush(session.brokerUrl) },
         )
@@ -296,7 +319,7 @@ object TelemetryManager {
         val appContext = context ?: return
         while (true) {
             val batch = synchronized(lock) {
-                telemetryUploadBatch(readOutbox(appContext), UPLOAD_BATCH_SIZE)
+                telemetryUploadBatch(outboxSnapshotLocked(appContext), UPLOAD_BATCH_SIZE)
             }
             if (batch.isEmpty()) return
             sendTelemetryBatchAndCommit(
@@ -304,12 +327,7 @@ object TelemetryManager {
                 queuedEventIds = batch.mapTo(hashSetOf()) { it.eventId },
                 send = { TelemetryClient(brokerUrl).send(it) },
                 commit = { sentIDs ->
-                    synchronized(lock) {
-                        writeOutbox(
-                            appContext,
-                            readOutbox(appContext).filterNot { it.eventId in sentIDs },
-                        )
-                    }
+                    synchronized(lock) { removeFromOutboxLocked(appContext, sentIDs) }
                 },
             )
         }
@@ -323,42 +341,141 @@ object TelemetryManager {
 
     private fun enqueueAllLocked(context: Context, events: List<TelemetryEvent>) {
         if (events.isEmpty()) return
-        writeOutbox(
-            context,
-            (readOutbox(context) + events.map(::sanitizeTelemetryEvent)).takeLast(MAX_QUEUED_EVENTS),
-        )
+        val cache = loadOutboxLocked(context)
+        val sanitized = events.map(::sanitizeTelemetryEvent)
+        cache.addAll(sanitized)
+        while (cache.size > MAX_QUEUED_EVENTS) cache.removeAt(0)
+        val appended = runCatching {
+            outboxFile(context).appendText(
+                sanitized.joinToString(separator = "") { json.encodeToString(it) + "\n" },
+            )
+        }.isSuccess
+        outboxFileLines += sanitized.size
+        if (!appended || outboxFileLines > OUTBOX_COMPACT_THRESHOLD) {
+            rewriteOutboxLocked(context, cache)
+        }
     }
 
-    private fun readOutbox(context: Context): List<TelemetryEvent> {
-        val encoded = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE).getString(KEY_OUTBOX, null)
-            ?: return emptyList()
+    /** Immutable snapshot for consumers that iterate outside [lock]. */
+    private fun outboxSnapshotLocked(context: Context): List<TelemetryEvent> =
+        loadOutboxLocked(context).toList()
+
+    private fun removeFromOutboxLocked(context: Context, ids: Set<String>) {
+        if (ids.isEmpty()) return
+        val cache = loadOutboxLocked(context)
+        if (cache.removeAll { it.eventId in ids }) {
+            rewriteOutboxLocked(context, cache)
+        }
+    }
+
+    private fun transformOutboxLocked(context: Context, transform: (TelemetryEvent) -> TelemetryEvent) {
+        val cache = loadOutboxLocked(context)
+        var changed = false
+        for (index in cache.indices) {
+            val next = transform(cache[index])
+            if (next != cache[index]) {
+                cache[index] = next
+                changed = true
+            }
+        }
+        if (changed) rewriteOutboxLocked(context, cache)
+    }
+
+    private fun outboxFile(context: Context): File = File(context.filesDir, OUTBOX_FILE)
+
+    private fun loadOutboxLocked(context: Context): MutableList<TelemetryEvent> {
+        outboxCache?.let { return it }
+        val file = outboxFile(context)
+        val legacy = readLegacyOutboxLocked(context)
+        var needsRewrite = legacy != null
+        val parsed = legacy
+            ?: if (file.isFile) {
+                val lines = runCatching {
+                    file.useLines { sequence -> sequence.filter { it.isNotBlank() }.toList() }
+                }.getOrDefault(emptyList())
+                val decoded = lines.mapNotNull { line ->
+                    runCatching { json.decodeFromString<TelemetryEvent>(line) }.getOrNull()
+                }
+                needsRewrite = decoded.size != lines.size
+                decoded
+            } else {
+                emptyList()
+            }
+        val events = parsed.map(::sanitizeTelemetryEvent)
+            .takeLast(MAX_QUEUED_EVENTS)
+            .toMutableList()
+        if (needsRewrite || events.size != parsed.size) {
+            rewriteOutboxLocked(context, events)
+        } else {
+            outboxFileLines = events.size
+        }
+        outboxCache = events
+        return events
+    }
+
+    /** One-time migration from the pre-file SharedPreferences blob; the key is cleared after. */
+    private fun readLegacyOutboxLocked(context: Context): List<TelemetryEvent>? {
+        val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        val encoded = prefs.getString(KEY_OUTBOX, null) ?: return null
+        prefs.edit().remove(KEY_OUTBOX).apply()
         return runCatching { json.decodeFromString<List<TelemetryEvent>>(encoded) }
             .getOrDefault(emptyList())
-            .map(::sanitizeTelemetryEvent)
     }
 
-    private fun writeOutbox(context: Context, events: List<TelemetryEvent>) {
-        context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
-            .edit()
-            .putString(KEY_OUTBOX, json.encodeToString(events))
-            .apply()
+    private fun rewriteOutboxLocked(context: Context, events: List<TelemetryEvent>) {
+        val file = outboxFile(context)
+        runCatching {
+            val temp = File(file.parentFile, "$OUTBOX_FILE.tmp")
+            temp.writeText(events.joinToString(separator = "") { json.encodeToString(it) + "\n" })
+            if (!temp.renameTo(file)) {
+                file.writeText(events.joinToString(separator = "") { json.encodeToString(it) + "\n" })
+                temp.delete()
+            }
+        }
+        outboxFileLines = events.size
     }
 
-    private fun deviceAttributes(context: Context): Map<String, String> {
-        val connectivity = context.getSystemService(ConnectivityManager::class.java)
-        val capabilities = connectivity.getNetworkCapabilities(connectivity.activeNetwork)
-        return mapOf(
+    /** Truly process-constant attributes, built once. */
+    private val staticDeviceAttributes: Map<String, String> by lazy {
+        mapOf(
             "app_version" to BuildConfig.VERSION_NAME,
             "os_name" to "android",
             "android_api" to Build.VERSION.SDK_INT.toString(),
             "device_manufacturer" to Build.MANUFACTURER,
             "device_model" to Build.MODEL,
-            "locale" to Locale.getDefault().toLanguageTag(),
-            "timezone" to TimeZone.getDefault().id,
-            "network_transport" to transportName(capabilities),
-            "network_metered" to (capabilities?.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED) != true).toString(),
-            "network_roaming" to (capabilities?.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_ROAMING) != true).toString(),
         )
+    }
+
+    /**
+     * Short-lived cache for the network attributes: resolving them costs two binder calls, and
+     * events cluster in bursts (connect ladder, recovery), so a small TTL removes almost all of
+     * that IPC without reporting stale transports.
+     */
+    private const val NETWORK_ATTRIBUTES_TTL_MS = 5_000L
+    private var cachedNetworkAttributes: Pair<Long, Map<String, String>>? = null
+
+    private fun deviceAttributes(context: Context): Map<String, String> {
+        val now = SystemClock.elapsedRealtime()
+        val cached = synchronized(lock) { cachedNetworkAttributes }
+        val network = if (cached != null && now - cached.first < NETWORK_ATTRIBUTES_TTL_MS) {
+            cached.second
+        } else {
+            val connectivity = context.getSystemService(ConnectivityManager::class.java)
+            val capabilities = connectivity.getNetworkCapabilities(connectivity.activeNetwork)
+            val fresh = mapOf(
+                "network_transport" to transportName(capabilities),
+                "network_metered" to (capabilities?.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED) != true).toString(),
+                "network_roaming" to (capabilities?.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_ROAMING) != true).toString(),
+            )
+            synchronized(lock) { cachedNetworkAttributes = now to fresh }
+            fresh
+        }
+        // Locale/timezone can change mid-process and are cheap to read — keep them live.
+        return staticDeviceAttributes +
+            mapOf(
+                "locale" to Locale.getDefault().toLanguageTag(),
+                "timezone" to TimeZone.getDefault().id,
+            ) + network
     }
 
     private fun transportName(capabilities: NetworkCapabilities?): String = when {

--- a/android/app/src/main/java/com/openrung/vpn/OpenRungVpnService.kt
+++ b/android/app/src/main/java/com/openrung/vpn/OpenRungVpnService.kt
@@ -66,11 +66,27 @@ import kotlin.coroutines.coroutineContext
 import kotlin.random.Random
 
 class OpenRungVpnService : VpnService() {
-    // One background thread, not a pool: every identity check and monitor-job handoff in this
-    // class relies on all tunnel state being touched from a single thread. Keeping that thread
-    // off Main matters because libbox setup/start/stop, config validation, and telemetry I/O
-    // can each block for hundreds of milliseconds (ANR risk on the UI thread).
-    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Default.limitedParallelism(1))
+    // Each instance gets its own Job (so onDestroy cancels only its own work) on the shared
+    // process-wide service thread (see [serviceThread] for why the thread must be global).
+    private val serviceScope = CoroutineScope(SupervisorJob() + serviceThread)
+
+    /**
+     * The startId of the most recent delivered start command, stamped on Main. `stopSelf(id)`
+     * stops the service iff `id` still matches AMS's most recent start, so every self-stop must
+     * carry the id of the epoch it is allowed to end — never this field read at stop time,
+     * which by then is the id of whatever superseded that epoch. Revoke/destroy teardowns
+     * therefore capture this AT POST TIME on Main; connect epochs use [epochStartId].
+     */
+    @Volatile
+    private var lastStartId = -1
+
+    /**
+     * The startId of the command that opened the current connect epoch (service-thread
+     * confined; recovery reconnects keep it — they run inside the same epoch). Failure tails
+     * stop the service with THIS id: when a newer CONNECT has been delivered, this id no longer
+     * matches AMS's latest and the stop is refused, sparing the successor.
+     */
+    private var epochStartId = -1
     private val relaySelector = RelaySelector()
     private val punchRecoveryCircuitBreaker = PunchRecoveryCircuitBreaker()
     private val wssFallbackPolicy = WssFallbackPolicy(NativeWssFrontSetValidator)
@@ -100,10 +116,18 @@ class OpenRungVpnService : VpnService() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         // Lifecycle callbacks arrive on Main but never touch tunnel state directly: they post to
         // the service thread, which owns every field in this class.
+        lastStartId = startId
         val action = intent?.action
         val brokerUrl = intent?.getStringExtra(EXTRA_BROKER_URL).orEmpty()
         val targetCountry = intent?.getStringExtra(EXTRA_TARGET_COUNTRY)?.takeIf { it.isNotBlank() }
         val targetRelayId = intent?.getStringExtra(EXTRA_TARGET_RELAY_ID)?.takeIf { it.isNotBlank() }
+        if (action == ACTION_CONNECT) {
+            // startForegroundService demands startForeground within seconds. Claim it here on
+            // Main — before this start waits its turn behind whatever the service thread is
+            // draining (a slow native teardown can hold it well past that window). connect()
+            // refreshes the same notification once it actually runs.
+            startForeground(NOTIFICATION_ID, notification(getString(R.string.vpn_notification_preparing)))
+        }
         serviceScope.launch {
             handleStartAction(action, brokerUrl, targetCountry, targetRelayId, startId)
         }
@@ -130,6 +154,7 @@ class OpenRungVpnService : VpnService() {
                 // A user-initiated connect starts a new recovery epoch. Recursive recovery calls
                 // connect() directly and deliberately keep the breaker state that led to them.
                 punchRecoveryCircuitBreaker.reset()
+                epochStartId = startId
                 connectJob = serviceScope.launch {
                     connect(requestedBrokerUrl.ifBlank { AppConfig.DEFAULT_BROKER_URL }, targetCountry, targetRelayId)
                 }
@@ -164,6 +189,7 @@ class OpenRungVpnService : VpnService() {
                     wssMonitorJob = null
                     connectJob?.cancel()
                     punchRecoveryCircuitBreaker.reset()
+                    epochStartId = startId
                     val storedBrokerUrl = this.brokerUrl
                     val storedTargetCountry = requestedTargetCountry
                     val storedTargetRelayId = requestedTargetRelayId
@@ -176,12 +202,15 @@ class OpenRungVpnService : VpnService() {
                     stopSelf(startId)
                 }
             }
-            ACTION_DISCONNECT -> disconnect()
+            ACTION_DISCONNECT -> disconnect(stopId = startId)
         }
     }
 
     override fun onRevoke() {
-        serviceScope.launch { disconnect() }
+        // Captured NOW, on Main: a connect delivered after this revoke gets a newer id, so the
+        // queued teardown's stopSelf(captured) is refused and the fresh connect survives.
+        val stopId = lastStartId
+        serviceScope.launch { disconnect(stopId) }
         super.onRevoke()
     }
 
@@ -190,8 +219,12 @@ class OpenRungVpnService : VpnService() {
         // completes is the scope cancelled so its Job and any in-flight coroutines (connect,
         // heartbeat, the disconnect() telemetry flush) don't outlive this service instance.
         // Mirrors OpenRungVpnModule.invalidate(). The on-destroy telemetry flush is best-effort —
-        // the outbox retries anything dropped here on the next session.
-        serviceScope.launch { disconnect() }.invokeOnCompletion { serviceScope.cancel() }
+        // the outbox retries anything dropped here on the next session. Because [serviceThread]
+        // is process-global, a replacement instance's first command is guaranteed to run AFTER
+        // this teardown, so the dead instance can never end the replacement's telemetry session
+        // or overwrite its published status.
+        val stopId = lastStartId // captured on Main at post time, same as onRevoke
+        serviceScope.launch { disconnect(stopId) }.invokeOnCompletion { serviceScope.cancel() }
         super.onDestroy()
     }
 
@@ -365,10 +398,20 @@ class OpenRungVpnService : VpnService() {
             if (engineMonitorJob !== currentJob) engineMonitorJob?.cancel()
             if (engineMonitorJob !== currentJob) engineMonitorJob = null
             if (punchMonitorJob !== currentJob) punchMonitorJob?.cancel()
-            punchMonitorJob = null
+            // Guarded like its siblings: a recovery reconnect runs INSIDE punchMonitorJob, and
+            // self-nulling the field here would make this coroutine uncancellable by a
+            // superseding CONNECT (whose cancel targets the field), bypassing the ensureActive
+            // guard below. The job's own finally nulls the field on completion.
+            if (punchMonitorJob !== currentJob) punchMonitorJob = null
             if (wssMonitorJob !== currentJob) wssMonitorJob?.cancel()
             if (wssMonitorJob !== currentJob) wssMonitorJob = null
             cleanupActiveTunnel()
+            // A newer command may have superseded this epoch while cleanup suspended (the WSS
+            // close is NonCancellable, so cancellation is only observed here). Everything below
+            // touches process-global or successor-owned state — activeRelayId, the telemetry
+            // session, the visible status, the service's lifetime — so a superseded failure
+            // path must fall silent instead.
+            coroutineContext.ensureActive()
             activeRelayId = null
             val failureReason = FailureClassifier.classify(error)
             val failureDetail = FailureClassifier.detail(error)
@@ -383,10 +426,13 @@ class OpenRungVpnService : VpnService() {
                 },
             )
             TelemetryManager.endSession("connection_failed")
-            runCatching { TelemetryManager.flush(AppConfig.TELEMETRY_BROKER_URL) }
             OpenRungStatusStore.fail(error.message ?: getString(R.string.error_vpn_connection_failed))
             stopForeground(STOP_FOREGROUND_REMOVE)
-            stopSelf()
+            // This epoch's own id, not the latest: a CONNECT delivered meanwhile carries a newer
+            // id, so AMS refuses this stop and the successor keeps the service.
+            stopSelf(epochStartId)
+            // Deliberately last: runCatching swallows cancellation, so nothing may publish after.
+            runCatching { TelemetryManager.flush(AppConfig.TELEMETRY_BROKER_URL) }
         }
     }
 
@@ -962,7 +1008,13 @@ class OpenRungVpnService : VpnService() {
         return candidates.filter { it.countryCode.trim().uppercase() == target }
     }
 
-    private fun disconnect() {
+    /**
+     * Tears down the tunnel and stops the service — but only if [stopId] is still the most
+     * recent start command. A DISCONNECT and a CONNECT can both be queued on the service thread
+     * before either runs; the stale disconnect must clean up its own epoch without stopping the
+     * service out from under the newer connect.
+     */
+    private fun disconnect(stopId: Int) {
         heartbeatJob?.cancel()
         heartbeatJob = null
         engineMonitorJob?.cancel()
@@ -985,7 +1037,7 @@ class OpenRungVpnService : VpnService() {
         }
         stopForeground(STOP_FOREGROUND_REMOVE)
         OpenRungStatusStore.setStatus(ConnectionStatus.DISCONNECTED, relayLabel = null, lastError = null)
-        stopSelf()
+        stopSelf(stopId)
     }
 
     /**
@@ -1088,12 +1140,18 @@ class OpenRungVpnService : VpnService() {
         if (wssMonitorJob !== currentJob) wssMonitorJob?.cancel()
         if (wssMonitorJob !== currentJob) wssMonitorJob = null
         cleanupActiveTunnel()
+        // See connect()'s failure tail: a superseded epoch must not end the successor's session,
+        // overwrite its status, or stop the service it now owns.
+        coroutineContext.ensureActive()
         activeRelayId = null
         TelemetryManager.endSession("connection_failed")
-        runCatching { TelemetryManager.flush(AppConfig.TELEMETRY_BROKER_URL) }
         OpenRungStatusStore.fail(userMessage)
         stopForeground(STOP_FOREGROUND_REMOVE)
-        stopSelf()
+        // This epoch's own id, not the latest: a CONNECT delivered meanwhile carries a newer
+        // id, so AMS refuses this stop and the successor keeps the service.
+        stopSelf(epochStartId)
+        // Deliberately last: runCatching swallows cancellation, so nothing may publish after.
+        runCatching { TelemetryManager.flush(AppConfig.TELEMETRY_BROKER_URL) }
     }
 
     /**
@@ -1363,45 +1421,72 @@ class OpenRungVpnService : VpnService() {
     }
 
     /**
-     * Mirrors the desktop client's thresholded through-tunnel health monitor. Only after repeated
-     * VPN failures do we probe independent connectivity endpoints on a physical Android [Network];
-     * a local outage is left alone, while a reachable endpoint proves that the direct tunnel itself
-     * needs recovery.
+     * Mirrors the desktop client's thresholded through-tunnel health monitor: only after the
+     * failure threshold do we probe independent endpoints on a physical Android [Network] — a
+     * local outage is left alone, while a reachable endpoint proves the tunnel itself needs
+     * recovery.
+     *
+     * The loop ticks at the base cadence forever — a tick reads in-memory counters and costs no
+     * radio (and `delay()` schedules no wakeup alarms, so it cannot wake a sleeping CPU). Only
+     * PROBES open a through-tunnel TLS connection, so only probes are rationed:
+     *
+     *  - Downlink growth since the last tick is treated as end-to-end health and skips the probe
+     *    — but ONLY while nothing is suspected. A counter push can lag by up to the engine's
+     *    status interval, so a sample may still carry pre-failure bytes, and a failed probe's
+     *    own transmission grows the uplink counter; neither may ever clear suspicion, so once a
+     *    probe has failed only a successful probe resets the count.
+     *  - Uplink growth WITHOUT downlink growth means something is sending and nothing is coming
+     *    back — the signature of a blackholed path with a user on it. That forces a probe
+     *    immediately, regardless of accumulated backoff.
+     *  - Otherwise the tunnel is idle: probe only when the backed-off allowance (base, doubling
+     *    per healthy observation up to [PUNCH_HEALTH_MAX_BACKOFF_MS]) runs out.
+     *
+     * Detection-latency bound (from actual failure, active user): counter pushes lag by up to
+     * the engine status interval, so up to TWO ticks can still read pre-failure downlink and be
+     * masked; the next tick's send-without-reply forces the first failed probe, and the
+     * remaining threshold probes run at base cadence — ≈ 6×base plus probe timeouts, ~3.5 min
+     * worst case (typically far less), versus ~105 s before backoff existed. A fully idle dead
+     * tunnel may sit until the cap (~5 min), but with no traffic no one is affected, and the
+     * first use flips it onto the fast path above.
      */
     private suspend fun awaitTunnelHealthFailure(): String {
         var failures = 0
-        // Each probe is a fresh TCP+TLS handshake through the tunnel — on cellular it drags the
-        // radio out of idle, so an unbacked-off ~30 s cadence dominates the battery cost of an
-        // idle connected session. Sustained health therefore doubles the interval (~30 s → 5 min
-        // cap); any suspicion resets to the fast cadence so the failure threshold resolves as
-        // quickly as it did before backoff existed. Availability is unaffected: detection is
-        // slower only after long proven-healthy stretches, never after a failure.
-        var intervalMs = PUNCH_HEALTH_MIN_DELAY_MS
-        var lastTraffic = TelemetryManager.currentTrafficCounters()
+        var probeAllowanceMs = PUNCH_HEALTH_MIN_DELAY_MS
+        var msUntilProbe = 0L
+        var lastCounters = TelemetryManager.currentTrafficCounters()
         while (true) {
-            delay(Random.nextLong((intervalMs * 5) / 6, (intervalMs * 7) / 6 + 1))
-            // Bytes moved since the last pass prove the tunnel end-to-end without opening a
-            // probe connection. Counters arrive on the engine's status-push cadence, so this can
-            // lag one window — the safe direction (an extra probe, never a missed failure).
-            val traffic = TelemetryManager.currentTrafficCounters()
-            if (traffic != null && traffic != lastTraffic) {
-                lastTraffic = traffic
-                failures = 0
-                intervalMs = (intervalMs * 2).coerceAtMost(PUNCH_HEALTH_MAX_BACKOFF_MS)
+            val passMs = Random.nextLong(
+                (PUNCH_HEALTH_MIN_DELAY_MS * 5) / 6,
+                (PUNCH_HEALTH_MIN_DELAY_MS * 7) / 6 + 1,
+            )
+            delay(passMs)
+            val counters = TelemetryManager.currentTrafficCounters()
+            val downlinkGrew = counters != null && lastCounters != null &&
+                counters.bytesReceived > lastCounters.bytesReceived
+            val uplinkGrew = counters != null && lastCounters != null &&
+                counters.bytesSent > lastCounters.bytesSent
+            if (counters != null) lastCounters = counters
+            if (failures == 0 && downlinkGrew) {
+                probeAllowanceMs = (probeAllowanceMs * 2).coerceAtMost(PUNCH_HEALTH_MAX_BACKOFF_MS)
+                msUntilProbe = probeAllowanceMs
                 continue
             }
-            lastTraffic = traffic
+            msUntilProbe -= passMs
+            val sendWithoutReply = uplinkGrew && !downlinkGrew
+            if (failures == 0 && !sendWithoutReply && msUntilProbe > 0) continue
             try {
                 InternetProbe(applicationContext).verifyOnce()
                 failures = 0
-                intervalMs = (intervalMs * 2).coerceAtMost(PUNCH_HEALTH_MAX_BACKOFF_MS)
+                probeAllowanceMs = (probeAllowanceMs * 2).coerceAtMost(PUNCH_HEALTH_MAX_BACKOFF_MS)
+                msUntilProbe = probeAllowanceMs
             } catch (error: CancellationException) {
                 throw error
             } catch (error: Throwable) {
                 if (!isGenuineRemoteDataPathFailure(error)) {
                     throw LocalTunnelException("active_tunnel_health", error)
                 }
-                intervalMs = PUNCH_HEALTH_MIN_DELAY_MS
+                probeAllowanceMs = PUNCH_HEALTH_MIN_DELAY_MS
+                msUntilProbe = 0
                 failures++
                 if (failures < PUNCH_HEALTH_FAILURE_THRESHOLD) continue
                 if (!physicalNetworkAlive()) continue
@@ -1564,6 +1649,20 @@ class OpenRungVpnService : VpnService() {
     }
 
     companion object {
+        /**
+         * One PROCESS-WIDE background thread shared by every service instance, not a pool and
+         * deliberately not per-instance. Single-threading (a) preserves the confinement every
+         * identity check and monitor-job handoff in this class relies on, off the UI thread
+         * (libbox setup/start/stop and telemetry I/O can block for hundreds of milliseconds);
+         * and (b) restores the total ordering across instance replacement that Main used to
+         * provide: OpenRungStatusStore and TelemetryManager are process singletons, and a
+         * destroyed instance's still-queued teardown must run BEFORE its replacement's connect,
+         * or the dead instance would end the new telemetry session and overwrite the new
+         * published status. Posts from lifecycle callbacks happen in Main order, so one shared
+         * queue yields exactly that ordering.
+         */
+        private val serviceThread = Dispatchers.Default.limitedParallelism(1)
+
         private const val ACTION_CONNECT = "com.openrung.action.CONNECT"
         private const val ACTION_DISCONNECT = "com.openrung.action.DISCONNECT"
         private const val ACTION_REAPPLY = "com.openrung.action.REAPPLY"

--- a/android/app/src/main/java/com/openrung/vpn/OpenRungVpnService.kt
+++ b/android/app/src/main/java/com/openrung/vpn/OpenRungVpnService.kt
@@ -1370,17 +1370,38 @@ class OpenRungVpnService : VpnService() {
      */
     private suspend fun awaitTunnelHealthFailure(): String {
         var failures = 0
+        // Each probe is a fresh TCP+TLS handshake through the tunnel — on cellular it drags the
+        // radio out of idle, so an unbacked-off ~30 s cadence dominates the battery cost of an
+        // idle connected session. Sustained health therefore doubles the interval (~30 s → 5 min
+        // cap); any suspicion resets to the fast cadence so the failure threshold resolves as
+        // quickly as it did before backoff existed. Availability is unaffected: detection is
+        // slower only after long proven-healthy stretches, never after a failure.
+        var intervalMs = PUNCH_HEALTH_MIN_DELAY_MS
+        var lastTraffic = TelemetryManager.currentTrafficCounters()
         while (true) {
-            delay(Random.nextLong(PUNCH_HEALTH_MIN_DELAY_MS, PUNCH_HEALTH_MAX_DELAY_MS + 1))
+            delay(Random.nextLong((intervalMs * 5) / 6, (intervalMs * 7) / 6 + 1))
+            // Bytes moved since the last pass prove the tunnel end-to-end without opening a
+            // probe connection. Counters arrive on the engine's status-push cadence, so this can
+            // lag one window — the safe direction (an extra probe, never a missed failure).
+            val traffic = TelemetryManager.currentTrafficCounters()
+            if (traffic != null && traffic != lastTraffic) {
+                lastTraffic = traffic
+                failures = 0
+                intervalMs = (intervalMs * 2).coerceAtMost(PUNCH_HEALTH_MAX_BACKOFF_MS)
+                continue
+            }
+            lastTraffic = traffic
             try {
                 InternetProbe(applicationContext).verifyOnce()
                 failures = 0
+                intervalMs = (intervalMs * 2).coerceAtMost(PUNCH_HEALTH_MAX_BACKOFF_MS)
             } catch (error: CancellationException) {
                 throw error
             } catch (error: Throwable) {
                 if (!isGenuineRemoteDataPathFailure(error)) {
                     throw LocalTunnelException("active_tunnel_health", error)
                 }
+                intervalMs = PUNCH_HEALTH_MIN_DELAY_MS
                 failures++
                 if (failures < PUNCH_HEALTH_FAILURE_THRESHOLD) continue
                 if (!physicalNetworkAlive()) continue
@@ -1409,8 +1430,13 @@ class OpenRungVpnService : VpnService() {
     }
 
     private suspend fun awaitPhysicalNetworkAlive() {
+        // A real outage (tunnel, subway, airplane mode) can last hours; probing TLS endpoints
+        // every 5 s the whole time keeps the radio awake for nothing. Back off toward a 60 s
+        // ceiling — reconnect latency after a long outage grows by at most that much.
+        var delayMs = PHYSICAL_NETWORK_RETRY_DELAY_MS
         while (!physicalNetworkAlive()) {
-            delay(PHYSICAL_NETWORK_RETRY_DELAY_MS)
+            delay(delayMs)
+            delayMs = (delayMs * 2).coerceAtMost(PHYSICAL_NETWORK_RETRY_MAX_DELAY_MS)
         }
     }
 
@@ -1548,10 +1574,11 @@ class OpenRungVpnService : VpnService() {
         private const val NOTIFICATION_ID = 2001
         internal const val HEARTBEAT_MIN_DELAY_MS = 50_000L
         internal const val HEARTBEAT_MAX_DELAY_MS = 70_000L
-        internal const val PUNCH_HEALTH_MIN_DELAY_MS = 25_000L
-        internal const val PUNCH_HEALTH_MAX_DELAY_MS = 35_000L
+        internal const val PUNCH_HEALTH_MIN_DELAY_MS = 30_000L
+        internal const val PUNCH_HEALTH_MAX_BACKOFF_MS = 300_000L
         internal const val PUNCH_HEALTH_FAILURE_THRESHOLD = 3
         private const val PHYSICAL_NETWORK_RETRY_DELAY_MS = 5_000L
+        private const val PHYSICAL_NETWORK_RETRY_MAX_DELAY_MS = 60_000L
         private const val ACCESS_TRANSPORT_DIRECT = "direct"
         private const val ACCESS_TRANSPORT_PUNCH = "punch"
         private const val ACCESS_TRANSPORT_WSS = "wss"

--- a/android/app/src/main/java/com/openrung/vpn/OpenRungVpnService.kt
+++ b/android/app/src/main/java/com/openrung/vpn/OpenRungVpnService.kt
@@ -200,6 +200,13 @@ class OpenRungVpnService : VpnService() {
                     // Nothing to reapply and no active tunnel: don't leave an idle START_STICKY
                     // service running just because a reapply intent started it.
                     stopSelf(startId)
+                } else {
+                    // Skipped mid-connect/recovery — but this REAPPLY still advanced AMS's
+                    // latest start id. Absorb it into the live epoch (whose next connect() pass
+                    // re-reads the persisted config anyway) so a later terminal failure's
+                    // stopSelf(epochStartId) still matches; otherwise the failed service would
+                    // linger unstopped behind the ignored REAPPLY's newer id.
+                    epochStartId = startId
                 }
             }
             ACTION_DISCONNECT -> disconnect(stopId = startId)

--- a/android/app/src/main/java/com/openrung/vpn/OpenRungVpnService.kt
+++ b/android/app/src/main/java/com/openrung/vpn/OpenRungVpnService.kt
@@ -66,7 +66,11 @@ import kotlin.coroutines.coroutineContext
 import kotlin.random.Random
 
 class OpenRungVpnService : VpnService() {
-    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    // One background thread, not a pool: every identity check and monitor-job handoff in this
+    // class relies on all tunnel state being touched from a single thread. Keeping that thread
+    // off Main matters because libbox setup/start/stop, config validation, and telemetry I/O
+    // can each block for hundreds of milliseconds (ANR risk on the UI thread).
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Default.limitedParallelism(1))
     private val relaySelector = RelaySelector()
     private val punchRecoveryCircuitBreaker = PunchRecoveryCircuitBreaker()
     private val wssFallbackPolicy = WssFallbackPolicy(NativeWssFrontSetValidator)
@@ -94,11 +98,27 @@ class OpenRungVpnService : VpnService() {
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        when (intent?.action) {
+        // Lifecycle callbacks arrive on Main but never touch tunnel state directly: they post to
+        // the service thread, which owns every field in this class.
+        val action = intent?.action
+        val brokerUrl = intent?.getStringExtra(EXTRA_BROKER_URL).orEmpty()
+        val targetCountry = intent?.getStringExtra(EXTRA_TARGET_COUNTRY)?.takeIf { it.isNotBlank() }
+        val targetRelayId = intent?.getStringExtra(EXTRA_TARGET_RELAY_ID)?.takeIf { it.isNotBlank() }
+        serviceScope.launch {
+            handleStartAction(action, brokerUrl, targetCountry, targetRelayId, startId)
+        }
+        return START_STICKY
+    }
+
+    private fun handleStartAction(
+        action: String?,
+        requestedBrokerUrl: String,
+        targetCountry: String?,
+        targetRelayId: String?,
+        startId: Int,
+    ) {
+        when (action) {
             ACTION_CONNECT -> {
-                val brokerUrl = intent.getStringExtra(EXTRA_BROKER_URL).orEmpty()
-                val targetCountry = intent.getStringExtra(EXTRA_TARGET_COUNTRY)?.takeIf { it.isNotBlank() }
-                val targetRelayId = intent.getStringExtra(EXTRA_TARGET_RELAY_ID)?.takeIf { it.isNotBlank() }
                 heartbeatJob?.cancel()
                 engineMonitorJob?.cancel()
                 engineMonitorJob = null
@@ -111,7 +131,7 @@ class OpenRungVpnService : VpnService() {
                 // connect() directly and deliberately keep the breaker state that led to them.
                 punchRecoveryCircuitBreaker.reset()
                 connectJob = serviceScope.launch {
-                    connect(brokerUrl.ifBlank { AppConfig.DEFAULT_BROKER_URL }, targetCountry, targetRelayId)
+                    connect(requestedBrokerUrl.ifBlank { AppConfig.DEFAULT_BROKER_URL }, targetCountry, targetRelayId)
                 }
             }
             ACTION_REAPPLY -> {
@@ -144,7 +164,7 @@ class OpenRungVpnService : VpnService() {
                     wssMonitorJob = null
                     connectJob?.cancel()
                     punchRecoveryCircuitBreaker.reset()
-                    val storedBrokerUrl = brokerUrl
+                    val storedBrokerUrl = this.brokerUrl
                     val storedTargetCountry = requestedTargetCountry
                     val storedTargetRelayId = requestedTargetRelayId
                     connectJob = serviceScope.launch {
@@ -158,22 +178,20 @@ class OpenRungVpnService : VpnService() {
             }
             ACTION_DISCONNECT -> disconnect()
         }
-        return START_STICKY
     }
 
     override fun onRevoke() {
-        disconnect()
+        serviceScope.launch { disconnect() }
         super.onRevoke()
     }
 
     override fun onDestroy() {
-        disconnect()
-        // Cancel the scope so its Job, its Main.immediate dispatcher, and any in-flight
-        // coroutines (connect, heartbeat, the disconnect() telemetry flush) don't outlive this
-        // service instance. Mirrors OpenRungVpnModule.invalidate(). This supersedes the explicit
-        // connectJob cancel (scope cancellation cancels all children). The on-destroy telemetry
-        // flush is best-effort — the outbox retries anything dropped here on the next session.
-        serviceScope.cancel()
+        // Teardown runs on the service thread like every other state mutation; only after it
+        // completes is the scope cancelled so its Job and any in-flight coroutines (connect,
+        // heartbeat, the disconnect() telemetry flush) don't outlive this service instance.
+        // Mirrors OpenRungVpnModule.invalidate(). The on-destroy telemetry flush is best-effort —
+        // the outbox retries anything dropped here on the next session.
+        serviceScope.launch { disconnect() }.invokeOnCompletion { serviceScope.cancel() }
         super.onDestroy()
     }
 

--- a/android/app/src/main/java/com/openrung/vpn/ProxyEngine.kt
+++ b/android/app/src/main/java/com/openrung/vpn/ProxyEngine.kt
@@ -9,6 +9,7 @@ import android.os.Build
 import android.os.ParcelFileDescriptor
 import android.os.Process
 import android.util.Log
+import com.openrung.BuildConfig
 import com.openrung.model.RelayDescriptor
 import com.openrung.state.OpenRungStatusStore
 import com.openrung.telemetry.TelemetryManager
@@ -128,8 +129,10 @@ class LibboxProxyEngine : ProxyEngine {
             basePath = File(vpnService.filesDir, "libbox").apply { mkdirs() }.path
             workingPath = File(vpnService.getExternalFilesDir(null) ?: vpnService.filesDir, "libbox").apply { mkdirs() }.path
             tempPath = File(vpnService.cacheDir, "libbox").apply { mkdirs() }.path
-            logMaxLines = 3000
-            debug = true
+            // The in-memory log ring is only read by debug tooling; keep it small in release,
+            // where debug mode would also forward every libbox line into the status store.
+            logMaxLines = if (BuildConfig.DEBUG) 3000 else 300
+            debug = BuildConfig.DEBUG
             crashReportSource = "OpenRungAndroid"
             oomKillerEnabled = false
             oomKillerDisabled = true
@@ -203,8 +206,12 @@ class LibboxProxyEngine : ProxyEngine {
     }
 
     companion object {
-        /** Status push interval, a Go time.Duration in nanoseconds. */
-        private const val STATUS_INTERVAL_NS = 3_000_000_000L
+        /**
+         * Status push interval, a Go time.Duration in nanoseconds. The counters it carries are
+         * cumulative and only sampled by the telemetry heartbeat (every 50–70 s), so a coarse
+         * interval loses no data while avoiding a loopback-gRPC wakeup every few seconds.
+         */
+        private const val STATUS_INTERVAL_NS = 60_000_000_000L
     }
 }
 
@@ -363,7 +370,11 @@ private class OpenRungCommandServerHandler(
             ?.filter { it.isNotBlank() }
             ?.forEach {
                 Log.d(LOG_TAG, it)
-                OpenRungStatusStore.appendLog("libbox: $it")
+                // Each appended line persists the status snapshot and fans out to the JS bridge;
+                // only debug builds surface libbox internals in the on-screen console.
+                if (BuildConfig.DEBUG) {
+                    OpenRungStatusStore.appendLog("libbox: $it")
+                }
             }
     }
 }

--- a/android/app/src/main/java/com/openrung/vpn/ProxyEngine.kt
+++ b/android/app/src/main/java/com/openrung/vpn/ProxyEngine.kt
@@ -50,6 +50,7 @@ import java.net.InetAddress
 import java.net.InetSocketAddress
 import java.net.InterfaceAddress
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 import java.net.NetworkInterface as JavaNetworkInterface
 import io.nekohasekai.libbox.NetworkInterface as BoxNetworkInterface
@@ -188,10 +189,34 @@ class LibboxProxyEngine : ProxyEngine {
     }
 
     override fun stop() {
+        captureFinalTrafficSnapshot()
         // Deliberately drain on every call. If stop wins while start is still inside a native call,
         // any resource published afterward is rejected and closed instead of surviving a one-shot
         // compare-and-set that already returned.
         resources.stop()
+    }
+
+    /**
+     * The status stream pushes counters only every [STATUS_INTERVAL_NS], so at teardown the
+     * cached totals can be up to a minute stale — a short session would report none of its
+     * post-initial traffic. The command server sends a status message immediately on subscribe,
+     * so a throwaway client grabs one final snapshot before the engine goes down. Best-effort
+     * and bounded: a dead or wedged server just fails the connect or times the latch out.
+     */
+    private fun captureFinalTrafficSnapshot() {
+        if (resources.isStopped()) return
+        runCatching {
+            val received = CountDownLatch(1)
+            val options = CommandClientOptions().apply {
+                addCommand(Libbox.CommandStatus)
+                statusInterval = STATUS_INTERVAL_NS
+            }
+            val client = CommandClient(TrafficStatusHandler { received.countDown() }, options)
+            runCatching { client.connect() }.onSuccess {
+                received.await(FINAL_STATUS_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+                runCatching { client.disconnect() }
+            }
+        }
     }
 
     private suspend fun ensureRunning() {
@@ -212,6 +237,9 @@ class LibboxProxyEngine : ProxyEngine {
          * interval loses no data while avoiding a loopback-gRPC wakeup every few seconds.
          */
         private const val STATUS_INTERVAL_NS = 60_000_000_000L
+
+        /** Upper bound on waiting for the teardown snapshot's immediate status push. */
+        private const val FINAL_STATUS_TIMEOUT_MS = 700L
     }
 }
 
@@ -311,7 +339,9 @@ internal class StopSafeResourceRegistry<K>(
 }
 
 /** Receives libbox status pushes and forwards the tunnel's traffic counters to telemetry. */
-private class TrafficStatusHandler : CommandClientHandler {
+private class TrafficStatusHandler(
+    private val onStatus: (() -> Unit)? = null,
+) : CommandClientHandler {
     override fun connected() = Unit
 
     override fun disconnected(message: String?) = Unit
@@ -339,6 +369,7 @@ private class TrafficStatusHandler : CommandClientHandler {
             bytesSent = status.uplinkTotal,
             bytesReceived = status.downlinkTotal,
         )
+        onStatus?.invoke()
     }
 }
 

--- a/android/app/src/test/java/com/openrung/net/WssClientTest.kt
+++ b/android/app/src/test/java/com/openrung/net/WssClientTest.kt
@@ -1,5 +1,7 @@
 package com.openrung.net
 
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertSame
@@ -68,7 +70,10 @@ class WssClientTest {
         ).close()
 
         assertTrue(closed.await(5, TimeUnit.SECONDS))
-        assertTrue(completion.isCompleted)
+        // Await the Deferred itself rather than sampling isCompleted: the latch counts down
+        // INSIDE closeNative, but completion.complete(Unit) runs strictly after closeNative
+        // returns on the IO thread — sampling at the latch instant races it (CI flake).
+        runBlocking { withTimeout(5_000) { completion.await() } }
         assertTrue(closeThread.get() !== caller)
     }
 }

--- a/android/app/src/test/java/com/openrung/telemetry/TelemetryManagerApplicationConnectionTest.kt
+++ b/android/app/src/test/java/com/openrung/telemetry/TelemetryManagerApplicationConnectionTest.kt
@@ -3,6 +3,7 @@ package com.openrung.telemetry
 import android.app.Application
 import android.content.Context
 import com.openrung.net.ClientGeoInfo
+import java.io.File
 import java.time.Duration
 import java.util.AbstractList
 import java.util.concurrent.CountDownLatch
@@ -285,15 +286,23 @@ class TelemetryManagerApplicationConnectionTest {
         json.decodeFromString<List<TelemetryEvent>>(storedOutboxJson())
             .filter { it.event == "application_connection" }
 
-    private fun storedOutboxJson(): String =
-        context.getSharedPreferences("openrung_telemetry", Context.MODE_PRIVATE)
-            .getString("outbox", null) ?: "[]"
+    /**
+     * The outbox is an append-only NDJSON file (one event per line); the legacy SharedPreferences
+     * blob only exists as a migration source. Joining the lines into a JSON array keeps the
+     * existing decode/contains assertions unchanged.
+     */
+    private fun storedOutboxJson(): String {
+        val file = File(context.filesDir, "openrung_telemetry_outbox.jsonl")
+        if (!file.isFile) return "[]"
+        return file.readLines().filter { it.isNotBlank() }.joinToString(",", "[", "]")
+    }
 
     private fun clearOutbox() {
         context.getSharedPreferences("openrung_telemetry", Context.MODE_PRIVATE)
             .edit()
             .clear()
             .commit()
+        File(context.filesDir, "openrung_telemetry_outbox.jsonl").delete()
     }
 
     private class BlockingPackageList(

--- a/ios/OpenRung/OpenRungVpnModule.swift
+++ b/ios/OpenRung/OpenRungVpnModule.swift
@@ -21,6 +21,10 @@ final class OpenRungVpnModule: RCTEventEmitter {
     private var recentRegions: [RecentNode] = []
     private var hasListeners = false
     private var vpnStatusObserver: NSObjectProtocol?
+    /// True while a trailing shared-state reload is scheduled (MainActor-confined). Each reload
+    /// decodes the full snapshot and serializes an 80-line payload across the bridge, so
+    /// notification bursts collapse into one reload ~100 ms later instead of one per line.
+    private var sharedStateReloadScheduled = false
     /// Bumped by every explicit connect/disconnect and by a split-tunnel reapply. The reapply
     /// dance stops the tunnel and restarts it after a 350 ms delay; it captures this value before
     /// sleeping and aborts the restart if a newer command (e.g. the user tapping Disconnect)
@@ -304,12 +308,23 @@ final class OpenRungVpnModule: RCTEventEmitter {
             { _, observer, _, _, _ in
                 guard let observer else { return }
                 let module = Unmanaged<OpenRungVpnModule>.fromOpaque(observer).takeUnretainedValue()
-                Task { @MainActor in module.reloadSharedState() }
+                Task { @MainActor in module.scheduleSharedStateReload() }
             },
             AppConfig.darwinNotificationName as CFString,
             nil,
             .deliverImmediately
         )
+    }
+
+    @MainActor
+    private func scheduleSharedStateReload() {
+        guard !sharedStateReloadScheduled else { return }
+        sharedStateReloadScheduled = true
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 100_000_000)
+            self.sharedStateReloadScheduled = false
+            self.reloadSharedState()
+        }
     }
 
     @MainActor

--- a/ios/PacketTunnel/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider.swift
@@ -1421,23 +1421,47 @@ final class PacketTunnelProvider: NEPacketTunnelProvider {
             throw LocalTunnelError(stage: "active_tunnel_health_setup", underlying: error)
         }
         var threshold = TunnelHealthFailureThreshold(requiredFailures: 3)
+        // Each probe is a fresh TCP+TLS handshake through the tunnel — on cellular it drags the
+        // radio out of idle, so an unbacked-off 30 s cadence dominates the battery cost of an
+        // idle connected session. Sustained health therefore doubles the interval (30 s → 5 min
+        // cap); any suspicion resets to the fast cadence so the 3-failure threshold resolves as
+        // quickly as it did before backoff existed. Availability is unaffected: detection is
+        // slower only after long proven-healthy stretches, never after a failure.
+        var intervalMs: UInt64 = Self.tunnelHealthBaseIntervalMs
+        var lastTraffic = TelemetryManager.currentTrafficCounters()
         while true {
-            let delayMs = UInt64.random(in: 25_000...35_000)
+            let delayMs = UInt64.random(in: (intervalMs * 5 / 6)...(intervalMs * 7 / 6))
             try await Task.sleep(nanoseconds: delayMs * 1_000_000)
+            // Bytes moved since the last pass prove the tunnel end-to-end without opening a
+            // probe connection. Counters arrive on the engine's status-push cadence, so this can
+            // lag one window — the safe direction (an extra probe, never a missed failure).
+            let traffic = TelemetryManager.currentTrafficCounters()
+            if let traffic, traffic != lastTraffic {
+                lastTraffic = traffic
+                threshold.recordSuccess()
+                intervalMs = min(intervalMs * 2, Self.tunnelHealthMaxIntervalMs)
+                continue
+            }
+            lastTraffic = traffic
             do {
                 _ = try await probe.verifyOnce()
                 threshold.recordSuccess()
+                intervalMs = min(intervalMs * 2, Self.tunnelHealthMaxIntervalMs)
             } catch is CancellationError {
                 throw CancellationError()
             } catch {
                 guard isGenuineRemoteDataPathFailure(error) else {
                     throw LocalTunnelError(stage: "active_tunnel_health", underlying: error)
                 }
+                intervalMs = Self.tunnelHealthBaseIntervalMs
                 guard threshold.recordRemoteFailure(), monitor.isSatisfied else { continue }
                 return "end-to-end tunnel health probe failed \(threshold.consecutiveFailures) times"
             }
         }
     }
+
+    private static let tunnelHealthBaseIntervalMs: UInt64 = 30_000
+    private static let tunnelHealthMaxIntervalMs: UInt64 = 300_000
 
     private func requestWssRecovery(
         trigger: String,

--- a/ios/PacketTunnel/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider.swift
@@ -1420,40 +1420,69 @@ final class PacketTunnelProvider: NEPacketTunnelProvider {
         } catch {
             throw LocalTunnelError(stage: "active_tunnel_health_setup", underlying: error)
         }
+        // The loop ticks at the base cadence forever — a tick reads in-memory counters and costs
+        // no radio. Only PROBES open a through-tunnel TLS connection, so only probes are
+        // rationed:
+        //
+        //  - Downlink growth since the last tick is treated as end-to-end health and skips the
+        //    probe — but ONLY while nothing is suspected. A counter push can lag by up to the
+        //    engine's status interval, so a sample may still carry pre-failure bytes, and a
+        //    failed probe's own transmission grows the uplink counter; neither may ever clear
+        //    suspicion, so once a probe has failed only a successful probe resets the count.
+        //  - Uplink growth WITHOUT downlink growth means something is sending and nothing is
+        //    coming back — the signature of a blackholed path with a user on it. That forces a
+        //    probe immediately, regardless of accumulated backoff.
+        //  - Otherwise the tunnel is idle: probe only when the backed-off allowance (base,
+        //    doubling per healthy observation up to the cap) runs out.
+        //
+        // Detection-latency bound (from actual failure, active user): counter pushes lag by up
+        // to the engine status interval, so up to TWO ticks can still read pre-failure downlink
+        // and be masked; the next tick's send-without-reply forces the first failed probe, and
+        // the remaining threshold probes run at base cadence — ≈ 6×base plus probe timeouts,
+        // ~3.5 min worst case (typically far less), versus ~105 s before backoff existed. A
+        // fully idle dead tunnel may sit until the cap (~5 min), but with no traffic no one is
+        // affected, and the first use flips it onto the fast path above.
         var threshold = TunnelHealthFailureThreshold(requiredFailures: 3)
-        // Each probe is a fresh TCP+TLS handshake through the tunnel — on cellular it drags the
-        // radio out of idle, so an unbacked-off 30 s cadence dominates the battery cost of an
-        // idle connected session. Sustained health therefore doubles the interval (30 s → 5 min
-        // cap); any suspicion resets to the fast cadence so the 3-failure threshold resolves as
-        // quickly as it did before backoff existed. Availability is unaffected: detection is
-        // slower only after long proven-healthy stretches, never after a failure.
-        var intervalMs: UInt64 = Self.tunnelHealthBaseIntervalMs
-        var lastTraffic = TelemetryManager.currentTrafficCounters()
+        var probeAllowanceMs: UInt64 = Self.tunnelHealthBaseIntervalMs
+        var msUntilProbe: Int64 = 0
+        var lastCounters = TelemetryManager.currentTrafficCounters()
         while true {
-            let delayMs = UInt64.random(in: (intervalMs * 5 / 6)...(intervalMs * 7 / 6))
-            try await Task.sleep(nanoseconds: delayMs * 1_000_000)
-            // Bytes moved since the last pass prove the tunnel end-to-end without opening a
-            // probe connection. Counters arrive on the engine's status-push cadence, so this can
-            // lag one window — the safe direction (an extra probe, never a missed failure).
-            let traffic = TelemetryManager.currentTrafficCounters()
-            if let traffic, traffic != lastTraffic {
-                lastTraffic = traffic
-                threshold.recordSuccess()
-                intervalMs = min(intervalMs * 2, Self.tunnelHealthMaxIntervalMs)
+            let passMs = UInt64.random(
+                in: (Self.tunnelHealthBaseIntervalMs * 5 / 6)...(Self.tunnelHealthBaseIntervalMs * 7 / 6)
+            )
+            try await Task.sleep(nanoseconds: passMs * 1_000_000)
+            let counters = TelemetryManager.currentTrafficCounters()
+            let downlinkGrew: Bool
+            let uplinkGrew: Bool
+            if let counters, let last = lastCounters {
+                downlinkGrew = counters.bytesReceived > last.bytesReceived
+                uplinkGrew = counters.bytesSent > last.bytesSent
+            } else {
+                downlinkGrew = false
+                uplinkGrew = false
+            }
+            if let counters { lastCounters = counters }
+            if threshold.consecutiveFailures == 0, downlinkGrew {
+                probeAllowanceMs = min(probeAllowanceMs * 2, Self.tunnelHealthMaxIntervalMs)
+                msUntilProbe = Int64(probeAllowanceMs)
                 continue
             }
-            lastTraffic = traffic
+            msUntilProbe -= Int64(passMs)
+            let sendWithoutReply = uplinkGrew && !downlinkGrew
+            if threshold.consecutiveFailures == 0, !sendWithoutReply, msUntilProbe > 0 { continue }
             do {
                 _ = try await probe.verifyOnce()
                 threshold.recordSuccess()
-                intervalMs = min(intervalMs * 2, Self.tunnelHealthMaxIntervalMs)
+                probeAllowanceMs = min(probeAllowanceMs * 2, Self.tunnelHealthMaxIntervalMs)
+                msUntilProbe = Int64(probeAllowanceMs)
             } catch is CancellationError {
                 throw CancellationError()
             } catch {
                 guard isGenuineRemoteDataPathFailure(error) else {
                     throw LocalTunnelError(stage: "active_tunnel_health", underlying: error)
                 }
-                intervalMs = Self.tunnelHealthBaseIntervalMs
+                probeAllowanceMs = Self.tunnelHealthBaseIntervalMs
+                msUntilProbe = 0
                 guard threshold.recordRemoteFailure(), monitor.isSatisfied else { continue }
                 return "end-to-end tunnel health probe failed \(threshold.consecutiveFailures) times"
             }

--- a/ios/PacketTunnel/PacketTunnelProxyEngine.swift
+++ b/ios/PacketTunnel/PacketTunnelProxyEngine.swift
@@ -34,8 +34,10 @@ final class EmbeddedProxyEngine: PacketTunnelProxyEngine {
     private var activeRelay: RelayDescriptor?
     private let stopSignal = EngineStopSignal()
 
-    /// Status push interval, a Go time.Duration in nanoseconds.
-    private static let statusIntervalNs: Int64 = 3_000_000_000
+    /// Status push interval, a Go time.Duration in nanoseconds. The counters it carries are
+    /// cumulative and only sampled by the telemetry heartbeat (every 50–70 s), so a coarse
+    /// interval loses no data while avoiding a loopback-gRPC wakeup every few seconds.
+    private static let statusIntervalNs: Int64 = 60_000_000_000
 
     /// Performs every deterministic local check available before opening a relay socket. This is
     /// intentionally ahead of direct reachability so a missing/stale native engine, unwritable
@@ -68,8 +70,15 @@ final class EmbeddedProxyEngine: PacketTunnelProxyEngine {
         setupOptions.basePath = directories.base.path
         setupOptions.workingPath = directories.working.path
         setupOptions.tempPath = directories.temporary.path
+        // The in-memory log ring lives inside the extension's ~50 MB jetsam budget; nothing in
+        // the release app reads it back, so keep it small outside debug builds.
+        #if DEBUG
         setupOptions.logMaxLines = 3000
         setupOptions.debug = true
+        #else
+        setupOptions.logMaxLines = 300
+        setupOptions.debug = false
+        #endif
         setupOptions.crashReportSource = AppConfig.engineDirectoryName
         setupOptions.oomKillerEnabled = false
         setupOptions.oomKillerDisabled = true

--- a/ios/PacketTunnel/PacketTunnelProxyEngine.swift
+++ b/ios/PacketTunnel/PacketTunnelProxyEngine.swift
@@ -153,6 +153,7 @@ final class EmbeddedProxyEngine: PacketTunnelProxyEngine {
 
     func stop() {
         _ = prepareForExpectedStop()
+        captureFinalTrafficSnapshot()
         try? statusClient?.disconnect()
         statusClient = nil
         try? commandServer?.closeService()
@@ -161,6 +162,24 @@ final class EmbeddedProxyEngine: PacketTunnelProxyEngine {
         commandServer = nil
         platformInterface = nil
         activeRelay = nil
+    }
+
+    /// The status stream pushes counters only every `statusIntervalNs`, so at teardown the
+    /// cached totals can be up to a minute stale — a short session would report none of its
+    /// post-initial traffic. The command server sends a status message immediately on
+    /// subscribe, so a throwaway client grabs one final snapshot before the engine goes down.
+    /// Best-effort and bounded: a dead or wedged server just fails the connect or times the
+    /// semaphore out.
+    private func captureFinalTrafficSnapshot() {
+        guard commandServer != nil else { return }
+        let options = LibboxCommandClientOptions()
+        options.addCommand(LibboxCommandStatus)
+        options.statusInterval = Self.statusIntervalNs
+        let received = DispatchSemaphore(value: 0)
+        guard let client = LibboxNewCommandClient(TrafficStatusHandler { received.signal() }, options) else { return }
+        guard (try? client.connect()) != nil else { return }
+        _ = received.wait(timeout: .now() + .milliseconds(700))
+        try? client.disconnect()
     }
 
     func prepareForExpectedStop() -> Bool { stopSignal.finishExpected() }
@@ -198,6 +217,12 @@ final class EmbeddedProxyEngine: PacketTunnelProxyEngine {
 
 /// Receives libbox status pushes and forwards the tunnel's traffic counters to telemetry.
 private final class TrafficStatusHandler: NSObject, LibboxCommandClientHandlerProtocol {
+    private let onStatus: (() -> Void)?
+
+    init(onStatus: (() -> Void)? = nil) {
+        self.onStatus = onStatus
+    }
+
     func connected() {}
 
     func disconnected(_ message: String?) {}
@@ -229,6 +254,7 @@ private final class TrafficStatusHandler: NSObject, LibboxCommandClientHandlerPr
             bytesSent: message.uplinkTotal,
             bytesReceived: message.downlinkTotal
         )
+        onStatus?()
     }
 }
 

--- a/ios/Shared/ActivityLog.swift
+++ b/ios/Shared/ActivityLog.swift
@@ -5,11 +5,17 @@ import Foundation
 public enum ActivityLog {
     public static let maxLines = 80
 
-    public static func line(_ message: String, at date: Date = Date()) -> String {
+    // Constructing a DateFormatter costs orders of magnitude more than formatting with one
+    // (ICU locale/pattern setup); formatting is thread-safe on modern Foundation.
+    private static let timestampFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.dateFormat = "HH:mm:ss"
-        return "[\(formatter.string(from: date))] \(message)"
+        return formatter
+    }()
+
+    public static func line(_ message: String, at date: Date = Date()) -> String {
+        "[\(timestampFormatter.string(from: date))] \(message)"
     }
 
     public static func appended(_ lines: [String], _ line: String, max: Int = maxLines) -> [String] {

--- a/ios/Shared/DeviceAttributes.swift
+++ b/ios/Shared/DeviceAttributes.swift
@@ -32,20 +32,27 @@ public enum DeviceAttributes {
         return model.isEmpty ? "unknown" : model
     }
 
+    /// Process-constant attributes, resolved once: appVersion/osVersion/deviceModel each cost a
+    /// bundle lookup, a UIDevice call, or a uname() syscall, and were previously re-resolved on
+    /// every telemetry event.
+    private static let staticAttributes: [String: String] = [
+        "app_version": appVersion,
+        "os_name": "ios",
+        "ios_version": osVersion,
+        "device_manufacturer": "Apple",
+        "device_model": deviceModel,
+    ]
+
     /// Best-effort attribute map attached to every telemetry event.
     public static func current() -> [String: String] {
         NetworkPathMonitor.shared.startIfNeeded()
         let path = NetworkPathMonitor.shared.currentSnapshot
-        return [
-            "app_version": appVersion,
-            "os_name": "ios",
-            "ios_version": osVersion,
-            "device_manufacturer": "Apple",
-            "device_model": deviceModel,
-            "locale": Locale.current.identifier,
-            "timezone": TimeZone.current.identifier,
-            "network_transport": path.transport,
-            "network_metered": String(path.isExpensive),
-        ]
+        var attributes = staticAttributes
+        // Locale/timezone can change mid-process and are cheap; network state is live by design.
+        attributes["locale"] = Locale.current.identifier
+        attributes["timezone"] = TimeZone.current.identifier
+        attributes["network_transport"] = path.transport
+        attributes["network_metered"] = String(path.isExpensive)
+        return attributes
     }
 }

--- a/ios/Shared/SharedConnectionState.swift
+++ b/ios/Shared/SharedConnectionState.swift
@@ -15,9 +15,9 @@ enum SharedConnectionState {
     /// write + a cross-process Darwin wakeup of the app, and a connect burst appends dozens of
     /// log lines in a couple of seconds. Log-only mutations therefore batch on this serial
     /// queue and flush at most every 250 ms; status/relay/error/recents changes flush
-    /// immediately and carry any pending log lines with them (the queue is FIFO, so ordering
-    /// between the two kinds is preserved). Worst case on an extension kill: the final ≤250 ms
-    /// of log lines are lost — terminal transitions are non-coalescable, so never the outcome.
+    /// SYNCHRONOUSLY (see mutate) so a terminal state is on disk before the caller hands
+    /// control back to NetworkExtension. Worst case on an extension kill: the final ≤250 ms of
+    /// log lines are lost — terminal transitions are synchronous, so never the outcome.
     private static let mutationQueue = DispatchQueue(label: "com.openrung.app.shared-connection-state")
     private static var pendingSnapshot: ConnectionStateSnapshot?
     private static var logFlushScheduled = false
@@ -112,16 +112,29 @@ enum SharedConnectionState {
         coalescable: Bool = false,
         _ transform: @escaping (inout ConnectionStateSnapshot) -> Void
     ) {
-        mutationQueue.async {
-            var pending = pendingSnapshot ?? snapshot()
-            transform(&pending)
-            pendingSnapshot = pending
-            if coalescable {
+        if coalescable {
+            mutationQueue.async {
+                applyOnQueue(transform)
                 scheduleLogFlush()
-            } else {
+            }
+        } else {
+            // Status/error/recents writes must be DURABLE before the caller proceeds: failure
+            // paths call cancelTunnelWithError or the stop completion right after, and
+            // NetworkExtension may suspend the process the moment they do — an async write
+            // would be lost with it. sync on the serial queue also drains any earlier queued
+            // log appends first, so ordering between the two kinds is preserved.
+            mutationQueue.sync {
+                applyOnQueue(transform)
                 flushPendingOnQueue()
             }
         }
+    }
+
+    /// Must run on `mutationQueue`.
+    private static func applyOnQueue(_ transform: (inout ConnectionStateSnapshot) -> Void) {
+        var pending = pendingSnapshot ?? snapshot()
+        transform(&pending)
+        pendingSnapshot = pending
     }
 
     /// Must run on `mutationQueue`.

--- a/ios/Shared/SharedConnectionState.swift
+++ b/ios/Shared/SharedConnectionState.swift
@@ -7,9 +7,20 @@ import Foundation
 enum SharedConnectionState {
     private static let key = "connection_state"
 
-    private static var defaults: UserDefaults? {
-        UserDefaults(suiteName: AppConfig.appGroupIdentifier)
-    }
+    // One suite instance for the process lifetime: the computed-property form re-registered a
+    // fresh UserDefaults with cfprefsd on every read/write.
+    private static let defaults: UserDefaults? = UserDefaults(suiteName: AppConfig.appGroupIdentifier)
+
+    /// Extension-side write coalescing. Every flush is a full snapshot encode + UserDefaults
+    /// write + a cross-process Darwin wakeup of the app, and a connect burst appends dozens of
+    /// log lines in a couple of seconds. Log-only mutations therefore batch on this serial
+    /// queue and flush at most every 250 ms; status/relay/error/recents changes flush
+    /// immediately and carry any pending log lines with them (the queue is FIFO, so ordering
+    /// between the two kinds is preserved). Worst case on an extension kill: the final ≤250 ms
+    /// of log lines are lost — terminal transitions are non-coalescable, so never the outcome.
+    private static let mutationQueue = DispatchQueue(label: "com.openrung.app.shared-connection-state")
+    private static var pendingSnapshot: ConnectionStateSnapshot?
+    private static var logFlushScheduled = false
 
     static func snapshot() -> ConnectionStateSnapshot {
         guard
@@ -80,7 +91,7 @@ enum SharedConnectionState {
     }
 
     static func appendLog(_ message: String) {
-        mutate { snapshot in
+        mutate(coalescable: true) { snapshot in
             snapshot.logLines = ActivityLog.appended(snapshot.logLines, ActivityLog.line(message))
         }
     }
@@ -97,9 +108,36 @@ enum SharedConnectionState {
 
     // MARK: - Persistence + notification
 
-    private static func mutate(_ transform: (inout ConnectionStateSnapshot) -> Void) {
-        var snapshot = snapshot()
-        transform(&snapshot)
+    private static func mutate(
+        coalescable: Bool = false,
+        _ transform: @escaping (inout ConnectionStateSnapshot) -> Void
+    ) {
+        mutationQueue.async {
+            var pending = pendingSnapshot ?? snapshot()
+            transform(&pending)
+            pendingSnapshot = pending
+            if coalescable {
+                scheduleLogFlush()
+            } else {
+                flushPendingOnQueue()
+            }
+        }
+    }
+
+    /// Must run on `mutationQueue`.
+    private static func scheduleLogFlush() {
+        guard !logFlushScheduled else { return }
+        logFlushScheduled = true
+        mutationQueue.asyncAfter(deadline: .now() + .milliseconds(250)) {
+            flushPendingOnQueue()
+        }
+    }
+
+    /// Must run on `mutationQueue`.
+    private static func flushPendingOnQueue() {
+        logFlushScheduled = false
+        guard let snapshot = pendingSnapshot else { return }
+        pendingSnapshot = nil
         guard let data = try? JSONEncoder().encode(snapshot) else { return }
         defaults?.set(data, forKey: key)
         postDarwinNotification()

--- a/ios/Shared/SingBoxConfiguration.swift
+++ b/ios/Shared/SingBoxConfiguration.swift
@@ -151,9 +151,17 @@ public struct SingBoxConfiguration: Equatable, Sendable {
             }
         }
 
+        // "info" logs every flow and DNS query — each line crosses the gomobile boundary and
+        // costs CPU inside the 50 MB extension, so release builds keep only warnings.
+        #if DEBUG
+        let logLevel = "info"
+        #else
+        let logLevel = "warn"
+        #endif
+
         return [
             "log": [
-                "level": "info",
+                "level": logLevel,
                 "timestamp": true
             ],
             "dns": dns,

--- a/ios/Shared/TelemetryManager.swift
+++ b/ios/Shared/TelemetryManager.swift
@@ -47,6 +47,13 @@ enum TelemetryManager {
         return sessionTraffic
     }
 
+    /// Cumulative session counters as last pushed by the engine (nil before the first push).
+    /// The tunnel health monitor compares successive values to skip probing while traffic is
+    /// demonstrably flowing.
+    static func currentTrafficCounters() -> TrafficCounters? {
+        trafficCounters()
+    }
+
     private static func resetTrafficCounters() {
         trafficLock.lock()
         defer { trafficLock.unlock() }

--- a/ios/Shared/TelemetryManager.swift
+++ b/ios/Shared/TelemetryManager.swift
@@ -169,9 +169,15 @@ enum TelemetryManager {
         )
     }
 
-    private static func iso8601Now() -> String {
+    // Constructing an ISO8601DateFormatter per event costs far more than formatting with one;
+    // the class is documented thread-safe.
+    private static let iso8601Formatter: ISO8601DateFormatter = {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        return formatter.string(from: Date())
+        return formatter
+    }()
+
+    private static func iso8601Now() -> String {
+        iso8601Formatter.string(from: Date())
     }
 }

--- a/ios/Shared/TelemetryOutbox.swift
+++ b/ios/Shared/TelemetryOutbox.swift
@@ -1,18 +1,48 @@
 import Foundation
 
-/// Native VPN telemetry outbox backed by a single JSON file in the App Group container.
-/// PacketTunnel heartbeat/session events use this queue; React Native speed-test telemetry goes
-/// directly through `OpenRungBroker`. Read-modify-write remains coordinated and atomic.
-/// Port of the outbox half of Android `TelemetryManager`.
+/// Native VPN telemetry outbox in the App Group container, stored as append-only NDJSON (one
+/// event per line). PacketTunnel heartbeat/session events use this queue; React Native
+/// speed-test telemetry goes directly through `OpenRungBroker`.
+///
+/// Appending encodes and writes ONE event; the previous single-JSON-array format decoded and
+/// re-encoded the entire queue (up to 500 events, hundreds of KB) on every enqueue — an O(n²)
+/// CPU/memory pattern inside the extension's ~50 MB jetsam budget, worst exactly when a blocked
+/// network keeps the queue full. Full rewrites now happen only on upload commits, geo
+/// back-patches, and occasional compaction; a torn final line from an extension kill is skipped
+/// on read. A legacy array-format file is migrated transparently on first touch.
+/// Read-modify-write remains coordinated and atomic. Port of the outbox half of Android
+/// `TelemetryManager`.
 enum TelemetryOutbox {
-    private static var fileURL: URL? {
-        FileManager.default
-            .containerURL(forSecurityApplicationGroupIdentifier: AppConfig.appGroupIdentifier)?
-            .appendingPathComponent(AppConfig.telemetryOutboxFilename)
-    }
+    private static let fileURL: URL? = FileManager.default
+        .containerURL(forSecurityApplicationGroupIdentifier: AppConfig.appGroupIdentifier)?
+        .appendingPathComponent(AppConfig.telemetryOutboxFilename)
+
+    /// Appends since the last full rewrite (process-local; only the extension writes). Once the
+    /// file could hold twice the in-memory cap, the next enqueue compacts it.
+    private static var uncompactedAppends = 0
 
     static func enqueue(_ event: TelemetryEvent) {
-        mutate { TelemetryOutboxState.appended($0, event) }
+        guard let url = fileURL, var line = try? JSONEncoder().encode(event) else { return }
+        line.append(UInt8(ascii: "\n"))
+        var coordinatorError: NSError?
+        NSFileCoordinator().coordinate(writingItemAt: url, options: [], error: &coordinatorError) { writeURL in
+            if isLegacyArrayFile(writeURL) || uncompactedAppends >= TelemetryOutboxState.maxQueued {
+                // Migrate/compact: fold the new event in through a full rewrite.
+                let events = TelemetryOutboxState.appended(decodeEvents(at: writeURL), event)
+                write(events, to: writeURL)
+                return
+            }
+            guard let handle = try? FileHandle(forWritingTo: writeURL) else {
+                // File missing (first event): create it with the single line.
+                try? line.write(to: writeURL, options: .atomic)
+                uncompactedAppends += 1
+                return
+            }
+            defer { try? handle.close() }
+            _ = try? handle.seekToEnd()
+            try? handle.write(contentsOf: line)
+            uncompactedAppends += 1
+        }
     }
 
     static func peek(max: Int) -> [TelemetryEvent] {
@@ -35,26 +65,55 @@ enum TelemetryOutbox {
         var events: [TelemetryEvent] = []
         var coordinatorError: NSError?
         NSFileCoordinator().coordinate(readingItemAt: url, options: [], error: &coordinatorError) { readURL in
-            guard let data = try? Data(contentsOf: readURL) else { return }
-            events = (try? JSONDecoder().decode([TelemetryEvent].self, from: data)) ?? []
+            events = decodeEvents(at: readURL)
         }
         return events
     }
 
+    /// Full read-transform-rewrite; reserved for the rare mutations (upload commit, geo
+    /// back-patch) that genuinely touch the whole queue.
     private static func mutate(_ transform: ([TelemetryEvent]) -> [TelemetryEvent]) {
         guard let url = fileURL else { return }
         var coordinatorError: NSError?
         NSFileCoordinator().coordinate(writingItemAt: url, options: [], error: &coordinatorError) { writeURL in
-            let current: [TelemetryEvent]
-            if let data = try? Data(contentsOf: writeURL) {
-                current = (try? JSONDecoder().decode([TelemetryEvent].self, from: data)) ?? []
-            } else {
-                current = []
-            }
-            let updated = transform(current)
-            if let data = try? JSONEncoder().encode(updated) {
-                try? data.write(to: writeURL, options: .atomic)
+            write(transform(decodeEvents(at: writeURL)), to: writeURL)
+        }
+    }
+
+    /// Must run inside a coordination block.
+    private static func write(_ events: [TelemetryEvent], to url: URL) {
+        let encoder = JSONEncoder()
+        var data = Data()
+        for event in events {
+            guard let line = try? encoder.encode(event) else { continue }
+            data.append(line)
+            data.append(UInt8(ascii: "\n"))
+        }
+        try? data.write(to: url, options: .atomic)
+        uncompactedAppends = 0
+    }
+
+    /// Must run inside a coordination block. Decodes NDJSON, or the legacy array format, capped
+    /// at the queue maximum (newest kept).
+    private static func decodeEvents(at url: URL) -> [TelemetryEvent] {
+        guard let data = try? Data(contentsOf: url), data.isEmpty == false else { return [] }
+        let decoder = JSONDecoder()
+        let events: [TelemetryEvent]
+        if data.first == UInt8(ascii: "[") {
+            events = (try? decoder.decode([TelemetryEvent].self, from: data)) ?? []
+        } else {
+            events = data.split(separator: UInt8(ascii: "\n")).compactMap {
+                try? decoder.decode(TelemetryEvent.self, from: $0)
             }
         }
+        return Array(events.suffix(TelemetryOutboxState.maxQueued))
+    }
+
+    /// Must run inside a coordination block. Cheap first-byte sniff for the pre-NDJSON format.
+    private static func isLegacyArrayFile(_ url: URL) -> Bool {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return false }
+        defer { try? handle.close() }
+        guard let first = try? handle.read(upToCount: 1), let byte = first.first else { return false }
+        return byte == UInt8(ascii: "[")
     }
 }

--- a/ios/Shared/TelemetryOutbox.swift
+++ b/ios/Shared/TelemetryOutbox.swift
@@ -17,16 +17,22 @@ enum TelemetryOutbox {
         .containerURL(forSecurityApplicationGroupIdentifier: AppConfig.appGroupIdentifier)?
         .appendingPathComponent(AppConfig.telemetryOutboxFilename)
 
-    /// Appends since the last full rewrite (process-local; only the extension writes). Once the
-    /// file could hold twice the in-memory cap, the next enqueue compacts it.
-    private static var uncompactedAppends = 0
+    /// Approximate line count of the outbox file (process-local; only the extension writes).
+    /// Initialized by COUNTING the file on first touch — a per-launch zero would let the file
+    /// grow without bound across extension restarts that each append fewer than the compaction
+    /// threshold. Refreshed by every full rewrite; once the file could hold twice the in-memory
+    /// cap, the next enqueue compacts it.
+    private static var fileLineCount = -1
 
     static func enqueue(_ event: TelemetryEvent) {
         guard let url = fileURL, var line = try? JSONEncoder().encode(event) else { return }
         line.append(UInt8(ascii: "\n"))
         var coordinatorError: NSError?
         NSFileCoordinator().coordinate(writingItemAt: url, options: [], error: &coordinatorError) { writeURL in
-            if isLegacyArrayFile(writeURL) || uncompactedAppends >= TelemetryOutboxState.maxQueued {
+            if fileLineCount < 0 {
+                fileLineCount = countLines(at: writeURL)
+            }
+            if isLegacyArrayFile(writeURL) || fileLineCount >= 2 * TelemetryOutboxState.maxQueued {
                 // Migrate/compact: fold the new event in through a full rewrite.
                 let events = TelemetryOutboxState.appended(decodeEvents(at: writeURL), event)
                 write(events, to: writeURL)
@@ -35,13 +41,35 @@ enum TelemetryOutbox {
             guard let handle = try? FileHandle(forWritingTo: writeURL) else {
                 // File missing (first event): create it with the single line.
                 try? line.write(to: writeURL, options: .atomic)
-                uncompactedAppends += 1
+                fileLineCount = 1
                 return
             }
             defer { try? handle.close() }
+            repairTornTail(handle)
             _ = try? handle.seekToEnd()
             try? handle.write(contentsOf: line)
-            uncompactedAppends += 1
+            fileLineCount += 1
+        }
+    }
+
+    /// Must run inside a coordination block. A write torn by an extension kill can leave the
+    /// final line without its newline; appending straight onto it would fuse two events into
+    /// one undecodable line, losing both. Truncate back to the last complete line first.
+    private static func repairTornTail(_ handle: FileHandle) {
+        guard let end = try? handle.seekToEnd(), end > 0 else { return }
+        try? handle.seek(toOffset: end - 1)
+        guard let last = try? handle.read(upToCount: 1), last.first != UInt8(ascii: "\n") else { return }
+        try? handle.seek(toOffset: 0)
+        let data = (try? handle.readToEnd()) ?? Data()
+        let keep = data.lastIndex(of: UInt8(ascii: "\n")).map { UInt64($0) + 1 } ?? 0
+        try? handle.truncate(atOffset: keep)
+    }
+
+    /// Must run inside a coordination block.
+    private static func countLines(at url: URL) -> Int {
+        guard let data = try? Data(contentsOf: url) else { return 0 }
+        return data.reduce(into: 0) { count, byte in
+            if byte == UInt8(ascii: "\n") { count += 1 }
         }
     }
 
@@ -90,7 +118,7 @@ enum TelemetryOutbox {
             data.append(UInt8(ascii: "\n"))
         }
         try? data.write(to: url, options: .atomic)
-        uncompactedAppends = 0
+        fileLineCount = events.count
     }
 
     /// Must run inside a coordination block. Decodes NDJSON, or the legacy array format, capped

--- a/ios/Shared/TelemetrySessionStore.swift
+++ b/ios/Shared/TelemetrySessionStore.swift
@@ -7,9 +7,9 @@ import Foundation
 enum TelemetrySessionStore {
     private static let key = "telemetry_session"
 
-    private static var defaults: UserDefaults? {
-        UserDefaults(suiteName: AppConfig.appGroupIdentifier)
-    }
+    // One suite instance for the process lifetime: the computed-property form re-registered a
+    // fresh UserDefaults with cfprefsd on every telemetry record.
+    private static let defaults: UserDefaults? = UserDefaults(suiteName: AppConfig.appGroupIdentifier)
 
     static func current() -> TelemetrySession? {
         guard let data = defaults?.data(forKey: key) else { return nil }

--- a/src/components/ConnectCard.tsx
+++ b/src/components/ConnectCard.tsx
@@ -113,7 +113,7 @@ interface FillGeometry {
   r: number;
 }
 
-export function ConnectCard({
+export const ConnectCard = React.memo(function ConnectCardComponent({
   status,
   relayName,
   isConnected,
@@ -260,7 +260,7 @@ export function ConnectCard({
 
     </View>
   );
-}
+});
 
 const styles = StyleSheet.create({
   card: {

--- a/src/components/ConsolePanel.tsx
+++ b/src/components/ConsolePanel.tsx
@@ -19,6 +19,20 @@ export interface ConsolePanelProps {
   style?: StyleProp<ViewStyle>;
 }
 
+/**
+ * Content-stable keys for an append-only ring buffer. Index-based keys shift on every append
+ * once the 80-line cap is hit, remounting all Text nodes per line; keying by the line plus its
+ * occurrence ordinal keeps existing rows mounted (only rows after a dropped duplicate remap).
+ */
+function keyedLines(lines: string[]): { key: string; line: string }[] {
+  const seen = new Map<string, number>();
+  return lines.map(line => {
+    const ordinal = seen.get(line) ?? 0;
+    seen.set(line, ordinal + 1);
+    return { key: `${line}#${ordinal}`, line };
+  });
+}
+
 export function ConsolePanel({
   logLines,
   lastError,
@@ -32,8 +46,8 @@ export function ConsolePanel({
     <View style={[styles.panel, style]}>
       <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
         {showMockNotice ? <Text style={styles.mockNotice}>[mock native module]</Text> : null}
-        {lines.map((line, index) => (
-          <Text key={`${index}-${line}`} style={styles.logLine}>
+        {keyedLines(lines).map(({ key, line }) => (
+          <Text key={key} style={styles.logLine}>
             {s.logLineFormat(line)}
           </Text>
         ))}

--- a/src/components/ExitNodeMap.tsx
+++ b/src/components/ExitNodeMap.tsx
@@ -55,6 +55,54 @@ const ASIA_PACIFIC_ZOOM = 2.2;
 const MIN_ZOOM = 1.2;
 const MAX_ZOOM = 4.8;
 
+// Module-level constants for every static Layer/Camera/hitbox prop: fresh object literals per
+// render would make RN re-diff (and potentially re-push) all map-layer props on each pass.
+const INITIAL_VIEW_STATE = { center: ASIA_PACIFIC_CENTER, zoom: ASIA_PACIFIC_ZOOM };
+const NODE_HITBOX = { top: 28, right: 28, bottom: 28, left: 28 };
+const HALO_OUTER_PAINT = {
+  'circle-radius': 27,
+  'circle-color': NODE_GREEN,
+  'circle-opacity': 0.07,
+};
+const HALO_PAINT = {
+  'circle-radius': 18,
+  'circle-color': NODE_GREEN,
+  'circle-opacity': 0.18,
+};
+const CORE_PAINT = {
+  'circle-radius': 6,
+  'circle-color': NODE_GREEN,
+  'circle-stroke-color': NODE_STROKE,
+  'circle-stroke-width': 2,
+};
+const COUNT_LAYOUT = {
+  'text-field': '{count}',
+  'text-font': ['Open Sans Semibold'],
+  'text-size': 11,
+  'text-offset': [0, -1.6] as [number, number],
+  'text-allow-overlap': true,
+  'text-ignore-placement': true,
+};
+const COUNT_PAINT = {
+  'text-color': NODE_GREEN,
+  'text-halo-color': NODE_STROKE,
+  'text-halo-width': 1.4,
+};
+const LABEL_LAYOUT = {
+  'text-field': '{label}',
+  'text-font': ['Open Sans Semibold'],
+  'text-size': 10,
+  'text-offset': [0, 1.4] as [number, number],
+  'text-anchor': 'top' as const,
+  // Unlike the count, labels yield on collision so dense clusters stay readable.
+};
+const LABEL_PAINT = {
+  'text-color': NODE_GREEN,
+  'text-halo-color': NODE_STROKE,
+  'text-halo-width': 1.2,
+  'text-opacity': 0.9,
+};
+
 export interface ExitNodeMapProps {
   regions: ExitNodeRegion[];
   onRegionPress: (countryCode: string) => void;
@@ -154,81 +202,19 @@ export function ExitNodeMap({
       androidView="texture"
       accessibilityLabel={s.mapContentDescription}
     >
-      <Camera
-        initialViewState={{ center: ASIA_PACIFIC_CENTER, zoom: ASIA_PACIFIC_ZOOM }}
-        minZoom={MIN_ZOOM}
-        maxZoom={MAX_ZOOM}
-      />
+      <Camera initialViewState={INITIAL_VIEW_STATE} minZoom={MIN_ZOOM} maxZoom={MAX_ZOOM} />
       <GeoJSONSource
         id={NODE_SOURCE}
         data={nodeCollection}
         onPress={handleNodePress}
         // Generous hit box around the dot (production queries a 28px-padded square).
-        hitbox={{ top: 28, right: 28, bottom: 28, left: 28 }}
+        hitbox={NODE_HITBOX}
       >
-        <Layer
-          id={`${NODE_HALO_LAYER}-outer`}
-          type="circle"
-          paint={{
-            'circle-radius': 27,
-            'circle-color': NODE_GREEN,
-            'circle-opacity': 0.07,
-          }}
-        />
-        <Layer
-          id={NODE_HALO_LAYER}
-          type="circle"
-          paint={{
-            'circle-radius': 18,
-            'circle-color': NODE_GREEN,
-            'circle-opacity': 0.18,
-          }}
-        />
-        <Layer
-          id={NODE_CORE_LAYER}
-          type="circle"
-          paint={{
-            'circle-radius': 6,
-            'circle-color': NODE_GREEN,
-            'circle-stroke-color': NODE_STROKE,
-            'circle-stroke-width': 2,
-          }}
-        />
-        <Layer
-          id={NODE_COUNT_LAYER}
-          type="symbol"
-          layout={{
-            'text-field': '{count}',
-            'text-font': ['Open Sans Semibold'],
-            'text-size': 11,
-            'text-offset': [0, -1.6],
-            'text-allow-overlap': true,
-            'text-ignore-placement': true,
-          }}
-          paint={{
-            'text-color': NODE_GREEN,
-            'text-halo-color': NODE_STROKE,
-            'text-halo-width': 1.4,
-          }}
-        />
-        <Layer
-          id={NODE_LABEL_LAYER}
-          type="symbol"
-          layout={{
-            'text-field': '{label}',
-            'text-font': ['Open Sans Semibold'],
-            'text-size': 10,
-            'text-offset': [0, 1.4],
-            'text-anchor': 'top',
-            // Unlike the count, labels yield on collision so dense clusters stay readable.
-          }}
-          paint={{
-            'text-color': NODE_GREEN,
-            'text-halo-color': NODE_STROKE,
-            'text-halo-width': 1.2,
-            'text-opacity': 0.9,
-          }}
-        />
+        <Layer id={`${NODE_HALO_LAYER}-outer`} type="circle" paint={HALO_OUTER_PAINT} />
+        <Layer id={NODE_HALO_LAYER} type="circle" paint={HALO_PAINT} />
+        <Layer id={NODE_CORE_LAYER} type="circle" paint={CORE_PAINT} />
+        <Layer id={NODE_COUNT_LAYER} type="symbol" layout={COUNT_LAYOUT} paint={COUNT_PAINT} />
+        <Layer id={NODE_LABEL_LAYER} type="symbol" layout={LABEL_LAYOUT} paint={LABEL_PAINT} />
       </GeoJSONSource>
       {children}
     </MapLibreMap>

--- a/src/components/MapStatusChip.tsx
+++ b/src/components/MapStatusChip.tsx
@@ -21,7 +21,7 @@ export interface MapStatusChipProps {
   style?: StyleProp<ViewStyle>;
 }
 
-export function MapStatusChip({
+export const MapStatusChip = React.memo(function MapStatusChipComponent({
   directoryStatus,
   regionCount,
   onRetry,
@@ -53,7 +53,7 @@ export function MapStatusChip({
     );
   }
   return <View style={[styles.chip, style]}>{label}</View>;
-}
+});
 
 const styles = StyleSheet.create({
   chip: {

--- a/src/components/NativeTabs.tsx
+++ b/src/components/NativeTabs.tsx
@@ -5,7 +5,7 @@
  * kept alive by the native tab controller, so the home map keeps its camera
  * and tiles across tab switches. Android keeps the custom JS TabBar.
  */
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import TabView, { type AppleIcon } from 'react-native-bottom-tabs';
 
 import { useStrings } from '../i18n';
@@ -20,13 +20,21 @@ const ICONS: Record<AppTab, AppleIcon> = {
   about: { sfSymbol: 'info.circle' },
 };
 
+const TAB_LABEL_STYLE = { fontFamily: monoFont };
+
 export interface NativeTabsProps {
   active: AppTab;
   onSelect: (tab: AppTab) => void;
   renderScene: (tab: AppTab) => React.ReactNode;
 }
 
-export function NativeTabs({ active, onSelect, renderScene }: NativeTabsProps): React.JSX.Element {
+/** Memoized (with stable prop objects) so re-renders above it don't push fresh props to the
+ * native tab controller on every pass. */
+export const NativeTabs = React.memo(function NativeTabsComponent({
+  active,
+  onSelect,
+  renderScene,
+}: NativeTabsProps): React.JSX.Element {
   const s = useStrings();
 
   const routes = useMemo(() => {
@@ -38,15 +46,27 @@ export function NativeTabs({ active, onSelect, renderScene }: NativeTabsProps): 
     return TAB_ORDER.map(tab => ({ key: tab, title: titles[tab], focusedIcon: ICONS[tab] }));
   }, [s]);
 
+  const navigationState = useMemo(
+    () => ({ index: TAB_ORDER.indexOf(active), routes }),
+    [active, routes],
+  );
+
+  const onIndexChange = useCallback((index: number) => onSelect(TAB_ORDER[index]), [onSelect]);
+
+  const renderRoute = useCallback(
+    ({ route }: { route: { key: string } }) => renderScene(route.key as AppTab),
+    [renderScene],
+  );
+
   return (
     <TabView
-      navigationState={{ index: TAB_ORDER.indexOf(active), routes }}
-      onIndexChange={index => onSelect(TAB_ORDER[index])}
-      renderScene={({ route }) => renderScene(route.key as AppTab)}
+      navigationState={navigationState}
+      onIndexChange={onIndexChange}
+      renderScene={renderRoute}
       tabBarActiveTintColor={palette.terminalGreen}
       tabBarInactiveTintColor={palette.dimText}
-      tabLabelStyle={{ fontFamily: monoFont }}
+      tabLabelStyle={TAB_LABEL_STYLE}
       hapticFeedbackEnabled
     />
   );
-}
+});

--- a/src/components/RecentsSection.tsx
+++ b/src/components/RecentsSection.tsx
@@ -34,7 +34,7 @@ function hasPinnedRelay(node: RecentNode): node is PinnedRecentNode {
   return (node.relayId?.trim().length ?? 0) > 0 && (node.relayName?.trim().length ?? 0) > 0;
 }
 
-export function RecentsSection({
+export const RecentsSection = React.memo(function RecentsSectionComponent({
   recents,
   liveRelayIds,
   onPress,
@@ -81,7 +81,7 @@ export function RecentsSection({
       />
     </View>
   );
-}
+});
 
 function PillGap(): React.JSX.Element {
   return <View style={styles.gap} />;

--- a/src/i18n/index.tsx
+++ b/src/i18n/index.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useEffect, useMemo } from 'react';
 import type { ConnectionStatus } from '../native/types';
-import { hydrateLanguage, setLanguageTag, useAppState } from '../state/store';
+import { hydrateLanguage, setLanguageTag, useAppSelector } from '../state/store';
 import { ar } from './strings/ar';
 import { en } from './strings/en';
 import type { Strings } from './strings/en';
@@ -128,7 +128,9 @@ const LanguageContext = createContext<LanguageContextValue>({
 });
 
 export function LanguageProvider({ children }: { children: React.ReactNode }): React.JSX.Element {
-  const { languageTag } = useAppState();
+  // Selector, not the whole store: the provider wraps the entire app, so it must only
+  // re-render when the language actually changes.
+  const languageTag = useAppSelector(current => current.languageTag);
 
   useEffect(() => {
     // Load the persisted selection (AsyncStorage key 'openrung.language') once on mount.

--- a/src/screens/MainScreen.tsx
+++ b/src/screens/MainScreen.tsx
@@ -37,9 +37,15 @@ import { ViewModeToggle } from '../components/ViewModeToggle';
 import { AppConfig } from '../config';
 import { resolveLanguage, useLanguage, useStrings } from '../i18n';
 import { pickLocalizedText } from '../model/updateStatus';
-import { hydrateHomeViewMode, refreshDirectory, setHomeViewMode } from '../state/store';
+import {
+  hydrateHomeViewMode,
+  refreshDirectory,
+  setHomeViewMode,
+  useAppSelector,
+  type AppState,
+} from '../state/store';
 import { dismissUpdateBanner, dismissUpdateNotice } from '../state/updateCheck';
-import { useVpnState } from '../state/useVpnState';
+import { useVpnActions } from '../state/useVpnState';
 import { monoFont, palette, tokens } from '../theme';
 
 /** Terminal-prompt wordmark: "OpenRung" + blinking block cursor + tagline. */
@@ -71,12 +77,46 @@ function Wordmark(): React.JSX.Element {
   );
 }
 
+/**
+ * Everything the home screen renders EXCEPT `native.logLines`: log lines change far more often
+ * than anything here (each one used to re-render the whole map tree), and only the Debug screen
+ * shows them. `useAppSelector`'s shallow comparison skips those events entirely.
+ */
+function selectMainScreenState(current: AppState) {
+  return {
+    status: current.native.status,
+    relayLabel: current.native.relayLabel,
+    relayName: current.native.relayName,
+    lastError: current.native.lastError,
+    recents: current.native.recents,
+    directoryStatus: current.directoryStatus,
+    availableRegions: current.availableRegions,
+    homeViewMode: current.homeViewMode,
+    connectedAtMs: current.connectedAtMs,
+    update: current.update,
+  };
+}
+
 export function MainScreen(): React.JSX.Element {
   const insets = useSafeAreaInsets();
   const s = useStrings();
   const { languageTag } = useLanguage();
-  const { state, isConnected, isWorking, disconnect, prepareAndConnect } = useVpnState();
-  const { native, directoryStatus, availableRegions, homeViewMode, connectedAtMs, update } = state;
+  const { disconnect, prepareAndConnect } = useVpnActions();
+  const {
+    status,
+    relayLabel,
+    relayName,
+    lastError,
+    recents,
+    directoryStatus,
+    availableRegions,
+    homeViewMode,
+    connectedAtMs,
+    update,
+  } = useAppSelector(selectMainScreenState);
+  const isConnected = status === 'connected';
+  const isWorking =
+    status === 'preparing' || status === 'connecting' || status === 'disconnecting';
   const isListMode = homeViewMode === 'list';
   const locale = resolveLanguage(languageTag);
 
@@ -165,10 +205,10 @@ export function MainScreen(): React.JSX.Element {
           <OceanTelemetry
             regions={availableRegions}
             directoryStatus={directoryStatus}
-            status={native.status}
-            relayLabel={native.relayLabel}
-            relayName={native.relayName}
-            lastError={native.lastError}
+            status={status}
+            relayLabel={relayLabel}
+            relayName={relayName}
+            lastError={lastError}
             connectedAtMs={connectedAtMs}
           />
         </ExitNodeMap>
@@ -237,14 +277,10 @@ export function MainScreen(): React.JSX.Element {
         )}
 
         <View style={styles.bottomStack} pointerEvents="box-none">
-          <RecentsSection
-            recents={native.recents}
-            liveRelayIds={liveRelayIds}
-            onPress={onConnectRelay}
-          />
+          <RecentsSection recents={recents} liveRelayIds={liveRelayIds} onPress={onConnectRelay} />
           <ConnectCard
-            status={native.status}
-            relayName={native.relayName}
+            status={status}
+            relayName={relayName}
             isConnected={isConnected}
             isWorking={isWorking}
             onToggle={onToggle}

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -33,13 +33,12 @@ import {
 import { OpenRungBrokerError } from '../native/OpenRungBroker';
 import { OpenRungVpn } from '../native/OpenRungVpn';
 import { runSpeedTest, type SpeedTestResult } from '../net/speedTestClient';
-import { useAppState } from '../state/store';
+import { useAppSelector } from '../state/store';
 import {
   buildSpeedTestCompletedEvent,
   buildSpeedTestFailedEvent,
   sendTelemetry,
 } from '../net/telemetryClient';
-import { useVpnState } from '../state/useVpnState';
 import { monoFont, palette, tokens } from '../theme';
 
 export interface SettingsScreenProps {
@@ -60,9 +59,11 @@ export function SettingsScreen({
 }: SettingsScreenProps): React.JSX.Element {
   const s = useStrings();
   const insets = useSafeAreaInsets();
-  const { state, isConnected } = useVpnState();
-  const { update } = state;
-  const { splitTunnel } = useAppState();
+  // Selectors, not the whole store: on iOS this scene stays mounted behind the other tabs, so
+  // it must not re-render on every mirrored native event (log lines, recents).
+  const isConnected = useAppSelector(current => current.native.status === 'connected');
+  const update = useAppSelector(current => current.update);
+  const splitTunnel = useAppSelector(current => current.splitTunnel);
 
   const [speedTestRunning, setSpeedTestRunning] = useState(false);
   const [speedTestResult, setSpeedTestResult] = useState<SpeedTestResult | null>(null);

--- a/src/screens/SplitTunnelingScreen.tsx
+++ b/src/screens/SplitTunnelingScreen.tsx
@@ -28,7 +28,7 @@ import {
   isAppListAvailable,
   type InstalledApp,
 } from '../native/OpenRungAppList';
-import { hydrateSplitTunnel, setSplitTunnel, useAppState } from '../state/store';
+import { hydrateSplitTunnel, setSplitTunnel, useAppSelector } from '../state/store';
 import { monoFont, palette, tokens } from '../theme';
 
 export interface SplitTunnelingScreenProps {
@@ -42,7 +42,7 @@ type CountryCode = (typeof COUNTRY_ORDER)[number];
 export function SplitTunnelingScreen({ onBack }: SplitTunnelingScreenProps): React.JSX.Element {
   const s = useStrings();
   const insets = useSafeAreaInsets();
-  const { splitTunnel } = useAppState();
+  const splitTunnel = useAppSelector(current => current.splitTunnel);
 
   useEffect(() => {
     // Ensure hydration has run when this screen is rendered outside the normal App launch flow.

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -1,12 +1,12 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { useSyncExternalStore } from 'react';
+import { useCallback, useRef, useSyncExternalStore } from 'react';
 import { AppConfig } from '../config';
 import type { DirectoryStatus, ExitNodeRegion, HomeViewMode } from '../model/exitNode';
 import { INITIAL_UPDATE_UI, type UpdateUiState } from '../model/updateStatus';
 import { firstReachable } from '../net/brokerClient';
 import { loadExitNodeDirectory } from '../net/exitNodeDirectory';
 import { OpenRungVpn } from '../native/OpenRungVpn';
-import type { NativeVpnState } from '../native/types';
+import type { NativeVpnState, RecentNode } from '../native/types';
 
 /**
  * Minimal external store holding the contract §4 AppState (mirrors the production
@@ -99,9 +99,72 @@ export function subscribe(listener: () => void): () => void {
   };
 }
 
-/** React hook over the external store. */
+/** React hook over the external store. Subscribes to EVERY store change — prefer
+ * `useAppSelector` in components, so a native event (e.g. a debug log line) only re-renders
+ * consumers whose selected slice actually changed. */
 export function useAppState(): AppState {
   return useSyncExternalStore(subscribe, getSnapshot);
+}
+
+/** Shallow equality over primitives, arrays (element-wise) and plain objects (own keys). */
+function shallowEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) {
+    return true;
+  }
+  if (typeof a !== 'object' || a == null || typeof b !== 'object' || b == null) {
+    return false;
+  }
+  if (Array.isArray(a) || Array.isArray(b)) {
+    return (
+      Array.isArray(a) &&
+      Array.isArray(b) &&
+      a.length === b.length &&
+      a.every((value, index) => Object.is(value, b[index]))
+    );
+  }
+  const keysA = Object.keys(a);
+  const keysB = Object.keys(b);
+  return (
+    keysA.length === keysB.length &&
+    keysA.every(
+      key =>
+        Object.prototype.hasOwnProperty.call(b, key) &&
+        Object.is((a as Record<string, unknown>)[key], (b as Record<string, unknown>)[key]),
+    )
+  );
+}
+
+/**
+ * Subscribes to the slice a component actually renders. The selected value is cached per hook:
+ * while the freshly selected value stays shallow-equal, the previous reference is returned and
+ * React bails out of the re-render. This is what keeps high-frequency native events (log lines
+ * during a connect) from re-rendering the map/tab tree.
+ */
+export function useAppSelector<T>(
+  selector: (current: AppState) => T,
+  isEqual: (a: T, b: T) => boolean = shallowEqual,
+): T {
+  const cacheRef = useRef<{ snapshot: AppState; selected: T } | null>(null);
+  // Latest selector/equality without re-subscribing (the standard external-store shim pattern).
+  const selectorRef = useRef(selector);
+  const isEqualRef = useRef(isEqual);
+  selectorRef.current = selector;
+  isEqualRef.current = isEqual;
+
+  const getSelected = useCallback((): T => {
+    const snapshot = getSnapshot();
+    const cache = cacheRef.current;
+    if (cache !== null && cache.snapshot === snapshot) {
+      return cache.selected;
+    }
+    const next = selectorRef.current(snapshot);
+    const selected =
+      cache !== null && isEqualRef.current(cache.selected, next) ? cache.selected : next;
+    cacheRef.current = { snapshot, selected };
+    return selected;
+  }, []);
+
+  return useSyncExternalStore(subscribe, getSelected);
 }
 
 /**
@@ -118,9 +181,54 @@ function nextConnectedAtMs(previous: AppState, native: NativeVpnState): number |
     : Date.now();
 }
 
+function sameRecent(a: RecentNode, b: RecentNode): boolean {
+  return (
+    a.countryCode === b.countryCode &&
+    a.relayId === b.relayId &&
+    a.label === b.label &&
+    a.relayName === b.relayName &&
+    a.latitude === b.latitude &&
+    a.longitude === b.longitude
+  );
+}
+
+/**
+ * Every bridge event materializes fresh arrays even when their content did not change. Reuse the
+ * previous references for content-equal `logLines`/`recents` (and the whole native slice when the
+ * event is a no-op) so `useAppSelector`'s shallow comparison can skip re-renders.
+ */
+function stabilizedNative(previous: NativeVpnState, next: NativeVpnState): NativeVpnState {
+  const logLines =
+    previous.logLines.length === next.logLines.length &&
+    next.logLines.every((line, index) => line === previous.logLines[index])
+      ? previous.logLines
+      : next.logLines;
+  const recents =
+    previous.recents.length === next.recents.length &&
+    next.recents.every((node, index) => sameRecent(node, previous.recents[index]))
+      ? previous.recents
+      : next.recents;
+  if (
+    logLines === previous.logLines &&
+    recents === previous.recents &&
+    previous.status === next.status &&
+    previous.relayLabel === next.relayLabel &&
+    previous.relayName === next.relayName &&
+    previous.lastError === next.lastError
+  ) {
+    return previous;
+  }
+  return { ...next, logLines, recents };
+}
+
 /** Mirrors a `NativeVpnState` (from getState() or an openrungStateChanged event) into the store. */
 export function applyNativeState(native: NativeVpnState): void {
-  setState({ ...state, native, connectedAtMs: nextConnectedAtMs(state, native) });
+  const stabilized = stabilizedNative(state.native, native);
+  const connectedAtMs = nextConnectedAtMs(state, stabilized);
+  if (stabilized === state.native && connectedAtMs === state.connectedAtMs) {
+    return; // content-identical event — nothing to publish
+  }
+  setState({ ...state, native: stabilized, connectedAtMs });
 }
 
 /**

--- a/src/state/useVpnState.ts
+++ b/src/state/useVpnState.ts
@@ -4,12 +4,7 @@ import { OpenRungVpn, subscribeVpnState } from '../native/OpenRungVpn';
 import { applyNativeState, flushSplitTunnelPush, useAppState } from './store';
 import type { AppState } from './store';
 
-export interface VpnStateHook {
-  state: AppState;
-  /** preparing | connecting | disconnecting */
-  isWorking: boolean;
-  /** connected */
-  isConnected: boolean;
+export interface VpnActions {
   /**
    * Start (or switch) the tunnel; country: ISO alpha-2 or omitted/null = broker picks.
    * relayId: connect to that exact broker relay (takes precedence over country).
@@ -25,36 +20,58 @@ export interface VpnStateHook {
   prepareAndConnect: (country?: string | null, relayId?: string | null) => Promise<void>;
 }
 
-/**
- * Wires native VPN events into the store: on mount, seeds the native slice via `getState()` and
- * subscribes to `openrungStateChanged`; exposes derived flags and the connect/disconnect actions.
- */
-export function useVpnState(): VpnStateHook {
-  const state = useAppState();
+export interface VpnStateHook extends VpnActions {
+  state: AppState;
+  /** preparing | connecting | disconnecting */
+  isWorking: boolean;
+  /** connected */
+  isConnected: boolean;
+}
 
-  useEffect(() => {
-    let mounted = true;
-    let receivedEvent = false;
-    // Subscribe FIRST so no event is missed, and track whether one has arrived: a slow getState()
-    // seed must not clobber a fresher event that landed while it was in flight (e.g. mounting during
-    // a connecting -> connected transition).
-    const unsubscribe = subscribeVpnState(nativeState => {
-      receivedEvent = true;
-      applyNativeState(nativeState);
+/**
+ * One app-lifetime subscription mirrors native VPN events into the store, no matter how many
+ * components read from it: on first use it subscribes to `openrungStateChanged`, then seeds the
+ * native slice via `getState()`. Subscribing FIRST means no event is missed, and the seed is
+ * skipped once an event has arrived: a slow getState() must not clobber a fresher event that
+ * landed while it was in flight (e.g. wiring up during a connecting -> connected transition).
+ * The subscription is deliberately never torn down — components come and go, the mirror stays.
+ */
+let nativeStateWired = false;
+
+function ensureNativeStateWired(): void {
+  if (nativeStateWired) {
+    return;
+  }
+  nativeStateWired = true;
+  let receivedEvent = false;
+  subscribeVpnState(nativeState => {
+    receivedEvent = true;
+    applyNativeState(nativeState);
+  });
+  OpenRungVpn.getState()
+    .then(nativeState => {
+      if (!receivedEvent) {
+        applyNativeState(nativeState);
+      }
+    })
+    .catch(() => {
+      // Native state stays at the store default until the first event arrives.
     });
-    OpenRungVpn.getState()
-      .then(nativeState => {
-        if (mounted && !receivedEvent) {
-          applyNativeState(nativeState);
-        }
-      })
-      .catch(() => {
-        // Native state stays at the store default until the first event arrives.
-      });
-    return () => {
-      mounted = false;
-      unsubscribe();
-    };
+}
+
+/** Test-only: lets a fresh test file re-run the wiring against a reset store/mock. */
+export function resetNativeStateWiringForTests(): void {
+  nativeStateWired = false;
+}
+
+/**
+ * Connect/disconnect actions plus the native-event wiring, without subscribing to any state:
+ * components that only trigger transitions (or select their own slices via `useAppSelector`)
+ * use this and skip the re-render-on-every-event cost of `useVpnState`.
+ */
+export function useVpnActions(): VpnActions {
+  useEffect(() => {
+    ensureNativeStateWired();
   }, []);
 
   const connect = useCallback(
@@ -82,10 +99,22 @@ export function useVpnState(): VpnStateHook {
     [connect],
   );
 
+  return { connect, disconnect, prepareAndConnect };
+}
+
+/**
+ * Full-state variant: subscribes to the ENTIRE store, so the component re-renders on every
+ * mirrored native event — including log lines. Only for consumers that render the log itself
+ * (Debug screen); everything else should pair `useVpnActions` with `useAppSelector`.
+ */
+export function useVpnState(): VpnStateHook {
+  const state = useAppState();
+  const actions = useVpnActions();
+
   const status = state.native.status;
   const isWorking =
     status === 'preparing' || status === 'connecting' || status === 'disconnecting';
   const isConnected = status === 'connected';
 
-  return { state, isWorking, isConnected, connect, disconnect, prepareAndConnect };
+  return { state, isWorking, isConnected, ...actions };
 }


### PR DESCRIPTION
Five independent performance fixes across iOS, Android, and the React Native layer, from a cross-platform review of both apps. One commit per slice; each intermediate state compiled and passed tests during development.

## The slices

1. **`perf: coarsen libbox status interval and gate debug logging by build type`** — libbox pushed traffic counters every 3 s over loopback gRPC on both platforms for values only the ~60 s heartbeat reads; now 60 s. Release builds stop running libbox in debug mode: log ring 3000→300 lines (it lived inside the iOS extension's ~50 MB jetsam budget), sing-box log level info→warn (info logs every flow), and Android stops fanning every libbox line into the status store + JS bridge.
2. **`perf(android): move VPN service work off the main thread`** — the whole connect/teardown path (config validation, `Libbox.setup`, engine start/stop that can block on a latch) ran on `Dispatchers.Main.immediate`. Now a dedicated single background thread (`limitedParallelism(1)`) — still one thread because the class's race handling relies on single-thread confinement — with lifecycle callbacks posting to it. Removes the ANR class of risk.
3. **`perf: selector-based store reads and coalesced native state events`** — every native event (including each log line during connect, 30–60 in seconds) replaced the whole JS store snapshot and re-rendered the entire tree through 2–3 duplicate subscriptions. Now: `useAppSelector` with shallow-equal caching + reference-stabilized arrays, one app-lifetime subscription, memoized map/tab/card components, stable MapLibre layer props, non-index ConsolePanel keys. Natively, log-only emissions coalesce (250 ms trailing, full snapshot; status/relay/error/recents changes emit immediately) and the iOS extension batches its shared-state UserDefaults writes + Darwin notifications the same way. The contract-§3 event payload shape is deliberately unchanged (no delta protocol) so stale-APK/fresh-JS pairings keep working.
4. **`perf: append-only NDJSON telemetry outbox on both platforms`** — recording one event decoded, rebuilt, re-encoded and rewrote the entire 500-event queue (O(n²) per session, worst on blocked networks that never drain, with allocation spikes inside the iOS extension's memory budget). Now append-only NDJSON, one line per event; full rewrites only on upload commits, geo back-patch, and amortized compaction. Legacy formats migrate transparently on both platforms; torn final lines are skipped. Device attributes are cached (static parts once; Android's two binder calls behind a 5 s TTL). Upload wire format unchanged.
5. **`perf: back off tunnel health probes; enable R8 with keep rules`** — the through-tunnel probe (fresh TCP+TLS every 25–35 s, ~2,900/day, dominant idle-battery cost on cellular) now skips itself when traffic counters prove bytes are flowing and doubles its interval on sustained health (30 s → 5 min cap), snapping back to 30 s on any suspicion — failure-detection latency after a failure is unchanged, preserving the availability-first design. Android's outage poll backs off 5 s → 60 s. Release builds get R8 + `shrinkResources` with keep rules for the gomobile/libbox JNI surface and kotlinx.serialization models.

## Verification

- TypeScript clean, ESLint clean (no new warnings), all 249 Jest tests pass.
- Android: `compileDebugKotlin` + all 193 JUnit/Robolectric tests pass (telemetry test helpers updated to the new outbox file; the pre-upgrade-scrub test now covers the migration path).
- iOS: PacketTunnel target builds Debug + Release; full app target builds through CocoaPods; entire XCTest suite passes on the final tree.
- **Live end-to-end on the R8 release APK** (Pixel emulator): install → launch → VPN consent → **connect to a real relay (CONNECTED, OS VPN active)** → clean disconnect, zero crashes/ANRs. That exercises the shrunk dex through the broker fetch, kotlinx-serialization decode, punch/relay ladder, libbox engine, and the new outbox + coalesced event paths in one pass.

## Not included (follow-ups from the same review, impact-ordered)

iOS `LibboxPacketTunnelPlatformInterface.tunnelProvider` retain cycle (`weak` fix), duplicate per-relay config preflights (biggest remaining time-to-connect lever), OceanTelemetry's 1 Hz tick without an AppState gate, consolidating the extension's 3–4 `NWPathMonitor`s, broker connection reuse for heartbeats, splitting the 71 KB licenses module, per-connect rule-set asset re-copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)