### PR TITLE
Fix telemetry delivery before VPN teardown

### DIFF
--- a/android/app/src/main/java/com/openrung/config/AppConfig.kt
+++ b/android/app/src/main/java/com/openrung/config/AppConfig.kt
@@ -9,14 +9,11 @@ object AppConfig {
     const val DEFAULT_BROKER_URL = "https://broker.openrung.org/"
 
     /**
-     * Telemetry / heartbeat / speed-test target. Uses the same Cloudflare-fronted HTTPS broker as
-     * discovery, so this traffic is TLS-protected — the app never sends anything in cleartext. Kept as
-     * a separate constant from [DEFAULT_BROKER_URL] because telemetry is high-volume (heartbeats fire
-     * ~once/minute per connected user), so it consumes the Cloudflare Worker free-tier request quota
-     * (100k/day). If that quota becomes a constraint, the planned fix is to send telemetry
-     * direct-to-origin over TLS via a dedicated unproxied hostname — "Option A" in
-     * docs/ARCHITECTURE.md § "Network transport". Never revert to a raw-IP HTTP endpoint: that leaked
-     * the user's real pre-VPN IP, geo and stable client ID in cleartext.
+     * Bootstrap telemetry / heartbeat target used until verified relay discovery selects a live
+     * broker front. The active telemetry session then follows that exact winner, so a client that
+     * reached discovery through fallback does not post its diagnostics back to a blocked primary.
+     * Never use a raw-IP HTTP endpoint: that would expose the user's pre-VPN IP, geo and stable
+     * client ID in cleartext.
      */
     const val TELEMETRY_BROKER_URL = "https://broker.openrung.org/"
 

--- a/android/app/src/main/java/com/openrung/telemetry/TelemetryManager.kt
+++ b/android/app/src/main/java/com/openrung/telemetry/TelemetryManager.kt
@@ -175,6 +175,17 @@ object TelemetryManager {
     fun activeSession(): Session? = synchronized(lock) { activeSession }
 
     /**
+     * Routes the still-current session through the broker front that won verified discovery.
+     * The expected ID prevents a cancelled connect epoch from overwriting its successor's route.
+     */
+    fun updateBrokerUrl(sessionId: String, brokerUrl: String): Boolean = synchronized(lock) {
+        val session = activeSession
+        if (session == null || session.id != sessionId) return@synchronized false
+        activeSession = session.copy(brokerUrl = brokerUrl)
+        true
+    }
+
+    /**
      * Records the tunnel's traffic counters for the active session. Reported values must be
      * cumulative since the engine started; the high-water mark is kept so a counter reset
      * (engine restart) never regresses what the session already reported.

--- a/android/app/src/main/java/com/openrung/vpn/OpenRungVpnService.kt
+++ b/android/app/src/main/java/com/openrung/vpn/OpenRungVpnService.kt
@@ -102,6 +102,7 @@ class OpenRungVpnService : VpnService() {
     private val pendingWssCloses = LinkedHashSet<Deferred<Unit>>()
     private var physicalNetworkMonitor: PhysicalNetworkEpochMonitor? = null
     private var brokerUrl: String = AppConfig.DEFAULT_BROKER_URL
+    private var telemetryBrokerUrl: String = AppConfig.TELEMETRY_BROKER_URL
     private var activeRelayId: String? = null
     private var requestedTargetCountry: String? = null
     private var requestedTargetRelayId: String? = null
@@ -135,7 +136,7 @@ class OpenRungVpnService : VpnService() {
         return START_STICKY
     }
 
-    private fun handleStartAction(
+    private suspend fun handleStartAction(
         action: String?,
         requestedBrokerUrl: String,
         targetCountry: String?,
@@ -223,14 +224,11 @@ class OpenRungVpnService : VpnService() {
     }
 
     override fun onDestroy() {
-        // Teardown runs on the service thread like every other state mutation; only after it
-        // completes is the scope cancelled so its Job and any in-flight coroutines (connect,
-        // heartbeat, the disconnect() telemetry flush) don't outlive this service instance.
-        // Mirrors OpenRungVpnModule.invalidate(). The on-destroy telemetry flush is best-effort —
-        // the outbox retries anything dropped here on the next session. Because [serviceThread]
-        // is process-global, a replacement instance's first command is guaranteed to run AFTER
-        // this teardown, so the dead instance can never end the replacement's telemetry session
-        // or overwrite its published status.
+        // Teardown runs on the service thread like every other state mutation; only after its
+        // bounded telemetry flush and local cleanup complete is the scope cancelled. Mirrors
+        // OpenRungVpnModule.invalidate(). Because [serviceThread] is process-global, a replacement
+        // instance's first command is guaranteed to run AFTER this teardown, so the dead instance
+        // can never end the replacement's telemetry session or overwrite its published status.
         val stopId = lastStartId // captured on Main at post time, same as onRevoke
         serviceScope.launch { disconnect(stopId) }.invokeOnCompletion { serviceScope.cancel() }
         super.onDestroy()
@@ -250,8 +248,10 @@ class OpenRungVpnService : VpnService() {
         // this epoch (preflight, punch, direct, WSS) sees the same rules. Recovery reconnects
         // re-enter connect() and naturally re-read the persisted config.
         splitTunnelRules = withContext(Dispatchers.IO) { currentSplitTunnelRules() }
-        // Telemetry/heartbeats intentionally keep using the dedicated configured target. Discovery's
-        // winning front is not automatically substituted for AppConfig.TELEMETRY_BROKER_URL.
+        // Start with the configured telemetry target so the pre-discovery event has a route. Once
+        // verified discovery succeeds, this session follows the winning front.
+        telemetryBrokerUrl = AppConfig.TELEMETRY_BROKER_URL
+        var sessionTelemetryBrokerUrl = telemetryBrokerUrl
         val telemetrySession = TelemetryManager.beginSession(applicationContext, AppConfig.TELEMETRY_BROKER_URL)
         var failureStage = "preparing"
         TelemetryManager.record("connection_attempted")
@@ -284,16 +284,29 @@ class OpenRungVpnService : VpnService() {
                 result to elapsed
             }
             val relayResponse = fetch.response
-            // Pin the winning front for native session-scoped control-plane work such as WSS
-            // tickets and recovery. Telemetry/heartbeats retain their dedicated configured target.
-            // The persisted/configured URL stays untouched so a user's custom choice survives.
+            // Pin the verified winner for every session-scoped broker call, including telemetry.
+            // The persisted/configured URL stays untouched so a user's custom choice survives the
+            // next session, where discovery will validate and select a winner again.
             if (fetch.brokerUrl != brokerUrl) {
-                this.brokerUrl = fetch.brokerUrl
                 OpenRungStatusStore.appendLog(getString(R.string.log_broker_fallback, fetch.brokerUrl))
             }
+            coroutineContext.ensureActive()
+            if (!TelemetryManager.updateBrokerUrl(telemetrySession.id, fetch.brokerUrl)) {
+                throw CancellationException("telemetry session was superseded")
+            }
+            this.brokerUrl = fetch.brokerUrl
+            telemetryBrokerUrl = fetch.brokerUrl
+            sessionTelemetryBrokerUrl = fetch.brokerUrl
             val candidates = relaySelector.orderedCandidates(relayResponse.relays, relayResponse.serverInstant)
             OpenRungStatusStore.appendLog(
                 getString(R.string.log_broker_returned, relayResponse.relays.size, candidates.size),
+            )
+            // Make the attempt visible before relay dialing. Upload failure is non-fatal and leaves
+            // the durable outbox untouched, but caller cancellation still aborts this stale epoch.
+            bestEffortTelemetryFlush(
+                brokerUrl = sessionTelemetryBrokerUrl,
+                timeoutMillis = TELEMETRY_FLUSH_TIMEOUT_MS,
+                flush = TelemetryManager::flush,
             )
             if (candidates.isEmpty()) {
                 throw RelaySelectionException.NoUsableRelay(getString(R.string.error_no_usable_relay))
@@ -396,9 +409,13 @@ class OpenRungVpnService : VpnService() {
             startTunnelEngineMonitor(relay, coroutineContext[Job])
             startPunchMonitor(relay, coroutineContext[Job])
             startWssMonitor(relay, coroutineContext[Job])
-            // This is deliberately the final operation. runCatching can swallow cancellation, so
-            // no stateful work may follow it; disconnect/recovery own the already-running jobs.
-            runCatching { TelemetryManager.flush(AppConfig.TELEMETRY_BROKER_URL) }
+            // This is deliberately the final operation. No stateful work may follow it;
+            // disconnect/recovery own the already-running jobs.
+            bestEffortTelemetryFlush(
+                brokerUrl = sessionTelemetryBrokerUrl,
+                timeoutMillis = TELEMETRY_FLUSH_TIMEOUT_MS,
+                flush = TelemetryManager::flush,
+            )
         } catch (error: CancellationException) {
             throw error
         } catch (error: Throwable) {
@@ -437,12 +454,17 @@ class OpenRungVpnService : VpnService() {
             )
             TelemetryManager.endSession("connection_failed")
             OpenRungStatusStore.fail(error.message ?: getString(R.string.error_vpn_connection_failed))
-            stopForeground(STOP_FOREGROUND_REMOVE)
-            // This epoch's own id, not the latest: a CONNECT delivered meanwhile carries a newer
-            // id, so AMS refuses this stop and the successor keeps the service.
-            stopSelf(epochStartId)
-            // Deliberately last: runCatching swallows cancellation, so nothing may publish after.
-            runCatching { TelemetryManager.flush(AppConfig.TELEMETRY_BROKER_URL) }
+            flushTelemetryBeforeStop(
+                brokerUrl = sessionTelemetryBrokerUrl,
+                timeoutMillis = TELEMETRY_FLUSH_TIMEOUT_MS,
+                flush = TelemetryManager::flush,
+                stop = {
+                    stopForeground(STOP_FOREGROUND_REMOVE)
+                    // This epoch's own id, not the latest: a CONNECT delivered meanwhile carries a
+                    // newer id, so AMS refuses this stop and the successor keeps the service.
+                    stopSelf(epochStartId)
+                },
+            )
         }
     }
 
@@ -1024,7 +1046,7 @@ class OpenRungVpnService : VpnService() {
      * before either runs; the stale disconnect must clean up its own epoch without stopping the
      * service out from under the newer connect.
      */
-    private fun disconnect(stopId: Int) {
+    private suspend fun disconnect(stopId: Int) {
         heartbeatJob?.cancel()
         heartbeatJob = null
         engineMonitorJob?.cancel()
@@ -1040,14 +1062,21 @@ class OpenRungVpnService : VpnService() {
         activeRelayId?.let {
             TelemetryManager.record("tunnel_stopped", relayId = it)
         }
+        val terminalTelemetryBrokerUrl = TelemetryManager.activeSession()?.brokerUrl
+            ?: telemetryBrokerUrl
         activeRelayId = null
         TelemetryManager.endSession("disconnect")
-        serviceScope.launch {
-            runCatching { TelemetryManager.flush(AppConfig.TELEMETRY_BROKER_URL) }
-        }
-        stopForeground(STOP_FOREGROUND_REMOVE)
         OpenRungStatusStore.setStatus(ConnectionStatus.DISCONNECTED, relayLabel = null, lastError = null)
-        stopSelf(stopId)
+        flushTelemetryBeforeStop(
+            brokerUrl = terminalTelemetryBrokerUrl,
+            timeoutMillis = TELEMETRY_FLUSH_TIMEOUT_MS,
+            flush = TelemetryManager::flush,
+            stop = {
+                if (lastStartId != stopId) return@flushTelemetryBeforeStop
+                stopForeground(STOP_FOREGROUND_REMOVE)
+                stopSelf(stopId)
+            },
+        )
     }
 
     /**
@@ -1153,15 +1182,22 @@ class OpenRungVpnService : VpnService() {
         // See connect()'s failure tail: a superseded epoch must not end the successor's session,
         // overwrite its status, or stop the service it now owns.
         coroutineContext.ensureActive()
+        val terminalTelemetryBrokerUrl = TelemetryManager.activeSession()?.brokerUrl
+            ?: telemetryBrokerUrl
         activeRelayId = null
         TelemetryManager.endSession("connection_failed")
         OpenRungStatusStore.fail(userMessage)
-        stopForeground(STOP_FOREGROUND_REMOVE)
-        // This epoch's own id, not the latest: a CONNECT delivered meanwhile carries a newer
-        // id, so AMS refuses this stop and the successor keeps the service.
-        stopSelf(epochStartId)
-        // Deliberately last: runCatching swallows cancellation, so nothing may publish after.
-        runCatching { TelemetryManager.flush(AppConfig.TELEMETRY_BROKER_URL) }
+        flushTelemetryBeforeStop(
+            brokerUrl = terminalTelemetryBrokerUrl,
+            timeoutMillis = TELEMETRY_FLUSH_TIMEOUT_MS,
+            flush = TelemetryManager::flush,
+            stop = {
+                stopForeground(STOP_FOREGROUND_REMOVE)
+                // This epoch's own id, not the latest: a CONNECT delivered meanwhile carries a
+                // newer id, so AMS refuses this stop and the successor keeps the service.
+                stopSelf(epochStartId)
+            },
+        )
     }
 
     /**
@@ -1716,6 +1752,7 @@ class OpenRungVpnService : VpnService() {
         internal const val PUNCH_HEALTH_MIN_DELAY_MS = 30_000L
         internal const val PUNCH_HEALTH_MAX_BACKOFF_MS = 300_000L
         internal const val PUNCH_HEALTH_FAILURE_THRESHOLD = 3
+        internal const val TELEMETRY_FLUSH_TIMEOUT_MS = 5_000L
         private const val PHYSICAL_NETWORK_RETRY_DELAY_MS = 5_000L
         private const val PHYSICAL_NETWORK_RETRY_MAX_DELAY_MS = 60_000L
         private const val ACCESS_TRANSPORT_DIRECT = "direct"

--- a/android/app/src/main/java/com/openrung/vpn/TerminalTelemetryFlush.kt
+++ b/android/app/src/main/java/com/openrung/vpn/TerminalTelemetryFlush.kt
@@ -17,8 +17,11 @@ internal suspend fun bestEffortTelemetryFlush(
     require(timeoutMillis > 0) { "telemetry flush timeout must be positive" }
     try {
         withTimeoutOrNull(timeoutMillis) { flush(brokerUrl) }
-    } catch (cancellation: CancellationException) {
-        throw cancellation
+    } catch (_: CancellationException) {
+        // Propagate only real caller cancellation. The native transport maps its own "cancelled"
+        // kind to CancellationException even while this coroutine is live; treating that as
+        // cancellation would skip a terminal caller's stop and leave the service running.
+        currentCoroutineContext().ensureActive()
     } catch (_: Throwable) {
         // Best effort: the outbox commits only successful uploads and will retry later.
     }

--- a/android/app/src/main/java/com/openrung/vpn/TerminalTelemetryFlush.kt
+++ b/android/app/src/main/java/com/openrung/vpn/TerminalTelemetryFlush.kt
@@ -1,0 +1,40 @@
+package com.openrung.vpn
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.withTimeoutOrNull
+
+/**
+ * Makes one bounded best-effort attempt without converting caller cancellation into success.
+ * Upload failures and the local timeout leave the durable outbox intact for a later session.
+ */
+internal suspend fun bestEffortTelemetryFlush(
+    brokerUrl: String,
+    timeoutMillis: Long,
+    flush: suspend (String) -> Unit,
+) {
+    require(timeoutMillis > 0) { "telemetry flush timeout must be positive" }
+    try {
+        withTimeoutOrNull(timeoutMillis) { flush(brokerUrl) }
+    } catch (cancellation: CancellationException) {
+        throw cancellation
+    } catch (_: Throwable) {
+        // Best effort: the outbox commits only successful uploads and will retry later.
+    }
+}
+
+/**
+ * Keeps the service alive until its final telemetry attempt completes or times out. The final
+ * cancellation check prevents a superseded epoch from stopping the service owned by its successor.
+ */
+internal suspend fun flushTelemetryBeforeStop(
+    brokerUrl: String,
+    timeoutMillis: Long,
+    flush: suspend (String) -> Unit,
+    stop: () -> Unit,
+) {
+    bestEffortTelemetryFlush(brokerUrl, timeoutMillis, flush)
+    currentCoroutineContext().ensureActive()
+    stop()
+}

--- a/android/app/src/test/java/com/openrung/telemetry/TelemetryManagerApplicationConnectionTest.kt
+++ b/android/app/src/test/java/com/openrung/telemetry/TelemetryManagerApplicationConnectionTest.kt
@@ -150,6 +150,16 @@ class TelemetryManagerApplicationConnectionTest {
     }
 
     @Test
+    fun `verified discovery winner reroutes only its matching active session`() {
+        assertTrue(TelemetryManager.updateBrokerUrl(session.id, "https://winner.example/"))
+        assertEquals("https://winner.example/", TelemetryManager.activeSession()?.brokerUrl)
+
+        val successor = TelemetryManager.beginSession(context, "https://successor.example/")
+        assertFalse(TelemetryManager.updateBrokerUrl(session.id, "https://stale.example/"))
+        assertEquals(successor, TelemetryManager.activeSession())
+    }
+
+    @Test
     fun `flow attribution linearizes after package lookup during session replacement`() {
         recordFlow(packageName = "com.example.replace-race")
         val lookupEntered = CountDownLatch(1)

--- a/android/app/src/test/java/com/openrung/vpn/TerminalTelemetryFlushTest.kt
+++ b/android/app/src/test/java/com/openrung/vpn/TerminalTelemetryFlushTest.kt
@@ -1,5 +1,6 @@
 package com.openrung.vpn
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.launch
@@ -49,6 +50,25 @@ class TerminalTelemetryFlushTest {
             flush = { _ ->
                 order += "flush"
                 awaitCancellation()
+            },
+            stop = { order += "stop" },
+        )
+
+        assertEquals(listOf("flush", "stop"), order)
+    }
+
+    @Test
+    fun `spurious native cancellation is a failed attempt and still stops the service`() = runTest {
+        val order = mutableListOf<String>()
+
+        flushTelemetryBeforeStop(
+            brokerUrl = "https://winner.example/",
+            timeoutMillis = 5_000,
+            flush = { _ ->
+                order += "flush"
+                // The native transport reports its own "cancelled" kind as CancellationException
+                // even while the calling coroutine is live.
+                throw CancellationException("native transport reported cancelled")
             },
             stop = { order += "stop" },
         )

--- a/android/app/src/test/java/com/openrung/vpn/TerminalTelemetryFlushTest.kt
+++ b/android/app/src/test/java/com/openrung/vpn/TerminalTelemetryFlushTest.kt
@@ -1,0 +1,82 @@
+package com.openrung.vpn
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TerminalTelemetryFlushTest {
+    @Test
+    fun `successful flush completes before service stop`() = runTest {
+        val order = mutableListOf<String>()
+
+        flushTelemetryBeforeStop(
+            brokerUrl = "https://winner.example/",
+            timeoutMillis = 5_000,
+            flush = { brokerUrl -> order += "flush:$brokerUrl" },
+            stop = { order += "stop" },
+        )
+
+        assertEquals(listOf("flush:https://winner.example/", "stop"), order)
+    }
+
+    @Test
+    fun `upload failure still stops and leaves retry policy to the outbox`() = runTest {
+        val order = mutableListOf<String>()
+
+        flushTelemetryBeforeStop(
+            brokerUrl = "https://winner.example/",
+            timeoutMillis = 5_000,
+            flush = { _ ->
+                order += "flush"
+                throw IllegalStateException("offline")
+            },
+            stop = { order += "stop" },
+        )
+
+        assertEquals(listOf("flush", "stop"), order)
+    }
+
+    @Test
+    fun `timeout bounds shutdown before service stop`() = runTest {
+        val order = mutableListOf<String>()
+
+        flushTelemetryBeforeStop(
+            brokerUrl = "https://winner.example/",
+            timeoutMillis = 5_000,
+            flush = { _ ->
+                order += "flush"
+                awaitCancellation()
+            },
+            stop = { order += "stop" },
+        )
+
+        assertEquals(listOf("flush", "stop"), order)
+    }
+
+    @Test
+    fun `caller cancellation prevents stale service stop`() = runTest {
+        val order = mutableListOf<String>()
+        val flushStarted = CompletableDeferred<Unit>()
+        val job = launch {
+            flushTelemetryBeforeStop(
+                brokerUrl = "https://winner.example/",
+                timeoutMillis = 5_000,
+                flush = { _ ->
+                    order += "flush"
+                    flushStarted.complete(Unit)
+                    awaitCancellation()
+                },
+                stop = { order += "stop" },
+            )
+        }
+        flushStarted.await()
+
+        job.cancel()
+        job.join()
+
+        assertEquals(listOf("flush"), order)
+    }
+}

--- a/ios/PacketTunnel/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider.swift
@@ -217,7 +217,10 @@ final class PacketTunnelProvider: NEPacketTunnelProvider {
             do {
                 try await TelemetryManager.flush(brokerURL: telemetryURLString)
             } catch is CancellationError {
-                throw CancellationError()
+                // Abort only for real task cancellation. The native transport maps its own
+                // "cancelled" kind to CancellationError even while this task is live; that must
+                // stay a failed best-effort attempt, not silently end the epoch mid-connect.
+                try Task.checkCancellation()
             } catch {
                 // Best effort; the success/failure tail retries the retained outbox.
             }

--- a/ios/PacketTunnel/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider.swift
@@ -107,7 +107,6 @@ final class PacketTunnelProvider: NEPacketTunnelProvider {
         // cancellable) is stopped below, after the await.
         SharedConnectionState.setStatus(.disconnecting)
 
-        let telemetryURLString = AppConfig.telemetryBrokerURL.absoluteString
         Task {
             // Connection-owning tasks must finish before engine teardown. In particular,
             // EmbeddedProxyEngine.start is not cancellable, so stopping it concurrently with a
@@ -118,7 +117,8 @@ final class PacketTunnelProvider: NEPacketTunnelProvider {
             if let relayID = detached?.relayID {
                 TelemetryManager.record("tunnel_stopped", relayId: relayID)
             }
-            TelemetryManager.endSession(reason: "disconnect")
+            let telemetryURLString = TelemetryManager.endSession(reason: "disconnect")
+                ?? AppConfig.telemetryBrokerURL.absoluteString
             // Engine/WSS observer waits are unblocked by the ordered cleanup above.
             await TunnelTransportCleanup.drain(pending.observers)
             SharedConnectionState.setStatus(.disconnected, clearRelayLabel: true, clearError: true)
@@ -160,9 +160,10 @@ final class PacketTunnelProvider: NEPacketTunnelProvider {
         // same rules; recovery reconnects re-read on their next connect() pass.
         let splitTunnelRules = resolveSplitTunnelRules()
         self.brokerURL = brokerURL
-        // Telemetry and heartbeats deliberately keep using the separately configured telemetry
-        // target; they do not automatically follow the front that wins relay discovery.
-        let session = TelemetryManager.beginSession(brokerURL: AppConfig.telemetryBrokerURL.absoluteString)
+        // Start with the configured telemetry target so the pre-discovery event has a route. Once
+        // verified discovery succeeds, this session follows the winning front.
+        var telemetryURLString = AppConfig.telemetryBrokerURL.absoluteString
+        let session = TelemetryManager.beginSession(brokerURL: telemetryURLString)
         var failureStage = "preparing"
 
         TelemetryManager.record("connection_attempted")
@@ -192,18 +193,34 @@ final class PacketTunnelProvider: NEPacketTunnelProvider {
             )
             let response = fetch.response
             let brokerFetchMs = Int64((DispatchTime.now().uptimeNanoseconds - brokerStartedNs) / 1_000_000)
-            // Pin the winning front at the head of this session's native WSS-ticket ladder.
-            // Telemetry remains on AppConfig.telemetryBrokerURL as described above.
+            // Pin the verified winner for every session-scoped broker call, including telemetry.
             if fetch.brokerURL != brokerURL {
-                self.brokerURL = fetch.brokerURL
                 SharedConnectionState.appendLog("configured broker did not win discovery; using fallback \(fetch.brokerURL.absoluteString)")
             }
+            try Task.checkCancellation()
+            telemetryURLString = fetch.brokerURL.absoluteString
+            guard TelemetryManager.updateBrokerURL(
+                telemetryURLString,
+                forSessionId: session.id
+            ) else {
+                throw CancellationError()
+            }
+            self.brokerURL = fetch.brokerURL
             if let geo = await geoLookup {
                 TelemetryManager.setGeoInfo(geo)
             }
 
             let candidates = selector.orderedCandidates(from: response.relays, now: response.serverTime)
             SharedConnectionState.appendLog("broker returned \(response.relays.count) relays; \(candidates.count) usable")
+            // Make the attempt visible before relay dialing. Delivery failure is non-fatal and
+            // leaves the durable outbox untouched, but cancellation still aborts this stale epoch.
+            do {
+                try await TelemetryManager.flush(brokerURL: telemetryURLString)
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                // Best effort; the success/failure tail retries the retained outbox.
+            }
             guard candidates.isEmpty == false else {
                 throw PacketTunnelError.noUsableRelay
             }
@@ -346,7 +363,7 @@ final class PacketTunnelProvider: NEPacketTunnelProvider {
             // Final, best-effort work only: no connection state or completion follows this await.
             guard Task.isCancelled == false else { return }
             do {
-                try await TelemetryManager.flush(brokerURL: AppConfig.telemetryBrokerURL.absoluteString)
+                try await TelemetryManager.flush(brokerURL: telemetryURLString)
             } catch is CancellationError {
                 return
             } catch {
@@ -367,8 +384,9 @@ final class PacketTunnelProvider: NEPacketTunnelProvider {
             let detail = FailureClassifier.detail(error)
             if detail.isEmpty == false { attributes["failure_detail"] = detail }
             TelemetryManager.record("connection_failed", attributes: attributes)
-            TelemetryManager.endSession(reason: "connection_failed")
-            try? await TelemetryManager.flush(brokerURL: AppConfig.telemetryBrokerURL.absoluteString)
+            let terminalTelemetryURLString = TelemetryManager.endSession(reason: "connection_failed")
+                ?? telemetryURLString
+            try? await TelemetryManager.flush(brokerURL: terminalTelemetryURLString)
             guard Task.isCancelled == false else {
                 completionHandler?(CancellationError())
                 return
@@ -1721,8 +1739,9 @@ final class PacketTunnelProvider: NEPacketTunnelProvider {
             cancelMonitor: false,
             expectedTransportEpoch: transportEpoch
         ) != nil else { return }
-        TelemetryManager.endSession(reason: "connection_failed")
-        try? await TelemetryManager.flush(brokerURL: AppConfig.telemetryBrokerURL.absoluteString)
+        let telemetryURLString = TelemetryManager.endSession(reason: "connection_failed")
+            ?? AppConfig.telemetryBrokerURL.absoluteString
+        try? await TelemetryManager.flush(brokerURL: telemetryURLString)
         // Successfully detaching the epoch transfers terminal ownership to this task. Internal
         // replacement may cancel it after that point, but allowing cancellation to abandon the
         // final provider error would leave a transport-less zombie tunnel. User shutdown still

--- a/ios/Shared/AppConfig.swift
+++ b/ios/Shared/AppConfig.swift
@@ -18,16 +18,11 @@ enum AppConfig {
     /// receives only the winning URL and a verified relay-list snapshot.
     static let defaultBrokerURL = URL(string: "https://broker.openrung.org/")!
 
-    /// Native VPN telemetry / heartbeat target. Uses the same Cloudflare-fronted HTTPS broker as
-    /// discovery, so this traffic is TLS-protected — the app never sends anything in cleartext.
-    /// React Native speed-test telemetry has its own TypeScript constant and reaches this broker
-    /// through `OpenRungBroker`, not this shared Swift client. Kept separate from `defaultBrokerURL`
-    /// because telemetry is high-volume (heartbeats fire ~once/minute per connected user), so it
-    /// consumes the Cloudflare Worker free-tier request quota (100k/day). If that quota becomes a
-    /// constraint, the planned fix is to send telemetry direct-to-origin over TLS via a dedicated
-    /// unproxied hostname — "Option A" in docs/ARCHITECTURE.md § "Network transport". Never revert
-    /// to a raw-IP HTTP endpoint: that leaked the user's real pre-VPN IP, geo and stable client ID
-    /// in cleartext.
+    /// Bootstrap native VPN telemetry / heartbeat target used until verified relay discovery
+    /// selects a live broker front. The active telemetry session then follows that exact winner,
+    /// so a client that reached discovery through fallback does not post diagnostics back to a
+    /// blocked primary. React Native speed-test telemetry has its own TypeScript route. Never use
+    /// a raw-IP HTTP endpoint: that would expose the user's pre-VPN IP, geo and stable client ID.
     static let telemetryBrokerURL = URL(string: "https://broker.openrung.org/")!
 
     /// Broker fronts retained for WSS-ticket ordering and other paths that have their own explicit

--- a/ios/Shared/TelemetryManager.swift
+++ b/ios/Shared/TelemetryManager.swift
@@ -64,6 +64,18 @@ enum TelemetryManager {
         TelemetrySessionStore.current()
     }
 
+    /// Routes the still-current session through the broker front that won verified discovery.
+    /// The expected ID prevents a cancelled connect epoch from overwriting its successor's route.
+    @discardableResult
+    static func updateBrokerURL(_ brokerURL: String, forSessionId sessionId: String) -> Bool {
+        guard var session = TelemetrySessionStore.current(), session.id == sessionId else {
+            return false
+        }
+        session.brokerURL = brokerURL
+        TelemetrySessionStore.save(session)
+        return true
+    }
+
     static func markConnected(relayId: String) {
         guard var session = TelemetrySessionStore.current() else { return }
         session.relayId = relayId
@@ -104,8 +116,9 @@ enum TelemetryManager {
         )
     }
 
-    static func endSession(reason: String) {
-        guard let session = TelemetrySessionStore.current() else { return }
+    @discardableResult
+    static func endSession(reason: String) -> String? {
+        guard let session = TelemetrySessionStore.current() else { return nil }
         let now = MonotonicClock.nowMs()
         var measurements: [String: Int64] = ["session_duration_ms": max(now - session.startedElapsedMs, 0)]
         if let connected = session.connectedElapsedMs {
@@ -117,6 +130,7 @@ enum TelemetryManager {
         record("connection_ended", relayId: session.relayId, attributes: ["reason": reason], measurements: measurements)
         resetTrafficCounters()
         TelemetrySessionStore.save(nil)
+        return session.brokerURL
     }
 
     /// Sends a heartbeat while draining queued events in FIFO, identity-homogeneous batches. The

--- a/ios/Shared/TelemetrySession.swift
+++ b/ios/Shared/TelemetrySession.swift
@@ -13,7 +13,7 @@ public enum MonotonicClock {
 public struct TelemetrySession: Codable, Sendable, Equatable {
     public let id: String
     public let clientId: String
-    public let brokerURL: String
+    public var brokerURL: String
     public let startedElapsedMs: Int64
     public var relayId: String?
     public var connectedElapsedMs: Int64?


### PR DESCRIPTION
## Summary

- Route Android and iOS VPN telemetry through the verified broker front that won relay discovery.
- Flush once immediately after discovery and use the same route for heartbeat, success, failure, and disconnect delivery.
- Keep Android VPN teardown alive for a bounded best-effort terminal flush while preserving cancellation and connection-epoch isolation.
- Add regressions for winner routing, failed delivery, timeout, and cancellation.

## Production failure addressed

Version 0.3.5 clients could successfully poll relay discovery through a fallback broker, while telemetry continued targeting the fixed primary broker. On Android, terminal delivery was also launched asynchronously and then cancelled as the VPN service stopped. Events were still enqueued in the durable outbox, but many clients never got a viable, completed drain, which produced the poll-only production pattern.

The telemetry serialization path does not use reflection that requires additional R8 keep rules, so this PR intentionally makes no R8 changes and excludes the separate outbox hardening opportunities.

## Verification

- Android focused unit tests: `TerminalTelemetryFlushTest` and `TelemetryManagerApplicationConnectionTest`
- iOS PacketTunnel target: build and link succeeded for generic iOS
- iOS OpenRungTests: 137 tests passed, 0 failures
- Rebased onto current `main` including #73
