### PR TITLE
Reclassify spurious native "cancelled" results instead of silently cancelling the epoch

### DIFF
--- a/android/app/src/main/java/com/openrung/net/NativeBrokerTransport.kt
+++ b/android/app/src/main/java/com/openrung/net/NativeBrokerTransport.kt
@@ -417,7 +417,7 @@ internal suspend fun <T> runNativeBrokerOperation(
 }
 
 /** Turns an unsuccessful or nil snapshot into the bounded native failure contract. */
-internal fun <T : NativeBrokerResult> requireNativeBrokerSuccess(
+internal suspend fun <T : NativeBrokerResult> requireNativeBrokerSuccess(
     result: T?,
     operationName: String,
 ): T {
@@ -437,7 +437,12 @@ internal fun <T : NativeBrokerResult> requireNativeBrokerSuccess(
         "$operationName failed: $detail"
     }
     if (kind == BrokerNativeFailureKind.CANCELLED) {
-        throw CancellationException(message)
+        // Cancellation is only ever the caller's: a genuinely cancelled coroutine propagates its
+        // own CancellationException here. A native "cancelled" kind reaching a live caller is a
+        // failed request — converting it into cancellation would silently end the caller's epoch
+        // (skipping failure status, telemetry, and service stop) on the strength of a Go-side
+        // race or mis-mapped binding error.
+        currentCoroutineContext().ensureActive()
     }
     throw BrokerNativeFailure(
         kind = kind,

--- a/android/app/src/main/java/com/openrung/vpn/TerminalTelemetryFlush.kt
+++ b/android/app/src/main/java/com/openrung/vpn/TerminalTelemetryFlush.kt
@@ -18,9 +18,10 @@ internal suspend fun bestEffortTelemetryFlush(
     try {
         withTimeoutOrNull(timeoutMillis) { flush(brokerUrl) }
     } catch (_: CancellationException) {
-        // Propagate only real caller cancellation. The native transport maps its own "cancelled"
-        // kind to CancellationException even while this coroutine is live; treating that as
-        // cancellation would skip a terminal caller's stop and leave the service running.
+        // Propagate only real caller cancellation. The native transport verifies the caller's
+        // cancellation state before mapping its own "cancelled" kind, but this terminal path
+        // keeps its own guard: any dependency minting CancellationException while this coroutine
+        // is live would otherwise skip a terminal caller's stop and leave the service running.
         currentCoroutineContext().ensureActive()
     } catch (_: Throwable) {
         // Best effort: the outbox commits only successful uploads and will retry later.

--- a/android/app/src/test/java/com/openrung/net/BrokerClientTest.kt
+++ b/android/app/src/test/java/com/openrung/net/BrokerClientTest.kt
@@ -2,6 +2,7 @@ package com.openrung.net
 
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -115,6 +116,34 @@ class BrokerClientTest {
         assertEquals(BrokerNativeFailureKind.HTTP_STATUS, failure.kind)
         assertEquals(503, failure.httpStatus)
         assertEquals(7_000L, failure.retryAfterMillis)
+    }
+
+    @Test
+    fun `spurious native cancelled discovery is a typed failure for a live caller`() = runBlocking {
+        val operation = RecordingNativeBrokerOperation().apply {
+            relayResult = NativeBrokerRelayResult(
+                succeeded = false,
+                errorKind = "cancelled",
+                errorText = "request cancelled",
+            )
+        }
+
+        // The VPN service's connect() rethrows CancellationException without publishing a failure
+        // status or stopping itself; a native "cancelled" kind seen by a live caller must surface
+        // as an ordinary typed failure instead.
+        val failure = assertSuspendThrows<BrokerNativeFailure> {
+            BrokerClient.firstReachable(
+                primary = "https://primary.example/",
+                limit = 5,
+                clientId = null,
+                sessionId = null,
+                operationFactory = RecordingNativeBrokerOperationFactory(operation),
+            )
+        }
+
+        assertEquals(BrokerNativeFailureKind.CANCELLED, failure.kind)
+        assertFalse(failure.isLocalPlatformFailure)
+        assertEquals(1, operation.closeCalls.get())
     }
 
     @Test

--- a/android/app/src/test/java/com/openrung/net/NativeBrokerTransportTest.kt
+++ b/android/app/src/test/java/com/openrung/net/NativeBrokerTransportTest.kt
@@ -6,6 +6,8 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
@@ -116,24 +118,57 @@ class NativeBrokerTransportTest {
     }
 
     @Test
-    fun `blank and future error kinds normalize to unknown and text is sanitized bounded`() {
+    fun `blank and future error kinds normalize to unknown and text is sanitized bounded`() = runBlocking {
         listOf("", "future_kind").forEach { rawKind ->
             val result = NativeBrokerCommonResult(
                 succeeded = false,
                 errorKind = rawKind,
                 errorText = "unsafe\r\n\t" + "😀".repeat(200),
             )
-            val failure = try {
+            val failure = assertSuspendThrows<BrokerNativeFailure> {
                 requireNativeBrokerSuccess(result, "native request")
-                throw AssertionError("expected failure")
-            } catch (error: BrokerNativeFailure) {
-                error
             }
             assertEquals(BrokerNativeFailureKind.UNKNOWN, failure.kind)
             assertFalse(failure.message.orEmpty().contains('\r'))
             assertFalse(failure.message.orEmpty().contains('\n'))
             assertTrue(failure.message.orEmpty().toByteArray(Charsets.UTF_8).size <= 256)
         }
+    }
+
+    @Test
+    fun `native cancelled kind reaching a live caller is a typed failure not cancellation`() = runBlocking {
+        val result = NativeBrokerCommonResult(
+            succeeded = false,
+            errorKind = "cancelled",
+            errorText = "request cancelled",
+        )
+
+        val failure = assertSuspendThrows<BrokerNativeFailure> {
+            requireNativeBrokerSuccess(result, "native request")
+        }
+
+        assertEquals(BrokerNativeFailureKind.CANCELLED, failure.kind)
+        assertFalse(failure.isLocalPlatformFailure)
+    }
+
+    @Test
+    fun `native cancelled kind in a cancelled caller propagates real cancellation`() = runBlocking {
+        val result = NativeBrokerCommonResult(succeeded = false, errorKind = "cancelled")
+        val observed = CompletableDeferred<Throwable>()
+        val job = launch {
+            currentCoroutineContext().cancel(CancellationException("caller cancelled"))
+            try {
+                requireNativeBrokerSuccess(result, "native request")
+            } catch (error: Throwable) {
+                observed.complete(error)
+                throw error
+            }
+        }
+        job.join()
+
+        val error = observed.await()
+        assertTrue("expected CancellationException, got $error", error is CancellationException)
+        assertFalse(error is BrokerNativeFailure)
     }
 
     @Test

--- a/android/app/src/test/java/com/openrung/net/WssTicketClientTest.kt
+++ b/android/app/src/test/java/com/openrung/net/WssTicketClientTest.kt
@@ -289,6 +289,56 @@ class WssTicketClientTest {
             }
     }
 
+    // Real time on purpose: requestOnce hops through Dispatchers.IO, which runTest's virtual
+    // clock treats as idle waiting, expiring the per-attempt withTimeout before the fake returns.
+    @Test
+    fun `spurious native cancelled attempt is a typed failure and fails over to the next front`() = runBlocking {
+        val cancelledOperation = RecordingNativeBrokerOperation().apply {
+            wssTicketResult = NativeBrokerWssTicketResult(
+                succeeded = false,
+                errorKind = "cancelled",
+                errorText = "request cancelled",
+            )
+        }
+        val successOperation = RecordingNativeBrokerOperation().apply {
+            wssTicketResult = NativeBrokerWssTicketResult(
+                succeeded = true,
+                ticket = "opaque-ticket",
+                url = FRONT_URL,
+                expiresAtMillis = 1_785_024_060_123,
+            )
+        }
+        val factory = RecordingNativeBrokerOperationFactory(cancelledOperation, successOperation)
+
+        // A native "cancelled" kind with this caller still live is one failed attempt, not epoch
+        // cancellation: failover must continue to the next front instead of aborting the ladder.
+        val result = WssTicketClient.requestWithFailover(
+            brokerUrls = listOf("https://primary.example/", "https://secondary.example/"),
+            relayId = "relay-a",
+            frontId = "front-a",
+            clientId = null,
+            sessionId = null,
+            policy = WssTicketPolicy(totalDeadlineMillis = 20_000),
+            elapsedRealtimeMillis = { 0L },
+            wait = {},
+            attempt = { brokerUrl, relayId, frontId, clientId, sessionId, timeout ->
+                WssTicketClient.requestOnce(
+                    brokerUrl = brokerUrl,
+                    relayId = relayId,
+                    frontId = frontId,
+                    clientId = clientId,
+                    sessionId = sessionId,
+                    timeoutMillis = timeout,
+                    operationFactory = factory,
+                )
+            },
+        )
+
+        assertEquals("opaque-ticket", result.ticket)
+        assertEquals(1, cancelledOperation.wssTicketCalls.size)
+        assertEquals(1, successOperation.wssTicketCalls.size)
+    }
+
     @Test
     fun `caller cancellation propagates and never attempts another front`() = runTest {
         val calls = mutableListOf<String>()

--- a/android/app/src/test/java/com/openrung/telemetry/TelemetryClientTest.kt
+++ b/android/app/src/test/java/com/openrung/telemetry/TelemetryClientTest.kt
@@ -109,7 +109,7 @@ class TelemetryClientTest {
     }
 
     @Test
-    fun `Go cancelled result remains structured cancellation and closes operation`() = runBlocking {
+    fun `spurious Go cancelled result is a typed failure for a live caller and closes operation`() = runBlocking {
         val operation = RecordingNativeBrokerOperation().apply {
             telemetryResult = NativeBrokerCommonResult(
                 succeeded = false,
@@ -118,13 +118,16 @@ class TelemetryClientTest {
             )
         }
 
-        assertSuspendThrows<CancellationException> {
+        // A native "cancelled" kind reaching this live coroutine is a failed upload the outbox
+        // retries later; CancellationException here would end the caller's epoch instead.
+        val failure = assertSuspendThrows<BrokerNativeFailure> {
             TelemetryClient(
                 "https://telemetry.example/",
                 RecordingNativeBrokerOperationFactory(operation),
             ).send(listOf(EVENT))
         }
 
+        assertEquals(BrokerNativeFailureKind.CANCELLED, failure.kind)
         assertEquals(1, operation.closeCalls.get())
     }
 

--- a/ios/OpenRungTests/BrokerClientTests.swift
+++ b/ios/OpenRungTests/BrokerClientTests.swift
@@ -106,6 +106,34 @@ final class BrokerClientTests: XCTestCase {
         XCTAssertEqual(operation.closeCount, 1)
     }
 
+    func testSpuriousNativeCancelledDiscoveryIsTypedFailureForLiveCaller() async {
+        let operation = TestNativeBrokerOperation()
+        operation.relayHandler = { _, _, _, _ in
+            NativeBrokerRelayResultSnapshot(
+                succeeded: false,
+                errorKind: "cancelled",
+                errorText: "request cancelled"
+            )
+        }
+
+        // The provider's connect path treats CancellationError as a user-initiated stop and skips
+        // cleanup and failure publication; a native "cancelled" kind seen by a live task must
+        // surface as an ordinary typed failure instead.
+        do {
+            _ = try await BrokerClient.firstReachable(
+                primary: primary,
+                operationFactory: TestNativeBrokerFactory(operation: operation)
+            )
+            XCTFail("expected typed cancelled failure")
+        } catch let failure as BrokerNativeFailure {
+            XCTAssertEqual(failure.kind, .cancelled)
+            XCTAssertFalse(failure.isLocalPlatformFailure)
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+        XCTAssertEqual(operation.closeCount, 1)
+    }
+
     func testNilNativeOperationIsUnavailableWithNoHTTPFallback() async {
         let factory = TestNativeBrokerFactory(operation: nil)
         do {

--- a/ios/OpenRungTests/NativeBrokerTransportTests.swift
+++ b/ios/OpenRungTests/NativeBrokerTransportTests.swift
@@ -179,9 +179,15 @@ final class NativeBrokerTransportTests: XCTestCase {
     }
 
     func testBindingCancellationAndFutureKindsAreNormalized() {
+        // No cancelled task exists here: a native "cancelled" kind reaching a live caller is a
+        // bounded typed failure, never cooperative cancellation minted on the binding's behalf.
         let cancelled = NativeBrokerResultSnapshot(succeeded: false, errorKind: "cancelled")
         XCTAssertThrowsError(try cancelled.throwIfFailed()) { error in
-            XCTAssertTrue(error is CancellationError)
+            guard let failure = error as? BrokerNativeFailure else {
+                return XCTFail("unexpected error: \(error)")
+            }
+            XCTAssertEqual(failure.kind, .cancelled)
+            XCTAssertFalse(failure.isLocalPlatformFailure)
         }
 
         for bindingKind in ["", "future_kind", "unavailable", "decode"] {
@@ -199,6 +205,28 @@ final class NativeBrokerTransportTests: XCTestCase {
                 XCTAssertLessThanOrEqual(failure.message.utf8.count, 256)
             }
         }
+    }
+
+    func testBindingCancellationInCancelledTaskRemainsCooperativeCancellation() async {
+        let snapshot = NativeBrokerResultSnapshot(succeeded: false, errorKind: "cancelled")
+        let task = Task.detached { () -> Error? in
+            while Task.isCancelled == false {
+                await Task.yield()
+            }
+            do {
+                try snapshot.throwIfFailed()
+                return nil
+            } catch {
+                return error
+            }
+        }
+        task.cancel()
+
+        let observed = await task.value
+        XCTAssertTrue(
+            observed is CancellationError,
+            "got \(String(describing: observed))"
+        )
     }
 
     func testConfiguredFactoriesSelectNativeAndReactNativeConstructors() {

--- a/ios/OpenRungTests/TelemetryClientTests.swift
+++ b/ios/OpenRungTests/TelemetryClientTests.swift
@@ -68,6 +68,33 @@ final class TelemetryClientTests: XCTestCase {
         XCTAssertEqual(removedIDs.get(), [])
     }
 
+    func testSpuriousNativeCancelledSendIsTypedFailureForLiveCaller() async {
+        let operation = TestNativeBrokerOperation()
+        operation.telemetryHandler = { _, _ in
+            NativeBrokerResultSnapshot(
+                succeeded: false,
+                errorKind: "cancelled",
+                errorText: "request cancelled"
+            )
+        }
+        let client = TelemetryClient(
+            brokerURL: brokerURL,
+            operationFactory: TestNativeBrokerFactory(operation: operation)
+        )
+
+        // A native "cancelled" kind reaching this live task is a failed upload the outbox retries
+        // later; CancellationError here would end the caller's epoch instead.
+        do {
+            try await client.send([makeEvent()])
+            XCTFail("expected typed cancelled failure")
+        } catch let failure as BrokerNativeFailure {
+            XCTAssertEqual(failure.kind, .cancelled)
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+        XCTAssertEqual(operation.closeCount, 1)
+    }
+
     func testCancelledSendClosesAndDoesNotCommitQueuedIDs() async {
         let operation = BlockingNativeBrokerOperation()
         let removedIDs = TestLockedBox<Set<String>>([])

--- a/ios/OpenRungTests/WssTicketClientTests.swift
+++ b/ios/OpenRungTests/WssTicketClientTests.swift
@@ -118,6 +118,60 @@ final class WssTicketClientTests: XCTestCase {
         }
     }
 
+    func testSpuriousNativeCancelledAttemptIsTypedFailureAndFailsOverToNextFront() async throws {
+        let cancelledOperation = TestNativeBrokerOperation()
+        cancelledOperation.ticketHandler = { _, _, _, _, _ in
+            NativeBrokerWSSTicketResultSnapshot(
+                succeeded: false,
+                errorKind: "cancelled",
+                errorText: "request cancelled"
+            )
+        }
+        let successOperation = TestNativeBrokerOperation()
+        successOperation.ticketHandler = { _, _, _, _, _ in
+            NativeBrokerWSSTicketResultSnapshot(
+                succeeded: true,
+                ticket: "opaque-ticket",
+                url: Self.frontURL,
+                expiresAtMilliseconds: 1_753_142_520_123
+            )
+        }
+        let factory = TestNativeBrokerFactory([cancelledOperation, successOperation])
+        let attempted = TestLockedBox<[String]>([])
+
+        // A native "cancelled" kind with this task still live is one failed attempt, not epoch
+        // cancellation: failover must continue to the next front instead of aborting the ladder.
+        let ticket = try await WssTicketClient.requestWithFailover(
+            brokerURLs: [Self.primary, Self.secondary],
+            relayID: "relay-a",
+            frontID: "front-a",
+            clientID: nil,
+            sessionID: nil,
+            policy: WssTicketPolicy(),
+            monotonicMilliseconds: { 0 },
+            wait: { _ in },
+            attempt: { brokerURL, relayID, frontID, clientID, sessionID, _ in
+                attempted.mutate { $0.append(brokerURL.absoluteString) }
+                return try await WssTicketClient.requestOnce(
+                    operationFactory: factory,
+                    brokerURL: brokerURL,
+                    relayID: relayID,
+                    frontID: frontID,
+                    clientID: clientID,
+                    sessionID: sessionID
+                )
+            }
+        )
+
+        XCTAssertEqual(ticket.ticket, "opaque-ticket")
+        XCTAssertEqual(
+            attempted.get(),
+            [Self.primary.absoluteString, Self.secondary.absoluteString]
+        )
+        XCTAssertEqual(cancelledOperation.closeCount, 1)
+        XCTAssertEqual(successOperation.closeCount, 1)
+    }
+
     func testLocalNativeFailureWithIncidentalHTTPStatusIsNotProjectedOrRetried() async {
         let first = TestNativeBrokerOperation()
         first.ticketHandler = { _, _, _, _, _ in

--- a/ios/PacketTunnel/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider.swift
@@ -217,9 +217,11 @@ final class PacketTunnelProvider: NEPacketTunnelProvider {
             do {
                 try await TelemetryManager.flush(brokerURL: telemetryURLString)
             } catch is CancellationError {
-                // Abort only for real task cancellation. The native transport maps its own
-                // "cancelled" kind to CancellationError even while this task is live; that must
-                // stay a failed best-effort attempt, not silently end the epoch mid-connect.
+                // Abort only for real task cancellation. The native transport verifies the
+                // caller's cancellation state before mapping its own "cancelled" kind, but this
+                // mid-connect path keeps its own guard: a CancellationError from a dependency
+                // while this task is live must stay a failed best-effort attempt, not silently
+                // end the epoch.
                 try Task.checkCancellation()
             } catch {
                 // Best effort; the success/failure tail retries the retained outbox.

--- a/ios/Shared/NativeBrokerTransport.swift
+++ b/ios/Shared/NativeBrokerTransport.swift
@@ -543,7 +543,12 @@ public extension NativeBrokerResult {
             message: errorText
         )
         if failure.kind == .cancelled {
-            throw CancellationError()
+            // Cancellation is only ever the caller's: a genuinely cancelled task keeps its
+            // cooperative CancellationError here. A native "cancelled" kind reaching a live task
+            // is a failed request — converting it into cancellation would silently end the
+            // caller's epoch (skipping cleanup, failure status, and telemetry) on the strength
+            // of a Go-side race or mis-mapped binding error.
+            try Task.checkCancellation()
         }
         throw failure
     }


### PR DESCRIPTION
## What

Follow-up to #74's flush hardening. The central native-result mappers — `requireNativeBrokerSuccess` (`android/.../net/NativeBrokerTransport.kt`) and `throwIfFailed` (`ios/Shared/NativeBrokerTransport.swift`) — converted the binding's `"cancelled"` error kind into a fresh `CancellationException` / `CancellationError` unconditionally. Both now verify the caller's actual cancellation state first (`ensureActive()` / `Task.checkCancellation()`): a genuinely cancelled caller keeps its cooperative cancellation, while a live caller gets an ordinary `BrokerNativeFailure` with the bounded `CANCELLED` kind.

## Why

Every native broker call site funnels through these two mappers, and both runners already re-check cancellation after the worker returns — so a "cancelled" result reaching a live caller is by construction spurious (a Go-side race or mis-mapped binding error). Under the old mapping that spurious cancel was reachable from broker discovery and WSS ticket requests with real user impact:

- **Android** `connect()` rethrows `CancellationException` before any failure handling: no `connection_failed` telemetry, no `OpenRungStatusStore.fail`, no `stopSelf` — status stuck at CONNECTING with the foreground service leaked.
- **iOS** the connect path treats `CancellationError` as a user-initiated stop: `cleanupActiveTransport`, failure telemetry, and status publication all skipped.
- **Both**: WSS ticket failover aborted the whole front ladder instead of trying the next front.

Fixing centrally covers every consumer (BrokerClient, WssTicketClient, TelemetryClient, and both React Native bridges) in one place.

## Notes for review

- The reclassified failure keeps kind `CANCELLED` (not `UNAVAILABLE`): it stays in the bounded taxonomy, keeps telemetry `failure_reason` truthful, and — since it is not a local platform failure — WSS front failover correctly continues.
- The React Native bridges are behaviorally unchanged from JS's perspective (rejection kind `cancelled` either way, now with the real sanitized message).
- The #74 guards in `TerminalTelemetryFlush.kt` and the iOS early flush remain as defense in depth; their comments are updated to the new contract.
- Android `requireNativeBrokerSuccess` became `suspend` — all production call sites already were.
- Two existing tests asserting the old unconditional mapping were updated; all real-cancellation tests (bridge `cancel()`/`invalidate()`, racing-success suppression) pass unchanged.
- New Android WSS failover test uses `runBlocking` deliberately: `runTest`'s virtual clock expires the per-attempt `withTimeout` while `requestOnce` hops through real `Dispatchers.IO`.

## Testing

- `./android/gradlew -p android :app:testDebugUnitTest` — 197 tests, 0 failures
- `xcodebuild -project ios/OpenRung.xcodeproj -scheme OpenRungTests -destination 'platform=iOS Simulator,…' test` — 141 tests, 0 failures

New spurious-cancellation coverage mirroring `TerminalTelemetryFlushTest`: mapper live-caller vs. cancelled-caller on both platforms, broker discovery, telemetry send, and end-to-end WSS ticket failover past a spurious cancel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)