### PR TITLE
Use DoH failover for tunnel DNS probes

### DIFF
--- a/android/app/src/main/java/com/openrung/net/InternetProbe.kt
+++ b/android/app/src/main/java/com/openrung/net/InternetProbe.kt
@@ -2,16 +2,30 @@ package com.openrung.net
 
 import android.content.Context
 import android.net.ConnectivityManager
+import android.net.DnsResolver
 import android.net.Network
 import android.net.NetworkCapabilities
+import android.os.Build
+import android.os.CancellationSignal
 import android.os.SystemClock
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.asExecutor
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
+import java.io.ByteArrayOutputStream
 import java.io.IOException
+import java.net.DatagramPacket
+import java.net.DatagramSocket
 import java.net.HttpURLConnection
+import java.net.Inet4Address
+import java.net.InetAddress
+import java.net.UnknownHostException
 import java.net.URL
+import kotlin.random.Random
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 data class InternetProbeResult(
     val endpoint: String,
@@ -22,6 +36,163 @@ data class InternetProbeResult(
 class InternetProbeHttpStatusException(
     val status: Int,
 ) : IOException("internet probe returned HTTP $status")
+
+/** Ordering seam shared by startup and health probes: HTTPS can never mask a DNS failure. */
+internal suspend fun runFreshDnsHttpsProbe(
+    resolveFreshDns: suspend () -> Unit,
+    probeHttps: suspend () -> Unit,
+) {
+    resolveFreshDns()
+    probeHttps()
+}
+
+/** Minimal DNS wire codec for the API 26-28 cache-bypass path. */
+internal object TunnelDnsAProbe {
+    fun makeQuery(hostname: String, transactionId: Int): ByteArray {
+        require(transactionId in 0..0xffff) { "DNS transaction ID is out of range" }
+        val normalizedHostname = hostname.removeSuffix(".")
+        require(normalizedHostname.isNotEmpty() && normalizedHostname.length <= MAX_HOSTNAME_LENGTH) {
+            "invalid DNS hostname"
+        }
+
+        val labels = normalizedHostname.split('.')
+        val output = ByteArrayOutputStream(DNS_HEADER_LENGTH + normalizedHostname.length + 6)
+        output.write(transactionId ushr 8)
+        output.write(transactionId)
+        output.write(0x01)
+        output.write(0x00) // Recursion desired.
+        output.write(0x00)
+        output.write(0x01) // One question.
+        repeat(6) { output.write(0x00) }
+        labels.forEach { label ->
+            require(
+                label.isNotEmpty() &&
+                    label.length <= MAX_LABEL_LENGTH &&
+                    label.all { it.code in 1..0x7f },
+            ) { "invalid DNS hostname" }
+            output.write(label.length)
+            output.write(label.toByteArray(Charsets.US_ASCII))
+        }
+        output.write(0x00)
+        output.write(0x00)
+        output.write(0x01) // A.
+        output.write(0x00)
+        output.write(0x01) // IN.
+        return output.toByteArray()
+    }
+
+    /** Requires a complete NOERROR reply containing at least one IPv4 address answer. */
+    fun validateResponse(
+        response: ByteArray,
+        transactionId: Int,
+        length: Int = response.size,
+    ) {
+        if (length !in DNS_HEADER_LENGTH..response.size) invalidResponse("truncated header")
+        if (readUInt16(response, 0) != transactionId) invalidResponse("transaction mismatch")
+
+        val flags = readUInt16(response, 2)
+        if (flags and RESPONSE_FLAG == 0) invalidResponse("query packet received")
+        if (flags and OPCODE_MASK != 0) invalidResponse("unexpected opcode")
+        if (flags and TRUNCATED_FLAG != 0) invalidResponse("truncated reply")
+        if (flags and RESPONSE_CODE_MASK != 0) invalidResponse("resolver returned an error")
+        val questionCount = readUInt16(response, 4)
+        val answerCount = readUInt16(response, 6)
+        if (questionCount != 1) invalidResponse("unexpected question count")
+
+        var offset = skipName(response, length, DNS_HEADER_LENGTH)
+        if (offset > length - QUESTION_TRAILER_LENGTH) invalidResponse("truncated question")
+        if (
+            readUInt16(response, offset) != RECORD_TYPE_A ||
+            readUInt16(response, offset + 2) != RECORD_CLASS_IN
+        ) {
+            invalidResponse("unexpected question type")
+        }
+        offset += QUESTION_TRAILER_LENGTH
+
+        repeat(answerCount) {
+            offset = skipName(response, length, offset)
+            if (offset > length - RESOURCE_RECORD_HEADER_LENGTH) {
+                invalidResponse("truncated answer")
+            }
+            val recordType = readUInt16(response, offset)
+            val recordClass = readUInt16(response, offset + 2)
+            val dataLength = readUInt16(response, offset + 8)
+            offset += RESOURCE_RECORD_HEADER_LENGTH
+            if (dataLength > length - offset) invalidResponse("truncated answer data")
+            if (
+                recordType == RECORD_TYPE_A &&
+                recordClass == RECORD_CLASS_IN &&
+                dataLength == IPV4_ADDRESS_LENGTH
+            ) {
+                return
+            }
+            offset += dataLength
+        }
+        invalidResponse("reply contained no IPv4 address")
+    }
+
+    private fun skipName(
+        response: ByteArray,
+        length: Int,
+        startingOffset: Int,
+        compressionDepth: Int = 0,
+    ): Int {
+        if (compressionDepth > MAX_COMPRESSION_DEPTH) invalidResponse("compression loop")
+        var offset = startingOffset
+        var labels = 0
+        while (true) {
+            if (offset >= length || labels > MAX_NAME_LABELS) invalidResponse("truncated name")
+            val labelLength = response[offset].toInt() and 0xff
+            when {
+                labelLength and COMPRESSION_MASK == COMPRESSION_MASK -> {
+                    if (offset >= length - 1) invalidResponse("truncated compression pointer")
+                    val pointer =
+                        ((labelLength and COMPRESSION_POINTER_MASK) shl 8) or
+                            (response[offset + 1].toInt() and 0xff)
+                    if (pointer < DNS_HEADER_LENGTH || pointer >= offset) {
+                        invalidResponse("invalid compression pointer")
+                    }
+                    skipName(response, length, pointer, compressionDepth + 1)
+                    return offset + 2
+                }
+
+                labelLength and COMPRESSION_MASK != 0 -> invalidResponse("invalid label")
+                labelLength == 0 -> return offset + 1
+                labelLength > MAX_LABEL_LENGTH -> invalidResponse("invalid label length")
+                else -> {
+                    offset += 1
+                    if (labelLength > length - offset) invalidResponse("truncated label")
+                    offset += labelLength
+                    labels += 1
+                }
+            }
+        }
+    }
+
+    private fun readUInt16(bytes: ByteArray, offset: Int): Int =
+        ((bytes[offset].toInt() and 0xff) shl 8) or
+            (bytes[offset + 1].toInt() and 0xff)
+
+    private fun invalidResponse(detail: String): Nothing =
+        throw IOException("invalid DNS response: $detail")
+
+    private const val DNS_HEADER_LENGTH = 12
+    private const val QUESTION_TRAILER_LENGTH = 4
+    private const val RESOURCE_RECORD_HEADER_LENGTH = 10
+    private const val RECORD_TYPE_A = 1
+    private const val RECORD_CLASS_IN = 1
+    private const val IPV4_ADDRESS_LENGTH = 4
+    private const val RESPONSE_FLAG = 0x8000
+    private const val OPCODE_MASK = 0x7800
+    private const val TRUNCATED_FLAG = 0x0200
+    private const val RESPONSE_CODE_MASK = 0x000f
+    private const val COMPRESSION_MASK = 0xc0
+    private const val COMPRESSION_POINTER_MASK = 0x3f
+    private const val MAX_HOSTNAME_LENGTH = 253
+    private const val MAX_LABEL_LENGTH = 63
+    private const val MAX_NAME_LABELS = 127
+    private const val MAX_COMPRESSION_DEPTH = 127
+}
 
 class InternetProbe(context: Context) {
     private val connectivityManager = context.getSystemService(ConnectivityManager::class.java)
@@ -95,8 +266,19 @@ class InternetProbe(context: Context) {
                 ?.hasTransport(NetworkCapabilities.TRANSPORT_VPN) == true
         }
 
-    private suspend fun probe(network: Network, endpoint: String) = withContext(Dispatchers.IO) {
-        val connection = (network.openConnection(URL(endpoint)) as HttpURLConnection).apply {
+    private suspend fun probe(network: Network, endpoint: String) {
+        val url = URL(endpoint)
+        // An HTTPS-only check can reuse a cached address and say nothing about the tunnel's DNS
+        // path. Force a resolution on this exact VPN Network first. The matching sing-box rule
+        // also disables its own cache, so every supported API reaches proxied DoH per attempt.
+        runFreshDnsHttpsProbe(
+            resolveFreshDns = { resolveFreshDns(network, url.host) },
+            probeHttps = { probeHttps(network, url) },
+        )
+    }
+
+    private suspend fun probeHttps(network: Network, url: URL) = withContext(Dispatchers.IO) {
+        val connection = (network.openConnection(url) as HttpURLConnection).apply {
             requestMethod = "GET"
             connectTimeout = REQUEST_TIMEOUT_MS
             readTimeout = REQUEST_TIMEOUT_MS
@@ -116,14 +298,132 @@ class InternetProbe(context: Context) {
         }
     }
 
+    private suspend fun resolveFreshDns(network: Network, hostname: String) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            // Network.getAllByName() can reuse netd's cache on API 26-28. Address the VPN's own
+            // DNS listener with a raw query instead: bindSocket keeps the datagram in this VPN,
+            // while the exact sing-box probe rule disables its upstream cache.
+            return resolveFreshDnsLegacy(network, hostname)
+        }
+
+        resolveFreshDnsApi29(network, hostname)
+    }
+
+    private suspend fun resolveFreshDnsLegacy(network: Network, hostname: String) {
+        val tunnelDnsServers = connectivityManager.getLinkProperties(network)?.dnsServers.orEmpty()
+        val tunnelDnsServer = tunnelDnsServers.firstOrNull { it is Inet4Address }
+            ?: tunnelDnsServers.firstOrNull()
+            ?: throw UnknownHostException("VPN DNS listener is unavailable")
+        val transactionId = Random.nextInt(0x10000)
+        val query = try {
+            TunnelDnsAProbe.makeQuery(hostname, transactionId)
+        } catch (error: IllegalArgumentException) {
+            throw UnknownHostException("invalid DNS probe hostname: $hostname").apply {
+                initCause(error)
+            }
+        }
+
+        suspendCancellableCoroutine { continuation ->
+            val socket = try {
+                DatagramSocket()
+            } catch (error: IOException) {
+                continuation.resumeWithException(
+                    UnknownHostException("fresh DNS lookup failed for $hostname").apply {
+                        initCause(error)
+                    },
+                )
+                return@suspendCancellableCoroutine
+            }
+            continuation.invokeOnCancellation { socket.close() }
+            Dispatchers.IO.asExecutor().execute {
+                try {
+                    // bindSocket must run before connect; do not protect this socket, because its
+                    // purpose is specifically to enter the TUN and exercise proxied DoH.
+                    network.bindSocket(socket)
+                    // The generated resolver chain permits a 2s primary evaluation followed by
+                    // a 3s secondary attempt. Leave enough room for the secondary response.
+                    socket.soTimeout = LEGACY_DNS_TIMEOUT_MS
+                    socket.connect(tunnelDnsServer, DNS_PORT)
+                    socket.send(DatagramPacket(query, query.size))
+
+                    val response = ByteArray(MAX_DNS_RESPONSE_SIZE)
+                    val packet = DatagramPacket(response, response.size)
+                    socket.receive(packet)
+                    TunnelDnsAProbe.validateResponse(
+                        response = packet.data,
+                        transactionId = transactionId,
+                        length = packet.length,
+                    )
+                    if (continuation.isActive) continuation.resume(Unit)
+                } catch (error: Exception) {
+                    if (continuation.isActive) {
+                        // Only wire/transport failures are remote DNS evidence. Preserve local
+                        // permission and programming failures for FailureClassifier.
+                        val failure = if (error is IOException) {
+                            UnknownHostException("fresh DNS lookup failed for $hostname").apply {
+                                initCause(error)
+                            }
+                        } else {
+                            error
+                        }
+                        continuation.resumeWithException(failure)
+                    }
+                } finally {
+                    socket.close()
+                }
+            }
+        }
+    }
+
+    @Suppress("NewApi")
+    private suspend fun resolveFreshDnsApi29(network: Network, hostname: String) =
+        suspendCancellableCoroutine { continuation ->
+            val cancellationSignal = CancellationSignal()
+            continuation.invokeOnCancellation { cancellationSignal.cancel() }
+            DnsResolver.getInstance().query(
+                network,
+                hostname,
+                // Bypass Android/netd's lookup cache. Allow storing the fresh answer so the
+                // immediately-following HTTPS request can reuse precisely what was just proved.
+                DnsResolver.FLAG_NO_CACHE_LOOKUP,
+                Dispatchers.IO.asExecutor(),
+                cancellationSignal,
+                object : DnsResolver.Callback<List<InetAddress>> {
+                    override fun onAnswer(answer: List<InetAddress>, rcode: Int) {
+                        if (!continuation.isActive) return
+                        if (rcode != 0 || answer.isEmpty()) {
+                            continuation.resumeWithException(
+                                UnknownHostException(
+                                    "fresh DNS lookup failed for $hostname (rcode=$rcode)",
+                                ),
+                            )
+                        } else {
+                            continuation.resume(Unit)
+                        }
+                    }
+
+                    override fun onError(error: DnsResolver.DnsException) {
+                        if (!continuation.isActive) return
+                        continuation.resumeWithException(
+                            UnknownHostException("fresh DNS lookup failed for $hostname").apply {
+                                initCause(error)
+                            },
+                        )
+                    }
+                },
+            )
+        }
+
     companion object {
         private const val PROBE_DEADLINE_MS = 12_000L
         private const val RETRY_DELAY_MS = 500L
         private const val REQUEST_TIMEOUT_MS = 3_000
+        private const val LEGACY_DNS_TIMEOUT_MS = 6_000
+        private const val DNS_PORT = 53
+        private const val MAX_DNS_RESPONSE_SIZE = 4_096
 
         internal val ENDPOINTS = listOf(
-            "https://www.gstatic.com/generate_204",
-            "https://cp.cloudflare.com/generate_204",
+            "https://${SingBoxConfiguration.CONNECTIVITY_PROBE_HOST}/generate_204",
         )
 
         internal fun acceptsHttpStatus(status: Int): Boolean = status in 200..299

--- a/android/app/src/main/java/com/openrung/net/SingBoxConfiguration.kt
+++ b/android/app/src/main/java/com/openrung/net/SingBoxConfiguration.kt
@@ -43,6 +43,14 @@ data class SplitTunnelRules(
     }
 }
 
+data class DnsOverHttpsResolver(
+    val tag: String,
+    /** Literal address keeps the resolver bootstrap independent from DNS itself. */
+    val serverAddress: String,
+    /** Hostname authenticated by TLS while [serverAddress] is dialed directly. */
+    val tlsServerName: String,
+)
+
 data class SingBoxConfiguration(
     val relay: RelayDescriptor,
     /** Loopback TCP adapter exposed by a native transport. Empty means use the relay endpoint. */
@@ -50,7 +58,7 @@ data class SingBoxConfiguration(
     val bridgePort: Int = 0,
     val tunnelIPv4Address: String = "172.19.0.1/30",
     val tunnelIPv6Address: String = "fdfe:dcba:9876::1/126",
-    val dnsServers: List<String> = listOf("1.1.1.1", "8.8.8.8"),
+    val dnsOverHttpsResolvers: List<DnsOverHttpsResolver> = DEFAULT_DOH_RESOLVERS,
     val mtu: Int = 1400,
     val splitTunnel: SplitTunnelRules? = null,
 ) {
@@ -72,6 +80,9 @@ data class SingBoxConfiguration(
         val outboundPort = if (useLoopbackAdapter) bridgePort else relay.publicPort
         val bypassCountries = splitTunnel?.bypassCountries.orEmpty()
         val excludedPackages = splitTunnel?.excludedPackages.orEmpty()
+        validateDnsResolvers()
+        val primaryDnsResolver = dnsOverHttpsResolvers.first()
+        val fallbackDnsResolver = dnsOverHttpsResolvers.last()
 
         val tunInbound = mutableMapOf<String, JsonElement>(
             "type" to JsonPrimitive("tun"),
@@ -104,12 +115,21 @@ data class SingBoxConfiguration(
             })
             put("dns", buildJsonObject {
                 put("servers", buildJsonArray {
-                    dnsServers.forEachIndexed { index, server ->
+                    // Resolve DoH without asking DNS how to reach DNS: each resolver dials a
+                    // literal IP while TLS authenticates the provider hostname. WSS therefore
+                    // carries ordinary HTTPS/443 instead of the blackholed TCP/53 it replaces.
+                    dnsOverHttpsResolvers.forEach { resolver ->
                         add(buildJsonObject {
-                            put("tag", "dns-$index")
-                            put("type", "tcp")
-                            put("server", server)
+                            put("tag", resolver.tag)
+                            put("type", "https")
+                            put("server", resolver.serverAddress)
+                            put("server_port", 443)
+                            put("path", "/dns-query")
                             put("detour", "proxy")
+                            put("tls", buildJsonObject {
+                                put("enabled", true)
+                                put("server_name", resolver.tlsServerName)
+                            })
                         })
                     }
                     bypassCountries.forEach { country ->
@@ -123,17 +143,29 @@ data class SingBoxConfiguration(
                         })
                     }
                 })
-                if (bypassCountries.isNotEmpty()) {
-                    put("rules", buildJsonArray {
-                        bypassCountries.forEach { country ->
-                            add(buildJsonObject {
-                                put("rule_set", JsonArray(listOf(JsonPrimitive("geosite-$country"))))
-                                put("server", "dns-direct-$country")
-                            })
-                        }
-                    })
-                }
-                put("final", "dns-0")
+                put("rules", buildJsonArray {
+                    // These exact-host rules deliberately precede every country rule. The probe
+                    // therefore cannot be captured by geosite-cn (or a future country list), and
+                    // disabling both caches makes each health check exercise upstream DoH.
+                    dnsFailoverRules(
+                        domain = CONNECTIVITY_PROBE_HOST,
+                        disableCache = true,
+                        requireAddress = true,
+                    ).forEach(::add)
+                    bypassCountries.forEach { country ->
+                        add(buildJsonObject {
+                            put("rule_set", JsonArray(listOf(JsonPrimitive("geosite-$country"))))
+                            put("action", "route")
+                            put("server", "dns-direct-$country")
+                        })
+                    }
+                    // A static primary `final` never consults a second resolver. Evaluate is
+                    // non-terminal on an exchange error in the pinned sing-box 1.14+ engine; a
+                    // usable response is returned by `respond`, otherwise the next resolver runs.
+                    dnsFailoverRules().forEach(::add)
+                })
+                put("final", fallbackDnsResolver.tag)
+                put("timeout", DNS_FALLBACK_TIMEOUT)
             })
             put("inbounds", JsonArray(listOf(JsonObject(tunInbound))))
             put("outbounds", buildJsonArray {
@@ -172,7 +204,7 @@ data class SingBoxConfiguration(
             put("route", buildJsonObject {
                 put("auto_detect_interface", true)
                 put("find_process", true)
-                put("default_domain_resolver", "dns-0")
+                put("default_domain_resolver", primaryDnsResolver.tag)
                 if (bypassCountries.isNotEmpty()) {
                     put("rule_set", buildJsonArray {
                         bypassCountries.forEach { country ->
@@ -186,12 +218,15 @@ data class SingBoxConfiguration(
                         put("protocol", "dns")
                         put("action", "hijack-dns")
                     })
-                    if (bypassCountries.isNotEmpty()) {
-                        // Route rules need a sniffed domain before geosite matching can work.
-                        add(buildJsonObject {
-                            put("action", "sniff")
-                        })
-                    }
+                    // Raw TUN connections arrive with an IP destination. Sniff first so both the
+                    // exact probe exception and country geosite rules can inspect TLS/HTTP names.
+                    add(buildJsonObject {
+                        put("action", "sniff")
+                    })
+                    add(buildJsonObject {
+                        put("domain", JsonArray(listOf(JsonPrimitive(CONNECTIVITY_PROBE_HOST))))
+                        put("outbound", "proxy")
+                    })
                     if (splitTunnel?.bypassLan == true) {
                         add(buildJsonObject {
                             put("ip_is_private", true)
@@ -225,6 +260,66 @@ data class SingBoxConfiguration(
         }
     }
 
+    /**
+     * Emits an ordered primary-to-secondary resolver chain using sing-box 1.14 DNS actions.
+     * `NOERROR` (including NODATA) and authoritative `NXDOMAIN` are terminal for ordinary
+     * lookups. The known-existing probe is stricter: its primary response is accepted only when
+     * it contains an address. Timeouts, transport errors, SERVFAIL and REFUSED fall through.
+     */
+    private fun dnsFailoverRules(
+        domain: String? = null,
+        disableCache: Boolean = false,
+        requireAddress: Boolean = false,
+    ): List<JsonObject> = buildList {
+        dnsOverHttpsResolvers.dropLast(1).forEach { resolver ->
+            add(buildJsonObject {
+                domain?.let {
+                    put("domain", JsonArray(listOf(JsonPrimitive(it))))
+                }
+                put("action", "evaluate")
+                put("server", resolver.tag)
+                put("timeout", DNS_PRIMARY_TIMEOUT)
+                if (disableCache) {
+                    put("disable_cache", true)
+                    put("disable_optimistic_cache", true)
+                }
+            })
+            if (requireAddress) {
+                add(buildJsonObject {
+                    domain?.let {
+                        put("domain", JsonArray(listOf(JsonPrimitive(it))))
+                    }
+                    put("match_response", true)
+                    put("ip_accept_any", true)
+                    put("action", "respond")
+                })
+            } else {
+                listOf("NOERROR", "NXDOMAIN").forEach { responseCode ->
+                    add(buildJsonObject {
+                        domain?.let {
+                            put("domain", JsonArray(listOf(JsonPrimitive(it))))
+                        }
+                        put("match_response", true)
+                        put("response_rcode", responseCode)
+                        put("action", "respond")
+                    })
+                }
+            }
+        }
+        add(buildJsonObject {
+            domain?.let {
+                put("domain", JsonArray(listOf(JsonPrimitive(it))))
+            }
+            put("action", "route")
+            put("server", dnsOverHttpsResolvers.last().tag)
+            put("timeout", DNS_FALLBACK_TIMEOUT)
+            if (disableCache) {
+                put("disable_cache", true)
+                put("disable_optimistic_cache", true)
+            }
+        })
+    }
+
     private fun localRuleSet(tag: String): JsonObject = buildJsonObject {
         put("type", "local")
         put("tag", tag)
@@ -253,7 +348,44 @@ data class SingBoxConfiguration(
         }
     }
 
+    private fun validateDnsResolvers() {
+        require(dnsOverHttpsResolvers.size >= 2) {
+            "at least two DNS-over-HTTPS resolvers are required for failover"
+        }
+        require(dnsOverHttpsResolvers.map { it.tag }.distinct().size == dnsOverHttpsResolvers.size) {
+            "DNS-over-HTTPS resolver tags must be unique"
+        }
+        dnsOverHttpsResolvers.forEach { resolver ->
+            require(resolver.tag.isNotBlank() && resolver.tlsServerName.isNotBlank()) {
+                "DNS-over-HTTPS resolver requires a tag and TLS server name"
+            }
+            val address = resolver.serverAddress.removePrefix("[").removeSuffix("]")
+            require(address.isIPv4Literal() || address.contains(":")) {
+                "DNS-over-HTTPS resolver bootstrap must be a literal IP address"
+            }
+        }
+    }
+
     companion object {
+        /** Exact host used only by startup and long-lived through-tunnel probes. */
+        const val CONNECTIVITY_PROBE_HOST = "cp.cloudflare.com"
+
+        val DEFAULT_DOH_RESOLVERS: List<DnsOverHttpsResolver> = listOf(
+            DnsOverHttpsResolver(
+                tag = "dns-proxy-primary",
+                serverAddress = "1.1.1.1",
+                tlsServerName = "cloudflare-dns.com",
+            ),
+            DnsOverHttpsResolver(
+                tag = "dns-proxy-secondary",
+                serverAddress = "8.8.8.8",
+                tlsServerName = "dns.google",
+            ),
+        )
+
+        private const val DNS_PRIMARY_TIMEOUT = "2s"
+        private const val DNS_FALLBACK_TIMEOUT = "3s"
+
         private val prettyJson = Json {
             prettyPrint = true
         }

--- a/android/app/src/main/java/com/openrung/vpn/OpenRungVpnService.kt
+++ b/android/app/src/main/java/com/openrung/vpn/OpenRungVpnService.kt
@@ -359,24 +359,25 @@ class OpenRungVpnService : VpnService() {
             }
 
             failureStage = "relay_connect"
-            val connectedRelay = connectFirstAvailable(rankedCandidates.map { it.relay })
-            // If a disconnect raced in while we were connecting, don't publish CONNECTED for a
-            // tunnel that's being torn down. Stopping the engine is owned by disconnect()/a new
-            // connect (both call cleanupActiveTunnel); we just must not commit CONNECTED here.
-            coroutineContext.ensureActive()
-            val relay = connectedRelay.relay
-            activeRelayId = relay.id
-            TelemetryManager.markConnected(relay.id)
-            OpenRungStatusStore.setStatus(
-                ConnectionStatus.CONNECTED,
-                relayLabel = null,
-                relayName = relay.displayName(),
-                // Bridge contract: anything but "foundation" collapses to "volunteer".
-                relayClass = relay.normalizedNodeClass(),
-                lastError = null,
+            val connectedRelay = publishConnectedAfterVerifiedStartup(
+                startAndVerify = { connectFirstAvailable(rankedCandidates.map { it.relay }) },
+                publishConnected = { verifiedRelay ->
+                    val relay = verifiedRelay.relay
+                    activeRelayId = relay.id
+                    TelemetryManager.markConnected(relay.id)
+                    OpenRungStatusStore.setStatus(
+                        ConnectionStatus.CONNECTED,
+                        relayLabel = null,
+                        relayName = relay.displayName(),
+                        // Bridge contract: anything but "foundation" collapses to "volunteer".
+                        relayClass = relay.normalizedNodeClass(),
+                        lastError = null,
+                    )
+                    updateNotification(getString(R.string.status_connected))
+                    applyRelayLocation(relay)
+                },
             )
-            updateNotification(getString(R.string.status_connected))
-            applyRelayLocation(relay)
+            val relay = connectedRelay.relay
             TelemetryManager.record(
                 event = "connection_succeeded",
                 relayId = relay.id,

--- a/android/app/src/main/java/com/openrung/vpn/StartupPublicationGate.kt
+++ b/android/app/src/main/java/com/openrung/vpn/StartupPublicationGate.kt
@@ -1,0 +1,18 @@
+package com.openrung.vpn
+
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+
+/**
+ * The single startup gate for visible CONNECTED publication. A failed or superseded tunnel
+ * startup never invokes [publishConnected]; callers receive the original failure instead.
+ */
+internal suspend fun <T> publishConnectedAfterVerifiedStartup(
+    startAndVerify: suspend () -> T,
+    publishConnected: (T) -> Unit,
+): T {
+    val verified = startAndVerify()
+    currentCoroutineContext().ensureActive()
+    publishConnected(verified)
+    return verified
+}

--- a/android/app/src/test/java/com/openrung/net/InternetProbeChinaBypassIntegrationTest.kt
+++ b/android/app/src/test/java/com/openrung/net/InternetProbeChinaBypassIntegrationTest.kt
@@ -1,0 +1,180 @@
+package com.openrung.net
+
+import com.openrung.model.RelayDescriptor
+import com.openrung.state.ConnectionStatus
+import com.openrung.vpn.publishConnectedAfterVerifiedStartup
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.net.ConnectException
+import java.net.UnknownHostException
+
+/** Generated-config integration coverage for the geosite-cn connectivity-probe regression. */
+class InternetProbeChinaBypassIntegrationTest {
+    @Test
+    fun `direct internet cannot publish connected when China bypass is on and proxy is dead`() = runTest {
+        val network = RoutingAwareNetwork(
+            configuration = chinaBypassConfiguration(),
+            directInternetAvailable = true,
+            proxyAvailable = false,
+        )
+        val publishedStatuses = mutableListOf<ConnectionStatus>()
+
+        val failure = runCatching {
+            publishConnectedAfterVerifiedStartup(
+                startAndVerify = {
+                    runFreshDnsHttpsProbe(
+                        resolveFreshDns = { network.resolveProbe() },
+                        probeHttps = { network.requestProbeHttps() },
+                    )
+                },
+                publishConnected = { publishedStatuses += ConnectionStatus.CONNECTED },
+            )
+        }.exceptionOrNull()
+
+        assertTrue(failure is UnknownHostException)
+        assertFalse(publishedStatuses.contains(ConnectionStatus.CONNECTED))
+        assertEquals(listOf(SimulatedPath.PROXY), network.selectedPaths)
+    }
+
+    @Test
+    fun `working proxy passes startup with China bypass enabled`() = runTest {
+        val network = RoutingAwareNetwork(
+            configuration = chinaBypassConfiguration(),
+            directInternetAvailable = true,
+            proxyAvailable = true,
+        )
+        val publishedStatuses = mutableListOf<ConnectionStatus>()
+
+        publishConnectedAfterVerifiedStartup(
+            startAndVerify = {
+                runFreshDnsHttpsProbe(
+                    resolveFreshDns = { network.resolveProbe() },
+                    probeHttps = { network.requestProbeHttps() },
+                )
+            },
+            publishConnected = { publishedStatuses += ConnectionStatus.CONNECTED },
+        )
+
+        assertEquals(listOf(ConnectionStatus.CONNECTED), publishedStatuses)
+        assertEquals(
+            listOf(SimulatedPath.PROXY, SimulatedPath.PROXY),
+            network.selectedPaths,
+        )
+    }
+
+    private fun chinaBypassConfiguration(): JsonObject = SingBoxConfiguration(
+        relay = relay(),
+        splitTunnel = SplitTunnelRules(
+            bypassLan = false,
+            bypassCountries = listOf("cn"),
+            excludedPackages = emptyList(),
+            ruleSetDirectory = "/data/user/0/rulesets",
+        ),
+    ).makeJsonObject()
+
+    private fun relay(): RelayDescriptor = RelayDescriptor(
+        id = "relay-1",
+        label = "test-relay",
+        publicHost = "203.0.113.10",
+        publicPort = 443,
+        relayProtocol = "vless-reality-vision",
+        clientId = "e6b1a1de-9f0f-4c1a-8bb1-1f2b3c4d5e6f",
+        realityPublicKey = "reality-key",
+        shortId = "abcd1234",
+        serverName = "www.example.com",
+        flow = "xtls-rprx-vision",
+        exitMode = "direct",
+        maxSessions = 8,
+        maxMbps = 100,
+        relayVersion = "1.0.0",
+        transport = "tunnel",
+        punchCapable = true,
+        punchEndpoint = "https://203.0.113.10:9444",
+        registeredAt = "2026-01-01T00:00:00Z",
+        lastHeartbeatAt = "2026-01-01T00:00:00Z",
+        expiresAt = "2026-01-01T01:00:00Z",
+    )
+}
+
+private enum class SimulatedPath {
+    DIRECT,
+    PROXY,
+}
+
+/**
+ * Treats the probe hostname as a geosite-cn member, matching the production regression. It walks
+ * generated rules in order; usable direct internet is intentionally available so only the exact
+ * forced-proxy rules can keep a dead proxy from looking healthy.
+ */
+private class RoutingAwareNetwork(
+    private val configuration: JsonObject,
+    private val directInternetAvailable: Boolean,
+    private val proxyAvailable: Boolean,
+) {
+    val selectedPaths = mutableListOf<SimulatedPath>()
+
+    fun resolveProbe() {
+        val path = selectedDnsPath()
+        selectedPaths += path
+        if (!isAvailable(path)) throw UnknownHostException("simulated probe DNS path is unavailable")
+    }
+
+    fun requestProbeHttps() {
+        val path = selectedRoutePath()
+        selectedPaths += path
+        if (!isAvailable(path)) throw ConnectException("simulated probe HTTPS path is unavailable")
+    }
+
+    private fun selectedDnsPath(): SimulatedPath {
+        val rules = configuration["dns"]!!.jsonObject["rules"]!!.jsonArray
+        for (element in rules) {
+            val rule = element.jsonObject
+            if (rule.matchesProbeDomain()) {
+                val server = rule["server"]?.jsonPrimitive?.content.orEmpty()
+                if (server.startsWith("dns-proxy-")) return SimulatedPath.PROXY
+            }
+            if (rule.matchesChinaRuleSet()) return SimulatedPath.DIRECT
+        }
+        return SimulatedPath.DIRECT
+    }
+
+    private fun selectedRoutePath(): SimulatedPath {
+        val route = configuration["route"]!!.jsonObject
+        for (element in route["rules"]!!.jsonArray) {
+            val rule = element.jsonObject
+            if (rule.matchesProbeDomain()) {
+                return if (rule["outbound"]?.jsonPrimitive?.content == "proxy") {
+                    SimulatedPath.PROXY
+                } else {
+                    SimulatedPath.DIRECT
+                }
+            }
+            if (rule.matchesChinaRuleSet()) return SimulatedPath.DIRECT
+        }
+        return if (route["final"]!!.jsonPrimitive.content == "proxy") {
+            SimulatedPath.PROXY
+        } else {
+            SimulatedPath.DIRECT
+        }
+    }
+
+    private fun JsonObject.matchesProbeDomain(): Boolean =
+        this["domain"]?.jsonArray?.any {
+            it.jsonPrimitive.content == SingBoxConfiguration.CONNECTIVITY_PROBE_HOST
+        } == true
+
+    private fun JsonObject.matchesChinaRuleSet(): Boolean =
+        this["rule_set"]?.jsonArray?.any { it.jsonPrimitive.content == "geosite-cn" } == true
+
+    private fun isAvailable(path: SimulatedPath): Boolean = when (path) {
+        SimulatedPath.DIRECT -> directInternetAvailable
+        SimulatedPath.PROXY -> proxyAvailable
+    }
+}

--- a/android/app/src/test/java/com/openrung/net/InternetProbeTest.kt
+++ b/android/app/src/test/java/com/openrung/net/InternetProbeTest.kt
@@ -1,0 +1,132 @@
+package com.openrung.net
+
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.net.UnknownHostException
+
+class InternetProbeTest {
+    @Test
+    fun `defaults use only dedicated forced-proxy hostname`() {
+        assertEquals(
+            listOf("https://cp.cloudflare.com/generate_204"),
+            InternetProbe.ENDPOINTS,
+        )
+        assertTrue(InternetProbe.ENDPOINTS.single().contains(SingBoxConfiguration.CONNECTIVITY_PROBE_HOST))
+        assertFalse(InternetProbe.ENDPOINTS.single().contains("www.gstatic.com"))
+    }
+
+    @Test
+    fun `probe requires fresh DNS before HTTPS`() = runTest {
+        val calls = mutableListOf<String>()
+
+        runFreshDnsHttpsProbe(
+            resolveFreshDns = { calls += "dns" },
+            probeHttps = { calls += "https" },
+        )
+
+        assertEquals(listOf("dns", "https"), calls)
+    }
+
+    @Test
+    fun `fresh DNS failure cannot be masked by reachable HTTPS`() = runTest {
+        var httpsAttempted = false
+
+        val failure = runCatching {
+            runFreshDnsHttpsProbe(
+                resolveFreshDns = { throw UnknownHostException("proxied DoH failed") },
+                probeHttps = { httpsAttempted = true },
+            )
+        }.exceptionOrNull()
+
+        assertTrue(failure is UnknownHostException)
+        assertFalse(httpsAttempted)
+    }
+
+    @Test
+    fun `only successful HTTPS statuses pass`() {
+        assertFalse(InternetProbe.acceptsHttpStatus(199))
+        assertTrue(InternetProbe.acceptsHttpStatus(200))
+        assertTrue(InternetProbe.acceptsHttpStatus(204))
+        assertTrue(InternetProbe.acceptsHttpStatus(299))
+        assertFalse(InternetProbe.acceptsHttpStatus(300))
+        assertFalse(InternetProbe.acceptsHttpStatus(503))
+    }
+
+    @Test
+    fun `legacy fresh DNS query is an uncached wire A lookup`() {
+        val query = TunnelDnsAProbe.makeQuery("cp.cloudflare.com", 0x1234)
+
+        assertEquals(0x12, query[0].toInt() and 0xff)
+        assertEquals(0x34, query[1].toInt() and 0xff)
+        assertEquals(0x01, query[2].toInt() and 0xff) // Recursion desired.
+        assertEquals(1, unsignedShort(query, 4))
+        assertTrue(query.takeLast(4).toByteArray().contentEquals(byteArrayOf(0, 1, 0, 1)))
+    }
+
+    @Test
+    fun `legacy fresh DNS accepts a matching address answer`() {
+        val response = successfulDnsResponse(transactionId = 0x2345, includeAddress = true)
+
+        TunnelDnsAProbe.validateResponse(response, transactionId = 0x2345)
+    }
+
+    @Test
+    fun `legacy fresh DNS rejects empty and failed replies`() {
+        val empty = successfulDnsResponse(transactionId = 0x3456, includeAddress = false)
+        val servfail = empty.copyOf().apply { this[3] = 0x82.toByte() }
+
+        assertTrue(
+            runCatching {
+                TunnelDnsAProbe.validateResponse(empty, transactionId = 0x3456)
+            }.exceptionOrNull() != null,
+        )
+        assertTrue(
+            runCatching {
+                TunnelDnsAProbe.validateResponse(servfail, transactionId = 0x3456)
+            }.exceptionOrNull() != null,
+        )
+    }
+
+    @Test
+    fun `legacy fresh DNS rejects mismatched and truncated replies`() {
+        val response = successfulDnsResponse(transactionId = 0x4567, includeAddress = true)
+        val truncated = response.copyOf().apply { this[2] = (this[2].toInt() or 0x02).toByte() }
+
+        assertTrue(
+            runCatching {
+                TunnelDnsAProbe.validateResponse(response, transactionId = 0x4568)
+            }.exceptionOrNull() != null,
+        )
+        assertTrue(
+            runCatching {
+                TunnelDnsAProbe.validateResponse(truncated, transactionId = 0x4567)
+            }.exceptionOrNull() != null,
+        )
+    }
+
+    private fun successfulDnsResponse(transactionId: Int, includeAddress: Boolean): ByteArray {
+        val query = TunnelDnsAProbe.makeQuery("cp.cloudflare.com", transactionId)
+        val responseHeaderAndQuestion = query.copyOf().apply {
+            this[2] = 0x81.toByte()
+            this[3] = 0x80.toByte()
+            this[6] = 0
+            this[7] = if (includeAddress) 1 else 0
+        }
+        if (!includeAddress) return responseHeaderAndQuestion
+        return responseHeaderAndQuestion + byteArrayOf(
+            0xc0.toByte(), 0x0c, // Answer name points at the question.
+            0x00, 0x01, // A.
+            0x00, 0x01, // IN.
+            0x00, 0x00, 0x00, 0x3c, // TTL.
+            0x00, 0x04,
+            104, 16, 123, 96,
+        )
+    }
+
+    private fun unsignedShort(bytes: ByteArray, offset: Int): Int =
+        ((bytes[offset].toInt() and 0xff) shl 8) or
+            (bytes[offset + 1].toInt() and 0xff)
+}

--- a/android/app/src/test/java/com/openrung/net/SingBoxConfigurationDnsTest.kt
+++ b/android/app/src/test/java/com/openrung/net/SingBoxConfigurationDnsTest.kt
@@ -1,0 +1,185 @@
+package com.openrung.net
+
+import com.openrung.model.RelayDescriptor
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SingBoxConfigurationDnsTest {
+    @Test
+    fun `proxied DNS uses non-circular DoH on 443`() {
+        val dns = config()["dns"]!!.jsonObject
+        val servers = dns["servers"]!!.jsonArray.map { it.jsonObject }
+
+        assertEquals(2, servers.size)
+        assertDohServer(
+            server = servers[0],
+            tag = "dns-proxy-primary",
+            address = "1.1.1.1",
+            tlsServerName = "cloudflare-dns.com",
+        )
+        assertDohServer(
+            server = servers[1],
+            tag = "dns-proxy-secondary",
+            address = "8.8.8.8",
+            tlsServerName = "dns.google",
+        )
+        assertEquals("dns-proxy-secondary", dns["final"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `conditional evaluate chain really fails over to secondary resolver`() {
+        val rules = config()["dns"]!!.jsonObject["rules"]!!.jsonArray
+            .map { it.jsonObject }
+            .filterNot { it.containsKey("domain") }
+
+        assertEquals(listOf("evaluate", "respond", "respond", "route"), rules.map(::action))
+        assertEquals("dns-proxy-primary", rules[0]["server"]!!.jsonPrimitive.content)
+        assertEquals("NOERROR", rules[1]["response_rcode"]!!.jsonPrimitive.content)
+        assertEquals("NXDOMAIN", rules[2]["response_rcode"]!!.jsonPrimitive.content)
+        assertEquals("dns-proxy-secondary", rules[3]["server"]!!.jsonPrimitive.content)
+
+        assertEquals("dns-proxy-primary", selectedResolver(rules, "NOERROR"))
+        assertEquals("dns-proxy-primary", selectedResolver(rules, "NXDOMAIN"))
+        assertEquals("dns-proxy-secondary", selectedResolver(rules, "SERVFAIL"))
+        assertEquals("dns-proxy-secondary", selectedResolver(rules, "REFUSED"))
+        assertEquals("dns-proxy-secondary", selectedResolver(rules, null))
+    }
+
+    @Test
+    fun `probe DNS and HTTPS rules outrank China bypass`() {
+        val config = config(
+            SplitTunnelRules(
+                bypassLan = false,
+                bypassCountries = listOf("cn"),
+                excludedPackages = emptyList(),
+                ruleSetDirectory = "/data/user/0/rulesets",
+            ),
+        )
+        val dnsRules = config["dns"]!!.jsonObject["rules"]!!.jsonArray.map { it.jsonObject }
+        val directChinaDnsIndex = dnsRules.indexOfFirst {
+            it["server"]?.jsonPrimitive?.content == "dns-direct-cn"
+        }
+        val probeRules = dnsRules.take(directChinaDnsIndex)
+
+        assertTrue(directChinaDnsIndex > 0)
+        assertEquals(listOf("evaluate", "respond", "route"), probeRules.map(::action))
+        probeRules.forEach { rule ->
+            assertEquals(
+                SingBoxConfiguration.CONNECTIVITY_PROBE_HOST,
+                rule["domain"]!!.jsonArray.single().jsonPrimitive.content,
+            )
+        }
+        assertEquals("dns-proxy-primary", probeRules[0]["server"]!!.jsonPrimitive.content)
+        assertEquals(true, probeRules[0]["disable_cache"]!!.jsonPrimitive.content.toBoolean())
+        assertEquals(true, probeRules[0]["disable_optimistic_cache"]!!.jsonPrimitive.content.toBoolean())
+        assertEquals(true, probeRules[1]["match_response"]!!.jsonPrimitive.content.toBoolean())
+        assertEquals(true, probeRules[1]["ip_accept_any"]!!.jsonPrimitive.content.toBoolean())
+        assertEquals("dns-proxy-secondary", probeRules[2]["server"]!!.jsonPrimitive.content)
+        assertEquals(true, probeRules[2]["disable_cache"]!!.jsonPrimitive.content.toBoolean())
+
+        val routeRules = config["route"]!!.jsonObject["rules"]!!.jsonArray.map { it.jsonObject }
+        val forcedProxyIndex = routeRules.indexOfFirst { rule ->
+            rule["domain"]?.jsonArray?.any {
+                it.jsonPrimitive.content == SingBoxConfiguration.CONNECTIVITY_PROBE_HOST
+            } == true
+        }
+        val directChinaRouteIndex = routeRules.indexOfFirst { rule ->
+            rule["rule_set"]?.jsonArray?.any { it.jsonPrimitive.content == "geosite-cn" } == true
+        }
+        assertEquals("sniff", action(routeRules[forcedProxyIndex - 1]))
+        assertEquals("proxy", routeRules[forcedProxyIndex]["outbound"]!!.jsonPrimitive.content)
+        assertTrue(forcedProxyIndex < directChinaRouteIndex)
+    }
+
+    @Test
+    fun `resolver bootstrap rejects hostnames and missing failover`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            SingBoxConfiguration(
+                relay = relay(),
+                dnsOverHttpsResolvers = listOf(
+                    DnsOverHttpsResolver("one", "dns.example", "dns.example"),
+                    DnsOverHttpsResolver("two", "8.8.8.8", "dns.google"),
+                ),
+            ).makeJsonObject()
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            SingBoxConfiguration(
+                relay = relay(),
+                dnsOverHttpsResolvers = listOf(
+                    DnsOverHttpsResolver("only", "1.1.1.1", "cloudflare-dns.com"),
+                ),
+            ).makeJsonObject()
+        }
+    }
+
+    private fun assertDohServer(
+        server: JsonObject,
+        tag: String,
+        address: String,
+        tlsServerName: String,
+    ) {
+        assertEquals(tag, server["tag"]!!.jsonPrimitive.content)
+        assertEquals("https", server["type"]!!.jsonPrimitive.content)
+        assertEquals(address, server["server"]!!.jsonPrimitive.content)
+        assertEquals(443, server["server_port"]!!.jsonPrimitive.content.toInt())
+        assertEquals("/dns-query", server["path"]!!.jsonPrimitive.content)
+        assertEquals("proxy", server["detour"]!!.jsonPrimitive.content)
+        assertFalse(server.containsKey("domain_resolver"))
+        val tls = server["tls"]!!.jsonObject
+        assertEquals(true, tls["enabled"]!!.jsonPrimitive.content.toBoolean())
+        assertEquals(tlsServerName, tls["server_name"]!!.jsonPrimitive.content)
+    }
+
+    /** Models pinned sing-box evaluate/respond behavior for a primary outcome. */
+    private fun selectedResolver(rules: List<JsonObject>, primaryRcode: String?): String {
+        var evaluatedBy: String? = null
+        rules.forEach { rule ->
+            when (action(rule)) {
+                "evaluate" -> evaluatedBy = rule["server"]!!.jsonPrimitive.content
+                "respond" -> if (
+                    primaryRcode != null &&
+                    rule["response_rcode"]!!.jsonPrimitive.content == primaryRcode
+                ) {
+                    return checkNotNull(evaluatedBy)
+                }
+                "route" -> return rule["server"]!!.jsonPrimitive.content
+            }
+        }
+        error("resolver chain did not terminate")
+    }
+
+    private fun action(rule: JsonObject): String = rule["action"]!!.jsonPrimitive.content
+
+    private fun config(splitTunnel: SplitTunnelRules? = null): JsonObject =
+        SingBoxConfiguration(relay(), splitTunnel = splitTunnel).makeJsonObject()
+
+    private fun relay(): RelayDescriptor = RelayDescriptor(
+        id = "relay-1",
+        label = "test-relay",
+        publicHost = "203.0.113.10",
+        publicPort = 443,
+        relayProtocol = "vless-reality-vision",
+        clientId = "e6b1a1de-9f0f-4c1a-8bb1-1f2b3c4d5e6f",
+        realityPublicKey = "reality-key",
+        shortId = "abcd1234",
+        serverName = "www.example.com",
+        flow = "xtls-rprx-vision",
+        exitMode = "direct",
+        maxSessions = 8,
+        maxMbps = 100,
+        relayVersion = "1.0.0",
+        transport = "tunnel",
+        punchCapable = true,
+        punchEndpoint = "https://203.0.113.10:9444",
+        registeredAt = "2026-01-01T00:00:00Z",
+        lastHeartbeatAt = "2026-01-01T00:00:00Z",
+        expiresAt = "2026-01-01T01:00:00Z",
+    )
+}

--- a/android/app/src/test/java/com/openrung/net/SingBoxConfigurationSplitTunnelTest.kt
+++ b/android/app/src/test/java/com/openrung/net/SingBoxConfigurationSplitTunnelTest.kt
@@ -35,12 +35,17 @@ class SingBoxConfigurationSplitTunnelTest {
 
         val routeRules = config.routeRules()
         assertEquals(baseline.routeRules().size + 1, routeRules.size)
-        val lanRule = routeRules[1].jsonObject
+        val lanRule = routeRules[3].jsonObject
         assertEquals(true, lanRule["ip_is_private"]!!.jsonPrimitive.content.toBoolean())
         assertEquals("direct", lanRule["outbound"]!!.jsonPrimitive.content)
-        assertFalse(routeRules.any { "sniff" == it.jsonObject["action"]?.jsonPrimitive?.content })
+        assertEquals("sniff", routeRules[1].jsonObject["action"]!!.jsonPrimitive.content)
+        assertEquals(
+            SingBoxConfiguration.CONNECTIVITY_PROBE_HOST,
+            routeRules[2].jsonObject["domain"]!!.jsonArray.single().jsonPrimitive.content,
+        )
+        assertEquals("proxy", routeRules[2].jsonObject["outbound"]!!.jsonPrimitive.content)
 
-        assertFalse(config["dns"]!!.jsonObject.containsKey("rules"))
+        assertTrue(config["dns"]!!.jsonObject.containsKey("rules"))
         assertFalse(config["route"]!!.jsonObject.containsKey("rule_set"))
         assertFalse(config.tunInbound().containsKey("exclude_package"))
     }
@@ -55,13 +60,14 @@ class SingBoxConfigurationSplitTunnelTest {
         val routeRules = config.routeRules()
         assertEquals("hijack-dns", routeRules[0].jsonObject["action"]!!.jsonPrimitive.content)
         assertEquals("sniff", routeRules[1].jsonObject["action"]!!.jsonPrimitive.content)
-        val countryRule = routeRules[2].jsonObject
+        assertEquals("proxy", routeRules[2].jsonObject["outbound"]!!.jsonPrimitive.content)
+        val countryRule = routeRules[3].jsonObject
         assertEquals(
             listOf("geosite-ir", "geoip-ir"),
             countryRule["rule_set"]!!.jsonArray.map { it.jsonPrimitive.content },
         )
         assertEquals("direct", countryRule["outbound"]!!.jsonPrimitive.content)
-        assertEquals(3, routeRules.size)
+        assertEquals(4, routeRules.size)
 
         val dns = config["dns"]!!.jsonObject
         val directServer = dns["servers"]!!.jsonArray.last().jsonObject
@@ -74,12 +80,14 @@ class SingBoxConfigurationSplitTunnelTest {
         )
 
         val dnsRules = dns["rules"]!!.jsonArray
-        assertEquals(1, dnsRules.size)
+        val countryDnsRule = dnsRules.first {
+            it.jsonObject["server"]?.jsonPrimitive?.content == "dns-direct-ir"
+        }.jsonObject
         assertEquals(
             listOf("geosite-ir"),
-            dnsRules[0].jsonObject["rule_set"]!!.jsonArray.map { it.jsonPrimitive.content },
+            countryDnsRule["rule_set"]!!.jsonArray.map { it.jsonPrimitive.content },
         )
-        assertEquals("dns-direct-ir", dnsRules[0].jsonObject["server"]!!.jsonPrimitive.content)
+        assertEquals("route", countryDnsRule["action"]!!.jsonPrimitive.content)
 
         val ruleSets = config["route"]!!.jsonObject["rule_set"]!!.jsonArray.map { it.jsonObject }
         assertEquals(listOf("geosite-ir", "geoip-ir"), ruleSets.map { it["tag"]!!.jsonPrimitive.content })
@@ -99,17 +107,18 @@ class SingBoxConfigurationSplitTunnelTest {
         ).makeJsonObject()
 
         val routeRules = config.routeRules().map { it.jsonObject }
-        assertEquals(5, routeRules.size)
+        assertEquals(6, routeRules.size)
         assertEquals("hijack-dns", routeRules[0]["action"]!!.jsonPrimitive.content)
         assertEquals("sniff", routeRules[1]["action"]!!.jsonPrimitive.content)
-        assertEquals(true, routeRules[2]["ip_is_private"]!!.jsonPrimitive.content.toBoolean())
+        assertEquals("proxy", routeRules[2]["outbound"]!!.jsonPrimitive.content)
+        assertEquals(true, routeRules[3]["ip_is_private"]!!.jsonPrimitive.content.toBoolean())
         assertEquals(
             listOf("geosite-ir", "geoip-ir"),
-            routeRules[3]["rule_set"]!!.jsonArray.map { it.jsonPrimitive.content },
+            routeRules[4]["rule_set"]!!.jsonArray.map { it.jsonPrimitive.content },
         )
         assertEquals(
             listOf("geosite-cn", "geoip-cn"),
-            routeRules[4]["rule_set"]!!.jsonArray.map { it.jsonPrimitive.content },
+            routeRules[5]["rule_set"]!!.jsonArray.map { it.jsonPrimitive.content },
         )
 
         val dns = config["dns"]!!.jsonObject
@@ -125,7 +134,10 @@ class SingBoxConfigurationSplitTunnelTest {
         assertTrue(directServers.none { it.containsKey("detour") })
         assertEquals(
             listOf("dns-direct-ir", "dns-direct-cn"),
-            dns["rules"]!!.jsonArray.map { it.jsonObject["server"]!!.jsonPrimitive.content },
+            dns["rules"]!!.jsonArray.mapNotNull {
+                it.jsonObject["server"]?.jsonPrimitive?.content
+                    ?.takeIf { server -> server.startsWith("dns-direct-") }
+            },
         )
         assertEquals(
             listOf("geosite-ir", "geoip-ir", "geosite-cn", "geoip-cn"),

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -169,10 +169,38 @@ weaken the production OS policy.
   path-health recovery cancels that monitor, stops libbox first, retires the
   epoch monitor, and only then closes the WSS adapter before waiting for a usable
   physical network. On iOS, every startup and health result used for path
-  classification is a bounded HTTPS response-head probe created with
+  classification first sends a raw, uncached A query to the TUN DNS address
+  with `NEPacketTunnelProvider.createUDPSessionThroughTunnel`, then performs a
+  bounded HTTPS response-head probe with
   `NEPacketTunnelProvider.createTCPConnectionThroughTunnel`; a provider-owned
   `URLSession` is excluded from its own TUN and must never authorize fallback
   or recovery.
+- **Tunnel DNS and end-to-end proof** — every generated tunnel configuration
+  sends ordinary DNS through the `proxy` outbound as DoH on TCP/443. The
+  primary transport dials literal `1.1.1.1` while authenticating and sending
+  `cloudflare-dns.com`; the secondary dials literal `8.8.8.8` while
+  authenticating and sending `dns.google`. The literal dial addresses are the
+  bootstrap: reaching DNS never first requires DNS, while TLS still verifies
+  the provider hostname. Sing-box 1.14 `evaluate`/`respond` rules accept a
+  usable primary result and otherwise reach an explicit secondary `route`
+  rule; `dns.final` remains a defensive secondary fallback rather than the
+  mechanism expected to make the second server run.
+
+  Startup and active health use only
+  `https://cp.cloudflare.com/generate_204`. Its exact-host DNS rules run before
+  every country rule, disable normal and optimistic DNS caches, require an
+  address from the primary or try the secondary, and therefore exercise a
+  fresh proxied DNS exchange. After the unconditional sniff action, an
+  exact-host route to `proxy` also runs before LAN and country bypasses. Thus a
+  working direct connection cannot make a dead proxy look healthy when China
+  bypass is enabled; native publishes `CONNECTED` only after this DNS plus
+  HTTPS path succeeds. Android 10+ bypasses netd's lookup cache with
+  `DnsResolver.FLAG_NO_CACHE_LOOKUP`; Android 8–9 instead sends a raw A query
+  to the VPN-advertised DNS listener from a socket bound to the VPN `Network`.
+  Android's separate physical-network recovery check is intentionally
+  different: it remains bound outside the VPN and keeps both gstatic and
+  Cloudflare endpoints so it can distinguish a live local network from a dead
+  tunnel.
 - **Telemetry / heartbeat / speed-test** — currently also `https://broker.openrung.org/`
   (the same Cloudflare-fronted broker); see the trade-off below.
 - **Update manifest** — the exact direct broker and CloudFront candidates use
@@ -184,12 +212,13 @@ weaken the production OS policy.
   accept) — because an unrecognized candidate throws inside the fail-open walk
   and would silently demote the app to the GitHub-only path. `transport:check`
   and `updateManifest.test.ts` both assert the two lists are identical.
-- **Geo lookup** (`https://ipwho.is/`) and **connectivity probes**
-  (`https://www.gstatic.com/generate_204`, `https://cp.cloudflare.com/generate_204`)
-  are HTTPS. Android's physical-network recovery probe deliberately uses
-  `Network.openConnection` against those two independent connectivity
-  endpoints so the check cannot accidentally traverse the unhealthy VPN; it
-  sends no OpenRung identity or broker headers.
+- **Geo lookup** (`https://ipwho.is/`) and both kinds of **connectivity probe**
+  are HTTPS. The through-tunnel startup/health probe is the protected
+  `https://cp.cloudflare.com/generate_204` path described above. Android's
+  physical-network recovery probe deliberately uses `Network.openConnection`
+  against `https://www.gstatic.com/generate_204` and
+  `https://cp.cloudflare.com/generate_204` so that check cannot accidentally
+  traverse the unhealthy VPN; it sends no OpenRung identity or broker headers.
 
 There is no runtime switch back to the removed JavaScript broker transports.
 A missing or stale `OpenRungBroker` binding rejects as `unavailable` and
@@ -275,11 +304,16 @@ At connect time the native generators translate the stored config into
 sing-box deltas: an `ip_is_private` → direct route rule for LAN bypass;
 per-country local rule sets (`geosite-<cc>.srs` / `geoip-<cc>.srs`, bundled
 from `rulesets/dist/` — Android stages them into `<filesDir>/libbox/rulesets/`,
-iOS reads them from the PacketTunnel bundle) routed direct, with a sniff rule
-and per-country DNS over the direct path (Shecan `178.22.122.100` for Iran,
-AliDNS `223.5.5.5` for China); and on Android an OS-level `exclude_package`
-list on the TUN inbound. The Android app picker is fed by the separate
-`OpenRungAppList` module (launcher apps, background-resolved). Everything
+iOS reads them from the PacketTunnel bundle) routed direct, with per-country
+DNS over the direct path (Shecan `178.22.122.100` for Iran, AliDNS
+`223.5.5.5` for China); and on Android an OS-level `exclude_package` list on
+the TUN inbound. Sniffing is part of the baseline configuration because the
+protected `cp.cloudflare.com` route needs the hostname even when no country is
+enabled. The probe-specific DNS and route rules always precede LAN/country
+bypasses; country-specific rules are inserted between that protected prefix
+and the ordinary primary-to-secondary DoH failover tail. The Android app picker
+is fed by the separate `OpenRungAppList` module (launcher apps,
+background-resolved). Everything
 fails open (CONTRACT §1): a bad/missing config or a missing rule-set file
 degrades to full-tunnel behavior with a log line — split tunneling never
 blocks a connect.

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -390,11 +390,49 @@ the native WSS adapter. Recovery waits for a usable physical network, fetches
 fresh signed relay data, and starts again at direct Reality; single-use tickets
 and the prior WSS preference are never reused across network epochs.
 
-iOS startup and active-health classification MUST probe over
-`NEPacketTunnelProvider.createTCPConnectionThroughTunnel` with TLS, bounded
-request time, and a bounded HTTP response head. A `URLSession` created by the
+Every generated sing-box configuration MUST use the two ordered proxied DoH
+transports below for ordinary tunnel DNS. They replace proxied TCP/53:
+
+1. `dns-proxy-primary`: HTTPS to literal `1.1.1.1:443`, path `/dns-query`,
+   `detour:"proxy"`, with TLS enabled and `server_name:"cloudflare-dns.com"`;
+2. `dns-proxy-secondary`: HTTPS to literal `8.8.8.8:443`, path `/dns-query`,
+   `detour:"proxy"`, with TLS enabled and `server_name:"dns.google"`.
+
+The transport `server` values MUST remain literal IP addresses. They are the
+non-circular bootstrap: sing-box dials the literal through `proxy`, while the
+TLS name supplies both authenticated SNI and the HTTP authority. Neither DoH
+transport may depend on itself or another network DNS lookup to resolve its
+own server. `dns.final` alone is not failover. With the pinned sing-box 1.14+
+engine, ordinary DNS rules MUST evaluate the primary with a 2 s timeout,
+respond to primary `NOERROR` or `NXDOMAIN`, and otherwise explicitly route to
+the secondary with a 3 s timeout. `dns.final` MUST remain the same secondary
+as a defensive fallback. Transport errors, timeouts, `SERVFAIL`, and `REFUSED`
+therefore exercise the second resolver.
+
+Both platforms' startup and active-health proof MUST use only
+`https://cp.cloudflare.com/generate_204`. Before each HTTPS proof, its
+exact-host DNS chain disables both normal and optimistic caching, evaluates
+the primary, accepts it only when the response contains an address, and routes
+an absent/unusable primary response to the secondary. Those probe DNS rules
+MUST precede all country DNS bypass rules. Route rules MUST sniff first, then
+force the exact probe host to `outbound:"proxy"` before any LAN or country
+bypass rule. A successful direct path is therefore insufficient evidence:
+startup MUST fail and MUST NOT publish `CONNECTED` when that proxied DNS plus
+HTTPS path fails, including while China bypass is enabled.
+
+iOS startup and active-health classification MUST first send a raw A query for
+the probe host to the TUN DNS address through
+`NEPacketTunnelProvider.createUDPSessionThroughTunnel`, requiring a bounded,
+valid response with an address. It MUST then perform the TLS/HTTPS phase over
+`NEPacketTunnelProvider.createTCPConnectionThroughTunnel` with bounded request
+time and a bounded HTTP response head. A `URLSession` created by the
 packet-tunnel provider bypasses that provider's TUN and therefore MUST NOT be
-used as evidence that Reality or WSS carried end-to-end traffic.
+used as evidence that Reality or WSS carried end-to-end traffic. Android's
+through-tunnel proof MUST remain bound to the VPN `Network`. On API 29+ it MUST
+use `DnsResolver.FLAG_NO_CACHE_LOOKUP`; on API 26–28 it MUST send a raw A query
+to the VPN-advertised DNS listener after `Network.bindSocket` and MUST NOT
+protect that socket out of the VPN. Its separate physical-network recovery
+probe remains outside the VPN and is specified below.
 
 - `vpn/OpenRungVpnService.kt`, `vpn/ProxyEngine.kt` — connect flow including
   Android NAT-punch-first/RelayHub and direct-first WSS/CDN fallback,
@@ -426,11 +464,17 @@ used as evidence that Reality or WSS carried end-to-end traffic.
   modern UDP DNS servers already dial directly, while detouring through the
   otherwise-empty tagged direct outbound fails during the sing-box Start stage)
   (`ir` → `178.22.122.100` Shecan, `cn` → `223.5.5.5` AliDNS) and a `dns.rules`
-  entry `{"rule_set":["geosite-<cc>"],"server":"dns-direct-<cc>"}` between
-  `servers` and `final`; `route.rule_set` local/binary entries for
+  entry `{"rule_set":["geosite-<cc>"],"action":"route","server":"dns-direct-<cc>"}`;
+  `route.rule_set` local/binary entries for
   `geosite-<cc>.srs` and `geoip-<cc>.srs` under `ruleSetDirectory`, before
-  `rules`; and `route.rules` ordered [hijack-dns (existing, first),
-  `{"action":"sniff"}` (only when countries non-empty),
+  `rules`. The complete `dns.rules` order is [the three exact
+  `cp.cloudflare.com` evaluate/address-respond/secondary-route rules,
+  per-country direct-DNS rules (`ir` before `cn`), ordinary primary evaluate,
+  primary `NOERROR` respond, primary `NXDOMAIN` respond, ordinary secondary
+  route], with `final:"dns-proxy-secondary"` retained as a defensive fallback.
+  The complete `route.rules` order is
+  [hijack-dns (first), `{"action":"sniff"}` (always), the exact
+  `cp.cloudflare.com` → `proxy` rule,
   `{"ip_is_private":true,"outbound":"direct"}` (only when bypassLan),
   per-country `{"rule_set":["geosite-<cc>","geoip-<cc>"],"outbound":"direct"}`,
   `ir` before `cn`]. `final:"proxy"`, `route_exclude_address` logic,
@@ -511,9 +555,11 @@ used as evidence that Reality or WSS carried end-to-end traffic.
   successful physical-network connectivity probe trigger fresh discovery/re-punch and
   RelayHub fallback. Native path loss waits for a reachable physical network, so
   a local outage leaves the foreground service CONNECTING instead of failing it.
-  That probe stays bound to `Network.openConnection` but targets only
-  `www.gstatic.com/generate_204` and `cp.cloudflare.com/generate_204`; any HTTP
-  response proves connectivity, and no OpenRung identity/broker header is sent.
+  That *physical-network* probe stays bound to `Network.openConnection` but
+  targets only `www.gstatic.com/generate_204` and
+  `cp.cloudflare.com/generate_204`; any HTTP response proves connectivity, and
+  no OpenRung identity/broker header is sent.
+  It is not the protected through-tunnel startup/health proof specified above.
 - A transport-independent engine monitor watches libbox during direct, punched,
   and WSS sessions. Unexpected engine exit is a terminal local failure and never
   starts reladdering or ticket acquisition. WSS network, adapter, and end-to-end

--- a/ios/OpenRungTests/PacketTunnelInternetProbeTests.swift
+++ b/ios/OpenRungTests/PacketTunnelInternetProbeTests.swift
@@ -2,6 +2,18 @@ import Foundation
 import XCTest
 
 final class PacketTunnelInternetProbeTests: XCTestCase {
+    func testDefaultsUseOnlyTheDedicatedForcedProxyHostname() throws {
+        XCTAssertEqual(
+            PacketTunnelInternetProbe.defaultEndpointStrings,
+            ["https://cp.cloudflare.com/generate_204"]
+        )
+        let endpoint = try TunnelProbeEndpoint(
+            XCTUnwrap(PacketTunnelInternetProbe.defaultEndpointStrings.first)
+        )
+        XCTAssertEqual(endpoint.host, SingBoxConfiguration.connectivityProbeHost)
+        XCTAssertNotEqual(endpoint.host, "www.gstatic.com")
+    }
+
     func testInjectedThroughTunnelTransportIsTheOnlyProbePath() async throws {
         let transport = FakeThroughTunnelTransport(responses: [
             .failure(URLError(.timedOut)),
@@ -28,6 +40,7 @@ final class PacketTunnelInternetProbeTests: XCTestCase {
                 try TunnelProbeEndpoint("https://second.example/check?probe=1"),
             ]
         )
+        XCTAssertEqual(transport.resolvedHosts, ["first.example", "second.example"])
     }
 
     func testEndpointRequiresHttpsAndBuildsAHostBoundRequest() throws {
@@ -63,6 +76,91 @@ final class PacketTunnelInternetProbeTests: XCTestCase {
         )
     }
 
+    func testDNSProbeBuildsAQueryAndRequiresMatchingSuccessfulAResponse() throws {
+        let transactionID: UInt16 = 0x1234
+        let query = try TunnelDNSAProbe.makeQuery(
+            host: SingBoxConfiguration.connectivityProbeHost,
+            transactionID: transactionID
+        )
+        XCTAssertEqual(Array(query.prefix(6)), [0x12, 0x34, 0x01, 0x00, 0x00, 0x01])
+        XCTAssertNotNil(query.range(of: Data("cloudflare".utf8)))
+
+        let response = makeDNSResponse(
+            from: query,
+            transactionID: transactionID,
+            address: [104, 16, 132, 229]
+        )
+        XCTAssertNoThrow(
+            try TunnelDNSAProbe.validateResponse(response, transactionID: transactionID)
+        )
+        XCTAssertThrowsError(
+            try TunnelDNSAProbe.validateResponse(response, transactionID: 0xabcd)
+        )
+    }
+
+    func testDNSProbeRejectsMalformedFailureAndEmptyReplies() throws {
+        let transactionID: UInt16 = 0x4567
+        let query = try TunnelDNSAProbe.makeQuery(host: "cp.cloudflare.com", transactionID: transactionID)
+
+        XCTAssertThrowsError(
+            try TunnelDNSAProbe.validateResponse(Data([0x45, 0x67]), transactionID: transactionID)
+        )
+        XCTAssertThrowsError(
+            try TunnelDNSAProbe.validateResponse(
+                makeDNSResponse(
+                    from: query,
+                    transactionID: transactionID,
+                    responseCode: 2,
+                    address: nil
+                ),
+                transactionID: transactionID
+            )
+        )
+        XCTAssertThrowsError(
+            try TunnelDNSAProbe.validateResponse(
+                makeDNSResponse(from: query, transactionID: transactionID, address: nil),
+                transactionID: transactionID
+            )
+        )
+        var invalidCompression = makeDNSResponse(
+            from: query,
+            transactionID: transactionID,
+            address: [104, 16, 132, 229]
+        )
+        invalidCompression[query.count] = 0xff
+        invalidCompression[query.count + 1] = 0xff
+        XCTAssertThrowsError(
+            try TunnelDNSAProbe.validateResponse(
+                invalidCompression,
+                transactionID: transactionID
+            )
+        )
+    }
+
+    func testFreshDNSFailurePreventsTheHTTPSProbe() async throws {
+        let transport = FakeThroughTunnelTransport(
+            dnsResponses: [.failure(URLError(.dnsLookupFailed))],
+            responses: [
+                .success(Data("HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n".utf8)),
+            ]
+        )
+        let probe = try PacketTunnelInternetProbe(
+            endpoints: ["https://cp.cloudflare.com/generate_204"],
+            transport: transport,
+            requestTimeoutMilliseconds: 100
+        )
+
+        do {
+            _ = try await probe.verifyOnce()
+            XCTFail("DNS failure must keep the HTTPS gate closed")
+        } catch {
+            XCTAssertTrue(isGenuineRemoteDataPathFailure(error))
+        }
+
+        XCTAssertEqual(transport.resolvedHosts, ["cp.cloudflare.com"])
+        XCTAssertTrue(transport.requestedEndpoints.isEmpty)
+    }
+
     func testFailedThroughTunnelSweepSurfacesRemotePathEvidence() async throws {
         let transport = FakeThroughTunnelTransport(responses: [
             .failure(URLError(.networkConnectionLost)),
@@ -80,15 +178,115 @@ final class PacketTunnelInternetProbeTests: XCTestCase {
             XCTAssertTrue(isGenuineRemoteDataPathFailure(error))
         }
     }
+
+    func testChinaBypassWithDirectInternetButDeadProxyNeverPassesStartupGate() async throws {
+        let configuration = chinaBypassConfiguration()
+        let transport = RoutingAwareProbeTransport(
+            configuration: configuration,
+            directInternetAvailable: true,
+            proxyAvailable: false
+        )
+        let probe = try PacketTunnelInternetProbe(
+            transport: transport,
+            deadlineMilliseconds: 5,
+            retryDelayNanoseconds: 1_000_000,
+            requestTimeoutMilliseconds: 100
+        )
+        var connectedPublicationCount = 0
+
+        do {
+            _ = try await StartupConnectionPublicationGate.run(
+                establishAndVerify: { try await probe.verify() },
+                publishConnected: { _ in connectedPublicationCount += 1 }
+            )
+        } catch {
+            XCTAssertTrue(isGenuineRemoteDataPathFailure(error))
+        }
+
+        XCTAssertEqual(connectedPublicationCount, 0)
+        XCTAssertFalse(transport.selectedPaths.isEmpty)
+        XCTAssertTrue(transport.selectedPaths.allSatisfy { $0 == .proxy })
+    }
+
+    func testChinaBypassWithWorkingProxyPassesStartupGate() async throws {
+        let transport = RoutingAwareProbeTransport(
+            configuration: chinaBypassConfiguration(),
+            directInternetAvailable: true,
+            proxyAvailable: true
+        )
+        let probe = try PacketTunnelInternetProbe(
+            transport: transport,
+            requestTimeoutMilliseconds: 100
+        )
+        var connectedPublicationCount = 0
+
+        _ = try await StartupConnectionPublicationGate.run(
+            establishAndVerify: { try await probe.verifyOnce() },
+            publishConnected: { _ in connectedPublicationCount += 1 }
+        )
+
+        XCTAssertEqual(connectedPublicationCount, 1)
+        XCTAssertEqual(transport.selectedPaths, [.proxy, .proxy])
+    }
+
+    private func makeDNSResponse(
+        from query: Data,
+        transactionID: UInt16,
+        responseCode: UInt8 = 0,
+        address: [UInt8]?
+    ) -> Data {
+        var response = query
+        response[0] = UInt8(transactionID >> 8)
+        response[1] = UInt8(transactionID & 0xff)
+        response[2] = 0x81
+        response[3] = 0x80 | (responseCode & 0x0f)
+        response[6] = 0
+        response[7] = address == nil ? 0 : 1
+        guard let address else { return response }
+        response.append(contentsOf: [
+            0xc0, 0x0c, // Compressed owner name pointing to the question.
+            0x00, 0x01, // A.
+            0x00, 0x01, // IN.
+            0x00, 0x00, 0x00, 0x3c, // TTL.
+            0x00, 0x04,
+        ])
+        response.append(contentsOf: address)
+        return response
+    }
+
+    private func chinaBypassConfiguration() -> [String: Any] {
+        SingBoxConfiguration(
+            relay: makeWssTestRelay(),
+            splitTunnel: SplitTunnelRules(
+                bypassLan: false,
+                bypassCountries: ["cn"],
+                ruleSetDirectory: "/var/rulesets"
+            )
+        ).makeJSONObject()
+    }
 }
 
-private final class FakeThroughTunnelTransport: ThroughTunnelHTTPTransport, @unchecked Sendable {
+private final class FakeThroughTunnelTransport: ThroughTunnelProbeTransport, @unchecked Sendable {
     private let lock = NSLock()
+    private var dnsResponses: [Result<Void, Error>]
     private var responses: [Result<Data, Error>]
+    private var storedHosts: [String] = []
     private var storedEndpoints: [TunnelProbeEndpoint] = []
 
-    init(responses: [Result<Data, Error>]) {
+    init(
+        dnsResponses: [Result<Void, Error>] = [],
+        responses: [Result<Data, Error>]
+    ) {
+        self.dnsResponses = dnsResponses
         self.responses = responses
+    }
+
+    func resolveFreshA(host: String) async throws {
+        let response: Result<Void, Error>? = lock.withLock {
+            storedHosts.append(host)
+            return dnsResponses.isEmpty ? nil : dnsResponses.removeFirst()
+        }
+        try response?.get()
     }
 
     func responseHead(for endpoint: TunnelProbeEndpoint) async throws -> Data {
@@ -101,5 +299,88 @@ private final class FakeThroughTunnelTransport: ThroughTunnelHTTPTransport, @unc
 
     var requestedEndpoints: [TunnelProbeEndpoint] {
         lock.withLock { storedEndpoints }
+    }
+
+    var resolvedHosts: [String] {
+        lock.withLock { storedHosts }
+    }
+}
+
+private enum SimulatedProbePath: Equatable {
+    case direct
+    case proxy
+}
+
+/// Small generated-config integration harness. It deliberately treats the connectivity host as if
+/// geosite-cn contains it; the first matching exact-host DNS and route rules must still win. This
+/// reproduces the dangerous environment: usable direct internet can answer the request, while a
+/// dead proxy must keep the startup handoff closed.
+private final class RoutingAwareProbeTransport: ThroughTunnelProbeTransport, @unchecked Sendable {
+    private let configuration: [String: Any]
+    private let directInternetAvailable: Bool
+    private let proxyAvailable: Bool
+    private let lock = NSLock()
+    private var storedPaths: [SimulatedProbePath] = []
+
+    init(
+        configuration: [String: Any],
+        directInternetAvailable: Bool,
+        proxyAvailable: Bool
+    ) {
+        self.configuration = configuration
+        self.directInternetAvailable = directInternetAvailable
+        self.proxyAvailable = proxyAvailable
+    }
+
+    func resolveFreshA(host: String) async throws {
+        let path = selectedDNSPath(for: host)
+        lock.withLock { storedPaths.append(path) }
+        let available = path == .proxy ? proxyAvailable : directInternetAvailable
+        guard available else { throw URLError(.cannotConnectToHost) }
+    }
+
+    func responseHead(for endpoint: TunnelProbeEndpoint) async throws -> Data {
+        let path = selectedHTTPSPath(for: endpoint.host)
+        lock.withLock { storedPaths.append(path) }
+        let available = path == .proxy ? proxyAvailable : directInternetAvailable
+        guard available else { throw URLError(.cannotConnectToHost) }
+        return Data("HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n".utf8)
+    }
+
+    var selectedPaths: [SimulatedProbePath] {
+        lock.withLock { storedPaths }
+    }
+
+    private func selectedDNSPath(for host: String) -> SimulatedProbePath {
+        guard
+            let dns = configuration["dns"] as? [String: Any],
+            let rules = dns["rules"] as? [[String: Any]]
+        else { return .direct }
+        for rule in rules {
+            if let domains = rule["domain"] as? [String], domains.contains(host) {
+                let server = rule["server"] as? String ?? ""
+                if server.hasPrefix("dns-proxy-") { return .proxy }
+            }
+            if let sets = rule["rule_set"] as? [String], sets.contains("geosite-cn") {
+                return .direct
+            }
+        }
+        return .direct
+    }
+
+    private func selectedHTTPSPath(for host: String) -> SimulatedProbePath {
+        guard
+            let route = configuration["route"] as? [String: Any],
+            let rules = route["rules"] as? [[String: Any]]
+        else { return .direct }
+        for rule in rules {
+            if let domains = rule["domain"] as? [String], domains.contains(host) {
+                return rule["outbound"] as? String == "proxy" ? .proxy : .direct
+            }
+            if let sets = rule["rule_set"] as? [String], sets.contains("geosite-cn") {
+                return .direct
+            }
+        }
+        return route["final"] as? String == "proxy" ? .proxy : .direct
     }
 }

--- a/ios/OpenRungTests/SplitTunnelConfigurationTests.swift
+++ b/ios/OpenRungTests/SplitTunnelConfigurationTests.swift
@@ -41,10 +41,12 @@ final class SplitTunnelConfigurationTests: XCTestCase {
         XCTAssertNil(route["rule_set"])
         XCTAssertEqual(try canonicalJSON(route["rules"]), try canonicalJSON([
             ["protocol": "dns", "action": "hijack-dns"],
+            ["action": "sniff"],
+            ["domain": ["cp.cloudflare.com"], "outbound": "proxy"],
             ["ip_is_private": true, "outbound": "direct"],
         ] as [[String: Any]]))
 
-        // Everything outside route — dns (no "rules" key), tun inbound, outbounds — is untouched.
+        // Everything outside route — DNS failover, tun inbound, outbounds — is untouched.
         baseline.removeValue(forKey: "route")
         split.removeValue(forKey: "route")
         XCTAssertEqual(try canonicalJSON(baseline), try canonicalJSON(split))
@@ -68,14 +70,19 @@ final class SplitTunnelConfigurationTests: XCTestCase {
             "type": "udp",
             "server": "178.22.122.100"
         ] as [String: Any]))
-        XCTAssertEqual(try canonicalJSON(dns["rules"]), try canonicalJSON([
-            ["rule_set": ["geosite-ir"], "server": "dns-direct-ir"],
-        ] as [[String: Any]]))
+        let dnsRules = try XCTUnwrap(dns["rules"] as? [[String: Any]])
+        XCTAssertEqual(dnsRules.count, 8)
+        XCTAssertEqual(try canonicalJSON(dnsRules[3]), try canonicalJSON([
+            "rule_set": ["geosite-ir"],
+            "action": "route",
+            "server": "dns-direct-ir",
+        ] as [String: Any]))
 
         let route = try XCTUnwrap(object["route"] as? [String: Any])
         XCTAssertEqual(try canonicalJSON(route["rules"]), try canonicalJSON([
             ["protocol": "dns", "action": "hijack-dns"],
             ["action": "sniff"],
+            ["domain": ["cp.cloudflare.com"], "outbound": "proxy"],
             ["rule_set": ["geosite-ir", "geoip-ir"], "outbound": "direct"],
         ] as [[String: Any]]))
         XCTAssertEqual(try canonicalJSON(route["rule_set"]), try canonicalJSON([
@@ -91,18 +98,23 @@ final class SplitTunnelConfigurationTests: XCTestCase {
 
         let dns = try XCTUnwrap(split["dns"] as? [String: Any])
         let servers = try XCTUnwrap(dns["servers"] as? [[String: Any]])
-        XCTAssertEqual(servers.map { $0["tag"] as? String }, ["dns-0", "dns-1", "dns-direct-ir", "dns-direct-cn"])
+        XCTAssertEqual(
+            servers.map { $0["tag"] as? String },
+            ["dns-proxy-primary", "dns-proxy-secondary", "dns-direct-ir", "dns-direct-cn"]
+        )
         XCTAssertEqual(servers[3]["server"] as? String, "223.5.5.5")
         XCTAssertTrue(servers.suffix(2).allSatisfy { $0["detour"] == nil })
-        XCTAssertEqual(try canonicalJSON(dns["rules"]), try canonicalJSON([
-            ["rule_set": ["geosite-ir"], "server": "dns-direct-ir"],
-            ["rule_set": ["geosite-cn"], "server": "dns-direct-cn"],
+        let dnsRules = try XCTUnwrap(dns["rules"] as? [[String: Any]])
+        XCTAssertEqual(try canonicalJSON(Array(dnsRules[3...4])), try canonicalJSON([
+            ["rule_set": ["geosite-ir"], "action": "route", "server": "dns-direct-ir"],
+            ["rule_set": ["geosite-cn"], "action": "route", "server": "dns-direct-cn"],
         ] as [[String: Any]]))
 
         let route = try XCTUnwrap(split["route"] as? [String: Any])
         XCTAssertEqual(try canonicalJSON(route["rules"]), try canonicalJSON([
             ["protocol": "dns", "action": "hijack-dns"],
             ["action": "sniff"],
+            ["domain": ["cp.cloudflare.com"], "outbound": "proxy"],
             ["ip_is_private": true, "outbound": "direct"],
             ["rule_set": ["geosite-ir", "geoip-ir"], "outbound": "direct"],
             ["rule_set": ["geosite-cn", "geoip-cn"], "outbound": "direct"],
@@ -123,6 +135,84 @@ final class SplitTunnelConfigurationTests: XCTestCase {
             split.removeValue(forKey: key)
         }
         XCTAssertEqual(try canonicalJSON(baseline), try canonicalJSON(split))
+    }
+
+    func testProxiedDNSUsesNonCircularDoH443AndFallsBackToASecondResolver() throws {
+        let object = SingBoxConfiguration(relay: makeWssTestRelay()).makeJSONObject()
+        let dns = try XCTUnwrap(object["dns"] as? [String: Any])
+        let servers = try XCTUnwrap(dns["servers"] as? [[String: Any]])
+
+        XCTAssertEqual(servers.count, 2)
+        XCTAssertEqual(try canonicalJSON(servers[0]), try canonicalJSON([
+            "tag": "dns-proxy-primary",
+            "type": "https",
+            "server": "1.1.1.1",
+            "server_port": 443,
+            "path": "/dns-query",
+            "detour": "proxy",
+            "tls": ["enabled": true, "server_name": "cloudflare-dns.com"],
+        ] as [String: Any]))
+        XCTAssertEqual(try canonicalJSON(servers[1]), try canonicalJSON([
+            "tag": "dns-proxy-secondary",
+            "type": "https",
+            "server": "8.8.8.8",
+            "server_port": 443,
+            "path": "/dns-query",
+            "detour": "proxy",
+            "tls": ["enabled": true, "server_name": "dns.google"],
+        ] as [String: Any]))
+        XCTAssertTrue(servers.allSatisfy { $0["domain_resolver"] == nil })
+        XCTAssertEqual(dns["final"] as? String, "dns-proxy-secondary")
+
+        let rules = try XCTUnwrap(dns["rules"] as? [[String: Any]])
+        XCTAssertEqual(rules.map { $0["action"] as? String }, [
+            "evaluate", "respond", "route", "evaluate", "respond", "respond", "route",
+        ])
+        XCTAssertEqual(rules[1]["ip_accept_any"] as? Bool, true)
+        XCTAssertNil(rules[1]["response_rcode"])
+        XCTAssertEqual(rules[2]["server"] as? String, "dns-proxy-secondary")
+        XCTAssertEqual(rules[3]["server"] as? String, "dns-proxy-primary")
+        XCTAssertEqual(rules[4]["match_response"] as? Bool, true)
+        XCTAssertEqual(rules[4]["response_rcode"] as? String, "NOERROR")
+        XCTAssertNil(rules[4]["server"])
+        XCTAssertEqual(rules[5]["response_rcode"] as? String, "NXDOMAIN")
+        XCTAssertEqual(rules[6]["server"] as? String, "dns-proxy-secondary")
+        XCTAssertEqual(rules[6]["timeout"] as? String, "3s")
+    }
+
+    func testChinaBypassCannotCaptureConnectivityProbeDNSOrHTTPS() throws {
+        let object = SingBoxConfiguration(
+            relay: makeWssTestRelay(),
+            splitTunnel: SplitTunnelRules(
+                bypassLan: false,
+                bypassCountries: ["cn"],
+                ruleSetDirectory: ruleSetDirectory
+            )
+        ).makeJSONObject()
+
+        let dns = try XCTUnwrap(object["dns"] as? [String: Any])
+        let dnsRules = try XCTUnwrap(dns["rules"] as? [[String: Any]])
+        let directDNSIndex = try XCTUnwrap(
+            dnsRules.firstIndex { $0["server"] as? String == "dns-direct-cn" }
+        )
+        XCTAssertGreaterThanOrEqual(directDNSIndex, 3)
+        XCTAssertEqual(dnsRules[0]["domain"] as? [String], ["cp.cloudflare.com"])
+        XCTAssertEqual(dnsRules[0]["server"] as? String, "dns-proxy-primary")
+        XCTAssertEqual(dnsRules[2]["domain"] as? [String], ["cp.cloudflare.com"])
+        XCTAssertEqual(dnsRules[2]["server"] as? String, "dns-proxy-secondary")
+        XCTAssertTrue((dnsRules[0]["disable_cache"] as? Bool) == true)
+        XCTAssertTrue((dnsRules[2]["disable_cache"] as? Bool) == true)
+
+        let route = try XCTUnwrap(object["route"] as? [String: Any])
+        let routeRules = try XCTUnwrap(route["rules"] as? [[String: Any]])
+        let chinaBypassIndex = try XCTUnwrap(
+            routeRules.firstIndex { ($0["rule_set"] as? [String])?.contains("geosite-cn") == true }
+        )
+        let forcedProxyIndex = try XCTUnwrap(
+            routeRules.firstIndex { $0["domain"] as? [String] == ["cp.cloudflare.com"] }
+        )
+        XCTAssertLessThan(forcedProxyIndex, chinaBypassIndex)
+        XCTAssertEqual(routeRules[forcedProxyIndex]["outbound"] as? String, "proxy")
     }
 
     func testBridgeModeKeepsSplitRulesAndStillOmitsRouteExcludeAddress() throws {

--- a/ios/PacketTunnel/PacketTunnelInternetProbe.swift
+++ b/ios/PacketTunnel/PacketTunnelInternetProbe.swift
@@ -45,8 +45,144 @@ struct TunnelProbeEndpoint: Equatable, Sendable {
     }
 }
 
-protocol ThroughTunnelHTTPTransport: Sendable {
+protocol ThroughTunnelProbeTransport: Sendable {
+    /// Performs an uncached A lookup through the TUN's DNS listener. This is intentionally
+    /// separate from the HTTPS connection so a cached/system resolution cannot satisfy health.
+    func resolveFreshA(host: String) async throws
     func responseHead(for endpoint: TunnelProbeEndpoint) async throws -> Data
+}
+
+/// The production handoff from a verified startup to visible CONNECTED state. Keeping this
+/// boundary explicit makes it impossible for a failed DNS/HTTPS proof to invoke the publisher,
+/// and lets the China-bypass regression exercise the same ordering without a live extension.
+enum StartupConnectionPublicationGate {
+    @discardableResult
+    static func run<Value>(
+        establishAndVerify: () async throws -> Value,
+        publishConnected: (Value) -> Void
+    ) async rethrows -> Value {
+        let verified = try await establishAndVerify()
+        publishConnected(verified)
+        return verified
+    }
+}
+
+/// Minimal DNS wire encoder/parser for the explicit through-TUN health lookup. Parsing is strict:
+/// a reply must match the transaction, be a complete successful response, and contain an IPv4
+/// address answer. A syntactically valid but empty response is not proof of working DNS.
+enum TunnelDNSAProbe {
+    static func makeQuery(host: String, transactionID: UInt16) throws -> Data {
+        let normalizedHost = host.hasSuffix(".") ? String(host.dropLast()) : host
+        guard normalizedHost.isEmpty == false, normalizedHost.utf8.count <= 253 else {
+            throw URLError(.badURL)
+        }
+
+        var bytes: [UInt8] = [
+            UInt8(transactionID >> 8), UInt8(transactionID & 0xff),
+            0x01, 0x00, // Recursion desired.
+            0x00, 0x01, // One question.
+            0x00, 0x00, // No answers.
+            0x00, 0x00, // No authority records.
+            0x00, 0x00, // No additional records.
+        ]
+        for label in normalizedHost.split(separator: ".", omittingEmptySubsequences: false) {
+            let labelBytes = Array(label.utf8)
+            guard labelBytes.isEmpty == false, labelBytes.count <= 63 else {
+                throw URLError(.badURL)
+            }
+            bytes.append(UInt8(labelBytes.count))
+            bytes.append(contentsOf: labelBytes)
+        }
+        bytes.append(0)
+        bytes.append(contentsOf: [0x00, 0x01, 0x00, 0x01]) // A, IN.
+        guard bytes.count <= 512 else { throw URLError(.badURL) }
+        return Data(bytes)
+    }
+
+    static func validateResponse(_ response: Data, transactionID: UInt16) throws {
+        let bytes = [UInt8](response)
+        guard bytes.count >= 12 else { throw URLError(.cannotParseResponse) }
+        guard readUInt16(bytes, at: 0) == transactionID else {
+            throw URLError(.cannotParseResponse)
+        }
+
+        let flags = readUInt16(bytes, at: 2)
+        guard flags & 0x8000 != 0, flags & 0x0200 == 0 else {
+            throw URLError(.cannotParseResponse)
+        }
+        guard flags & 0x000f == 0 else { throw URLError(.dnsLookupFailed) }
+        let questionCount = Int(readUInt16(bytes, at: 4))
+        let answerCount = Int(readUInt16(bytes, at: 6))
+        guard questionCount == 1 else { throw URLError(.cannotParseResponse) }
+
+        var offset = 12
+        try skipName(bytes, offset: &offset)
+        guard offset <= bytes.count - 4 else { throw URLError(.cannotParseResponse) }
+        guard readUInt16(bytes, at: offset) == 1, readUInt16(bytes, at: offset + 2) == 1 else {
+            throw URLError(.cannotParseResponse)
+        }
+        offset += 4
+
+        for _ in 0..<answerCount {
+            try skipName(bytes, offset: &offset)
+            guard offset <= bytes.count - 10 else { throw URLError(.cannotParseResponse) }
+            let recordType = readUInt16(bytes, at: offset)
+            let recordClass = readUInt16(bytes, at: offset + 2)
+            let dataLength = Int(readUInt16(bytes, at: offset + 8))
+            offset += 10
+            guard dataLength <= bytes.count - offset else {
+                throw URLError(.cannotParseResponse)
+            }
+            if recordType == 1, recordClass == 1, dataLength == 4 {
+                return
+            }
+            offset += dataLength
+        }
+        throw URLError(.dnsLookupFailed)
+    }
+
+    private static func readUInt16(_ bytes: [UInt8], at offset: Int) -> UInt16 {
+        UInt16(bytes[offset]) << 8 | UInt16(bytes[offset + 1])
+    }
+
+    private static func skipName(
+        _ bytes: [UInt8],
+        offset: inout Int,
+        compressionDepth: Int = 0
+    ) throws {
+        var labels = 0
+        while true {
+            guard offset < bytes.count, labels <= 127, compressionDepth <= 127 else {
+                throw URLError(.cannotParseResponse)
+            }
+            let length = Int(bytes[offset])
+            if length & 0xc0 == 0xc0 {
+                guard offset <= bytes.count - 2 else { throw URLError(.cannotParseResponse) }
+                let pointer = (length & 0x3f) << 8 | Int(bytes[offset + 1])
+                // RFC 1035 compression points to an earlier occurrence. Requiring a backwards
+                // pointer also makes cycles impossible before validating the pointed-to name.
+                guard pointer >= 12, pointer < offset else {
+                    throw URLError(.cannotParseResponse)
+                }
+                var pointedOffset = pointer
+                try skipName(
+                    bytes,
+                    offset: &pointedOffset,
+                    compressionDepth: compressionDepth + 1
+                )
+                offset += 2
+                return
+            }
+            guard length & 0xc0 == 0 else { throw URLError(.cannotParseResponse) }
+            offset += 1
+            if length == 0 { return }
+            guard length <= 63, length <= bytes.count - offset else {
+                throw URLError(.cannotParseResponse)
+            }
+            offset += length
+            labels += 1
+        }
+    }
 }
 
 /// A provider/API state failure is local evidence and must never be converted into WSS fallback.
@@ -57,11 +193,34 @@ enum PacketTunnelProbeTransportError: Error {
 /// Explicit Apple through-TUN transport. A URLSession created by the extension is intentionally
 /// excluded from its own packet tunnel; this API is the iOS 16/17 guarantee that the probe traverses
 /// the active Reality/libbox path instead of escaping on the hardware interface.
-private final class ProviderThroughTunnelHTTPTransport: ThroughTunnelHTTPTransport, @unchecked Sendable {
-    private weak var provider: NEPacketTunnelProvider?
+private final class ProviderThroughTunnelProbeTransport: ThroughTunnelProbeTransport, @unchecked Sendable {
+    static let defaultTunnelDNSServerAddress = "172.19.0.2"
 
-    init(provider: NEPacketTunnelProvider) {
+    private weak var provider: NEPacketTunnelProvider?
+    private let tunnelDNSServerAddress: String
+
+    init(
+        provider: NEPacketTunnelProvider,
+        tunnelDNSServerAddress: String = defaultTunnelDNSServerAddress
+    ) {
         self.provider = provider
+        self.tunnelDNSServerAddress = tunnelDNSServerAddress
+    }
+
+    func resolveFreshA(host: String) async throws {
+        guard let provider else { throw URLError(.cancelled) }
+        let transactionID = UInt16.random(in: UInt16.min...UInt16.max)
+        let query = try TunnelDNSAProbe.makeQuery(host: host, transactionID: transactionID)
+        let remote = NWHostEndpoint(hostname: tunnelDNSServerAddress, port: "53")
+        let session = provider.createUDPSessionThroughTunnel(to: remote, from: nil)
+        defer { session.cancel() }
+        try await withTaskCancellationHandler {
+            try await waitUntilReady(session)
+            let response = try await exchange(query, using: session)
+            try TunnelDNSAProbe.validateResponse(response, transactionID: transactionID)
+        } onCancel: {
+            session.cancel()
+        }
     }
 
     func responseHead(for endpoint: TunnelProbeEndpoint) async throws -> Data {
@@ -109,6 +268,74 @@ private final class ProviderThroughTunnelHTTPTransport: ThroughTunnelHTTPTranspo
         }
     }
 
+    private func waitUntilReady(_ session: NWUDPSession) async throws {
+        let observation = ObservationBox()
+        defer { observation.invalidate() }
+        try await withCheckedThrowingContinuation {
+            (continuation: CheckedContinuation<Void, Error>) in
+            let gate = ContinuationGate<Void>(continuation)
+            let token = session.observe(\.state, options: [.initial, .new]) { observed, _ in
+                switch observed.state {
+                case .ready:
+                    gate.resume(returning: ())
+                case .failed:
+                    gate.resume(throwing: URLError(.cannotConnectToHost))
+                case .cancelled:
+                    gate.resume(throwing: CancellationError())
+                case .invalid:
+                    gate.resume(throwing: PacketTunnelProbeTransportError.invalidConnectionState)
+                case .waiting, .preparing:
+                    break
+                @unknown default:
+                    gate.resume(throwing: URLError(.unknown))
+                }
+            }
+            observation.set(token)
+        }
+    }
+
+    private func exchange(_ query: Data, using session: NWUDPSession) async throws -> Data {
+        let observation = ObservationBox()
+        let gate = DeferredContinuationGate<Data>()
+        defer { observation.invalidate() }
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<Data, Error>) in
+                guard gate.install(continuation) else { return }
+                let token = session.observe(\.state, options: [.new]) { observed, _ in
+                    switch observed.state {
+                    case .failed:
+                        gate.resume(throwing: URLError(.networkConnectionLost))
+                    case .cancelled:
+                        gate.resume(throwing: CancellationError())
+                    case .invalid:
+                        gate.resume(throwing: PacketTunnelProbeTransportError.invalidConnectionState)
+                    case .waiting, .preparing, .ready:
+                        break
+                    @unknown default:
+                        gate.resume(throwing: URLError(.unknown))
+                    }
+                }
+                observation.set(token)
+                session.setReadHandler({ datagrams, error in
+                    if let error {
+                        gate.resume(throwing: error)
+                    } else if let response = datagrams?.first, response.isEmpty == false {
+                        gate.resume(returning: response)
+                    } else {
+                        gate.resume(throwing: URLError(.zeroByteResource))
+                    }
+                }, maxDatagrams: 1)
+                session.writeDatagram(query) { error in
+                    if let error { gate.resume(throwing: error) }
+                }
+            }
+        } onCancel: {
+            session.cancel()
+            gate.resume(throwing: CancellationError())
+        }
+    }
+
     private func write(_ data: Data, to connection: NWTCPConnection) async throws {
         try await withCheckedThrowingContinuation {
             (continuation: CheckedContinuation<Void, Error>) in
@@ -142,12 +369,11 @@ private final class ProviderThroughTunnelHTTPTransport: ThroughTunnelHTTPTranspo
 /// endpoint/status/retry policy hostlessly testable without opening sockets.
 struct PacketTunnelInternetProbe: Sendable {
     static let defaultEndpointStrings = [
-        "https://www.gstatic.com/generate_204",
-        "https://cp.cloudflare.com/generate_204",
+        "https://\(SingBoxConfiguration.connectivityProbeHost)/generate_204",
     ]
 
     private let endpoints: [TunnelProbeEndpoint]
-    private let transport: any ThroughTunnelHTTPTransport
+    private let transport: any ThroughTunnelProbeTransport
     private let deadlineMilliseconds: UInt64
     private let retryDelayNanoseconds: UInt64
     private let requestTimeoutMilliseconds: UInt64
@@ -158,16 +384,18 @@ struct PacketTunnelInternetProbe: Sendable {
     ) throws {
         try self.init(
             endpoints: endpoints,
-            transport: ProviderThroughTunnelHTTPTransport(provider: tunnelProvider)
+            transport: ProviderThroughTunnelProbeTransport(provider: tunnelProvider)
         )
     }
 
     init(
         endpoints: [String] = Self.defaultEndpointStrings,
-        transport: any ThroughTunnelHTTPTransport,
-        deadlineMilliseconds: UInt64 = 12_000,
+        transport: any ThroughTunnelProbeTransport,
+        deadlineMilliseconds: UInt64 = 14_000,
         retryDelayNanoseconds: UInt64 = 500_000_000,
-        requestTimeoutMilliseconds: UInt64 = 3_000
+        // A primary DNS exchange may consume its two-second timeout before the secondary DoH
+        // resolver is tried. Leave enough room for that failover plus the HTTPS/TLS exchange.
+        requestTimeoutMilliseconds: UInt64 = 7_000
     ) throws {
         self.endpoints = try endpoints.map(TunnelProbeEndpoint.init)
         guard self.endpoints.isEmpty == false else { throw URLError(.badURL) }
@@ -203,7 +431,8 @@ struct PacketTunnelInternetProbe: Sendable {
         for endpoint in endpoints {
             do {
                 let head = try await withTimeout(milliseconds: requestTimeoutMilliseconds) {
-                    try await transport.responseHead(for: endpoint)
+                    try await transport.resolveFreshA(host: endpoint.host)
+                    return try await transport.responseHead(for: endpoint)
                 }
                 let status = try Self.parseHTTPStatus(head)
                 guard InternetProbe.acceptsHTTPStatus(status) else { throw URLError(.badServerResponse) }
@@ -296,5 +525,46 @@ private final class ContinuationGate<Value>: @unchecked Sendable {
         let value = continuation
         continuation = nil
         return value
+    }
+}
+
+/// Allows cancellation to win even in the small interval before a continuation is installed.
+private final class DeferredContinuationGate<Value>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Value, Error>?
+    private var completedResult: Result<Value, Error>?
+
+    @discardableResult
+    func install(_ value: CheckedContinuation<Value, Error>) -> Bool {
+        lock.lock()
+        if let result = completedResult {
+            lock.unlock()
+            value.resume(with: result)
+            return false
+        }
+        continuation = value
+        lock.unlock()
+        return true
+    }
+
+    func resume(returning value: Value) {
+        finish(.success(value))
+    }
+
+    func resume(throwing error: Error) {
+        finish(.failure(error))
+    }
+
+    private func finish(_ result: Result<Value, Error>) {
+        lock.lock()
+        guard completedResult == nil else {
+            lock.unlock()
+            return
+        }
+        completedResult = result
+        let value = continuation
+        continuation = nil
+        lock.unlock()
+        value?.resume(with: result)
     }
 }

--- a/ios/PacketTunnel/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider.swift
@@ -270,44 +270,54 @@ final class PacketTunnelProvider: NEPacketTunnelProvider {
             }
 
             failureStage = "relay_connect"
-            let connected = try await connectFirstAvailableRelay(
-                rankedCandidates.map(\.relay),
-                splitTunnel: splitTunnelRules
+            let connected = try await StartupConnectionPublicationGate.run(
+                establishAndVerify: {
+                    let connected = try await connectFirstAvailableRelay(
+                        rankedCandidates.map(\.relay),
+                        splitTunnel: splitTunnelRules
+                    )
+
+                    // A stop may have arrived while we were connecting. Don't publish .connected
+                    // for a tunnel that's being torn down; stopTunnel awaited this task and stops
+                    // the engine connectFirstAvailableRelay assigned.
+                    try Task.checkCancellation()
+
+                    let relay = connected.relay
+                    let promoted = lifecycleQueue.sync {
+                        guard
+                            lifecycleIsStopping == false,
+                            activeTransport.epoch == connected.transportEpoch,
+                            activeTransport.engine === connected.engine,
+                            connected.punchSession == nil
+                                || activeTransport.punchSession === connected.punchSession,
+                            connected.wssSession == nil
+                                || activeTransport.wssSession === connected.wssSession
+                        else { return false }
+                        activeTransport.relayID = relay.id
+                        activeTransport.accessTransport = connected.accessTransport
+                        activeTransport.wssFrontID = connected.frontID
+                        // NetworkExtension exposes the recovered session as Connected only after
+                        // the new engine/session tuple atomically replaces the failed transport.
+                        reasserting = false
+                        return true
+                    }
+                    guard promoted else { throw CancellationError() }
+                    return connected
+                },
+                publishConnected: { connected in
+                    let relay = connected.relay
+                    TelemetryManager.markConnected(relayId: relay.id)
+                    SharedConnectionState.setStatus(
+                        .connected,
+                        relayName: relay.displayName(),
+                        // Bridge contract: anything but "foundation" collapses to "volunteer".
+                        relayClass: relay.normalizedNodeClass(),
+                        clearRelayLabel: true,
+                        clearError: true
+                    )
+                }
             )
-
-            // A stop may have arrived while we were connecting. Don't publish .connected or start
-            // the heartbeat for a tunnel that's being torn down; stopTunnel awaited this task and
-            // stops the engine connectFirstAvailableRelay assigned.
-            try Task.checkCancellation()
-
             let relay = connected.relay
-            let promoted = lifecycleQueue.sync {
-                guard
-                    lifecycleIsStopping == false,
-                    activeTransport.epoch == connected.transportEpoch,
-                    activeTransport.engine === connected.engine,
-                    connected.punchSession == nil
-                        || activeTransport.punchSession === connected.punchSession,
-                    connected.wssSession == nil || activeTransport.wssSession === connected.wssSession
-                else { return false }
-                activeTransport.relayID = relay.id
-                activeTransport.accessTransport = connected.accessTransport
-                activeTransport.wssFrontID = connected.frontID
-                // NetworkExtension exposes the recovered session as Connected only after the new
-                // engine/session tuple has atomically replaced the failed transport.
-                reasserting = false
-                return true
-            }
-            guard promoted else { throw CancellationError() }
-            TelemetryManager.markConnected(relayId: relay.id)
-            SharedConnectionState.setStatus(
-                .connected,
-                relayName: relay.displayName(),
-                // Bridge contract: anything but "foundation" collapses to "volunteer".
-                relayClass: relay.normalizedNodeClass(),
-                clearRelayLabel: true,
-                clearError: true
-            )
             applyRelayLocation(relay)
             var successMeasurements: [String: Int64] = [
                 "broker_fetch_ms": brokerFetchMs,

--- a/ios/Shared/InternetProbe.swift
+++ b/ios/Shared/InternetProbe.swift
@@ -23,16 +23,15 @@ public enum InternetProbeError: LocalizedError {
     }
 }
 
-/// Verifies internet reachability through the active tunnel by hitting captive-portal
-/// `generate_204` endpoints. Port of Android `InternetProbe`.
+/// Verifies internet reachability through the active tunnel by hitting the dedicated
+/// `generate_204` endpoint. Port of Android `InternetProbe`.
 ///
 /// This URLSession implementation is suitable for non-provider callers only. Apple deliberately
 /// excludes a PacketTunnelProvider's own URLSession traffic from its TUN; the extension therefore
-/// uses `PacketTunnelInternetProbe`, backed by `createTCPConnectionThroughTunnel`, whenever the
-/// result is used to classify a Reality/WSS path.
+/// uses `PacketTunnelInternetProbe`, backed by `createUDPSessionThroughTunnel` for fresh DNS and
+/// `createTCPConnectionThroughTunnel` for HTTPS, whenever the result classifies a Reality/WSS path.
 public struct InternetProbe: Sendable {
     public static let defaultEndpoints = [
-        "https://www.gstatic.com/generate_204",
         "https://cp.cloudflare.com/generate_204",
     ]
 

--- a/ios/Shared/SingBoxConfiguration.swift
+++ b/ios/Shared/SingBoxConfiguration.swift
@@ -1,10 +1,40 @@
 import Foundation
 
 public struct SingBoxConfiguration: Equatable, Sendable {
+    public struct DNSOverHTTPSResolver: Equatable, Sendable {
+        public let tag: String
+        public let serverAddress: String
+        public let tlsServerName: String
+
+        public init(tag: String, serverAddress: String, tlsServerName: String) {
+            self.tag = tag
+            self.serverAddress = serverAddress
+            self.tlsServerName = tlsServerName
+        }
+    }
+
+    /// A hostname used only to prove that the active tunnel can resolve DNS and complete HTTPS.
+    /// It must stay out of country-bypass routing even if a downloaded geosite rule later grows
+    /// to include it.
+    public static let connectivityProbeHost = "cp.cloudflare.com"
+
+    public static let defaultDNSOverHTTPSResolvers = [
+        DNSOverHTTPSResolver(
+            tag: "dns-proxy-primary",
+            serverAddress: "1.1.1.1",
+            tlsServerName: "cloudflare-dns.com"
+        ),
+        DNSOverHTTPSResolver(
+            tag: "dns-proxy-secondary",
+            serverAddress: "8.8.8.8",
+            tlsServerName: "dns.google"
+        ),
+    ]
+
     public let relay: RelayDescriptor
     public let tunnelIPv4Address: String
     public let tunnelIPv6Address: String
-    public let dnsServers: [String]
+    public let dnsOverHTTPSResolvers: [DNSOverHTTPSResolver]
     public let mtu: Int
     /// Optional loopback endpoint owned by a native access transport such as wsscore.
     public let bridgeHost: String?
@@ -18,7 +48,7 @@ public struct SingBoxConfiguration: Equatable, Sendable {
         relay: RelayDescriptor,
         tunnelIPv4Address: String = "172.19.0.1/30",
         tunnelIPv6Address: String = "fdfe:dcba:9876::1/126",
-        dnsServers: [String] = ["1.1.1.1", "8.8.8.8"],
+        dnsOverHTTPSResolvers: [DNSOverHTTPSResolver] = Self.defaultDNSOverHTTPSResolvers,
         mtu: Int = 1400,
         bridgeHost: String? = nil,
         bridgePort: Int? = nil,
@@ -27,7 +57,7 @@ public struct SingBoxConfiguration: Equatable, Sendable {
         self.relay = relay
         self.tunnelIPv4Address = tunnelIPv4Address
         self.tunnelIPv6Address = tunnelIPv6Address
-        self.dnsServers = dnsServers
+        self.dnsOverHTTPSResolvers = dnsOverHTTPSResolvers
         self.mtu = mtu
         self.bridgeHost = bridgeHost
         self.bridgePort = bridgePort
@@ -74,12 +104,26 @@ public struct SingBoxConfiguration: Equatable, Sendable {
         let bypassCountries = (splitTunnel?.bypassCountries ?? []).compactMap(SplitTunnelCountry.forCode)
         let bypassLan = splitTunnel?.bypassLan == true
 
-        var dnsServerObjects: [[String: Any]] = dnsServers.enumerated().map { index, server in
+        // Resolve DoH without asking DNS how to reach DNS: each resolver dials a literal IP while
+        // TLS still authenticates and sends the provider hostname. Both exchanges use the proxy,
+        // so WSS carries ordinary HTTPS/443 instead of the blackholed TCP/53 traffic it replaced.
+        let proxiedResolvers = dnsOverHTTPSResolvers.count >= 2
+            ? Array(dnsOverHTTPSResolvers.prefix(2))
+            : Self.defaultDNSOverHTTPSResolvers
+        let primaryDNS = proxiedResolvers[0].tag
+        let secondaryDNS = proxiedResolvers[1].tag
+        var dnsServerObjects: [[String: Any]] = proxiedResolvers.map { resolver in
             [
-                "tag": "dns-\(index)",
-                "type": "tcp",
-                "server": server,
-                "detour": "proxy"
+                "tag": resolver.tag,
+                "type": "https",
+                "server": resolver.serverAddress,
+                "server_port": 443,
+                "path": "/dns-query",
+                "detour": "proxy",
+                "tls": [
+                    "enabled": true,
+                    "server_name": resolver.tlsServerName,
+                ] as [String: Any],
             ]
         }
         for country in bypassCountries {
@@ -91,29 +135,86 @@ public struct SingBoxConfiguration: Equatable, Sendable {
                 "server": country.directResolver
             ])
         }
-        var dns: [String: Any] = [
-            "servers": dnsServerObjects,
-            "final": "dns-0"
+        // `final` by itself never retries another resolver. An evaluate action is deliberately
+        // non-terminal: a usable primary response is returned by a following respond rule, while
+        // an exchange error or unusable response falls through to the secondary. The known probe
+        // host requires at least one address; NXDOMAIN, SERVFAIL and empty NOERROR all fail over.
+        // The exact-host rules run first and disable both normal and optimistic caches so every
+        // startup/health HTTPS probe also exercises a fresh upstream DNS exchange.
+        var dnsRules: [[String: Any]] = [
+            [
+                "domain": [Self.connectivityProbeHost],
+                "action": "evaluate",
+                "server": primaryDNS,
+                "timeout": "2s",
+                "disable_cache": true,
+                "disable_optimistic_cache": true,
+            ],
+            [
+                "domain": [Self.connectivityProbeHost],
+                "match_response": true,
+                "ip_accept_any": true,
+                "action": "respond",
+            ],
+            [
+                "domain": [Self.connectivityProbeHost],
+                "action": "route",
+                "server": secondaryDNS,
+                "timeout": "3s",
+                "disable_cache": true,
+                "disable_optimistic_cache": true,
+            ],
         ]
         if bypassCountries.isEmpty == false {
-            dns["rules"] = bypassCountries.map { country in
+            dnsRules.append(contentsOf: bypassCountries.map { country in
                 [
                     "rule_set": [country.geositeTag],
+                    "action": "route",
                     "server": "dns-direct-\(country.code)"
                 ] as [String: Any]
-            }
+            })
         }
+        dnsRules.append([
+            "action": "evaluate",
+            "server": primaryDNS,
+            "timeout": "2s",
+        ])
+        dnsRules.append([
+            "match_response": true,
+            "response_rcode": "NOERROR",
+            "action": "respond",
+        ])
+        dnsRules.append([
+            "match_response": true,
+            "response_rcode": "NXDOMAIN",
+            "action": "respond",
+        ])
+        dnsRules.append([
+            "action": "route",
+            "server": secondaryDNS,
+            "timeout": "3s",
+        ])
+        let dns: [String: Any] = [
+            "servers": dnsServerObjects,
+            "rules": dnsRules,
+            "final": secondaryDNS,
+            "timeout": "3s",
+        ]
 
         var routeRules: [[String: Any]] = [
             [
                 "protocol": "dns",
                 "action": "hijack-dns"
-            ]
+            ],
+            // Sniff before applying the exact-host exception: packets arrive from the TUN with an
+            // IP destination, so country geosite matching and this anti-bypass rule both need the
+            // recovered TLS/HTTP hostname.
+            ["action": "sniff"],
+            [
+                "domain": [Self.connectivityProbeHost],
+                "outbound": "proxy",
+            ],
         ]
-        if bypassCountries.isEmpty == false {
-            // Domain rule sets need the sniffed hostname on raw connections.
-            routeRules.append(["action": "sniff"])
-        }
         if bypassLan {
             routeRules.append([
                 "ip_is_private": true,
@@ -128,7 +229,7 @@ public struct SingBoxConfiguration: Equatable, Sendable {
         }
         var route: [String: Any] = [
             "auto_detect_interface": true,
-            "default_domain_resolver": "dns-0",
+            "default_domain_resolver": primaryDNS,
             "rules": routeRules,
             "final": "proxy"
         ]


### PR DESCRIPTION
## Summary

- replace proxied TCP/53 with non-circular DoH/443 on Android and iOS
- add explicit primary-to-secondary DNS failover using sing-box evaluate/respond/route rules
- force the dedicated cp.cloudflare.com DNS and HTTPS probe through the proxy before China and other bypass rules
- require fresh DNS followed by HTTPS for startup and health checks
- gate CONNECTED publication on the verified startup result
- add generated-config, failover, DNS codec, and China-bypass dead/working proxy regressions

## Validation

- Android: ./gradlew --no-daemon :app:testDebugUnitTest
- iOS: 149 OpenRungTests passed with zero failures
- iOS PacketTunnel production target: build succeeded for the iOS Simulator
- pinned sing-box configuration checks passed
- npm run transport:check
- git diff --check
