### PR TITLE
Remove custom DNS resolver injection and bump 0.3.6

### DIFF
--- a/android/app/src/main/java/com/openrung/net/SingBoxConfiguration.kt
+++ b/android/app/src/main/java/com/openrung/net/SingBoxConfiguration.kt
@@ -51,11 +51,6 @@ data class SingBoxConfiguration(
     val bridgePort: Int = 0,
     val tunnelIPv4Address: String = DEFAULT_TUNNEL_IPV4_ADDRESS,
     val tunnelIPv6Address: String = "fdfe:dcba:9876::1/126",
-    /**
-     * DoH resolver IPs in priority order. The first is the `evaluate`d primary; the last is the
-     * terminal fallback that answers when every earlier resolver times out or errors.
-     */
-    val dnsServers: List<String> = DEFAULT_DOH_RESOLVERS,
     val mtu: Int = 1400,
     val splitTunnel: SplitTunnelRules? = null,
 ) {
@@ -77,6 +72,7 @@ data class SingBoxConfiguration(
         val outboundPort = if (useLoopbackAdapter) bridgePort else relay.publicPort
         val bypassCountries = splitTunnel?.bypassCountries.orEmpty()
         val excludedPackages = splitTunnel?.excludedPackages.orEmpty()
+        val dnsServers = DEFAULT_DOH_RESOLVERS
 
         val tunInbound = mutableMapOf<String, JsonElement>(
             "type" to JsonPrimitive("tun"),
@@ -108,7 +104,6 @@ data class SingBoxConfiguration(
                 put("timestamp", true)
             })
             put("dns", buildJsonObject {
-                require(dnsServers.isNotEmpty()) { "at least one DoH resolver is required" }
                 put("servers", buildJsonArray {
                     dnsServers.forEachIndexed { index, server ->
                         add(buildJsonObject {
@@ -281,6 +276,7 @@ data class SingBoxConfiguration(
         domainSuffixes: List<String>?,
         disableCache: Boolean,
     ): List<JsonObject> = buildList {
+        val dnsServers = DEFAULT_DOH_RESOLVERS
         fun JsonObjectBuilder.putScopeAndCache() {
             domainSuffixes?.let {
                 put("domain_suffix", JsonArray(it.map(::JsonPrimitive)))

--- a/android/app/src/test/java/com/openrung/vpn/StartupProbeChinaBypassTest.kt
+++ b/android/app/src/test/java/com/openrung/vpn/StartupProbeChinaBypassTest.kt
@@ -30,7 +30,7 @@ import java.net.SocketTimeoutException
  *
  * These run the REAL seams — the WSS fallback ladder, the startup guard race, the startup
  * classification ([verifyStartupTunnelPath], which alone authorizes success), the composite
- * fresh-DNS + HTTPS probe, resolver rotation, and the real cn-bypass configuration. Fakes exist
+ * fresh-DNS + HTTPS probe, resolver failover, and the real cn-bypass configuration. Fakes exist
  * only at the two socket boundaries, which is precisely what a dead or working proxy controls:
  * with the emitted config, ALL probe DNS and HTTPS flows traverse the proxy (asserted below and
  * in SingBoxConfigurationDnsTest), so "proxy dead + direct internet fine" means both boundaries

--- a/ios/OpenRung.xcodeproj/project.pbxproj
+++ b/ios/OpenRung.xcodeproj/project.pbxproj
@@ -1003,7 +1003,7 @@
 					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
 					"\"$(inherited)\"",
 				);
-				MARKETING_VERSION = 0.3.5;
+				MARKETING_VERSION = 0.3.6;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -1159,7 +1159,7 @@
 					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
 					"\"$(inherited)\"",
 				);
-				MARKETING_VERSION = 0.3.5;
+				MARKETING_VERSION = 0.3.6;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				OTHER_CFLAGS = (

--- a/ios/OpenRungTests/StartupPathVerificationTests.swift
+++ b/ios/OpenRungTests/StartupPathVerificationTests.swift
@@ -7,7 +7,7 @@ import XCTest
 ///
 /// These run the REAL seams — the WSS fallback ladder, the startup verification/classification
 /// (`verifyStartupTunnelPath`, which alone authorizes success), the composite fresh-DNS + HTTPS
-/// probe, resolver rotation, and the real cn-bypass configuration (DnsConfigurationTests pins
+/// probe, resolver failover, and the real cn-bypass configuration (DnsConfigurationTests pins
 /// that every probe flow is proxied). Fakes exist only at the two socket boundaries, which is
 /// precisely what a dead or working proxy controls. Mirror of Android
 /// `StartupProbeChinaBypassTest`.

--- a/ios/Shared/SingBoxConfiguration.swift
+++ b/ios/Shared/SingBoxConfiguration.swift
@@ -55,7 +55,6 @@ public struct SingBoxConfiguration: Equatable, Sendable {
     public let relay: RelayDescriptor
     public let tunnelIPv4Address: String
     public let tunnelIPv6Address: String
-    public let dnsServers: [String]
     public let mtu: Int
     /// Optional loopback endpoint owned by a native access transport such as wsscore.
     public let bridgeHost: String?
@@ -69,9 +68,6 @@ public struct SingBoxConfiguration: Equatable, Sendable {
         relay: RelayDescriptor,
         tunnelIPv4Address: String = SingBoxConfiguration.defaultTunnelIPv4Address,
         tunnelIPv6Address: String = "fdfe:dcba:9876::1/126",
-        // DoH resolver IPs in priority order. The first is the `evaluate`d primary; the last is
-        // the terminal fallback that answers when every earlier resolver times out or errors.
-        dnsServers: [String] = SingBoxConfiguration.defaultDoHResolvers,
         mtu: Int = 1400,
         bridgeHost: String? = nil,
         bridgePort: Int? = nil,
@@ -80,7 +76,6 @@ public struct SingBoxConfiguration: Equatable, Sendable {
         self.relay = relay
         self.tunnelIPv4Address = tunnelIPv4Address
         self.tunnelIPv6Address = tunnelIPv6Address
-        self.dnsServers = dnsServers
         self.mtu = mtu
         self.bridgeHost = bridgeHost
         self.bridgePort = bridgePort
@@ -127,6 +122,7 @@ public struct SingBoxConfiguration: Equatable, Sendable {
         let bypassCountries = (splitTunnel?.bypassCountries ?? []).compactMap(SplitTunnelCountry.forCode)
         let bypassLan = splitTunnel?.bypassLan == true
 
+        let dnsServers = Self.defaultDoHResolvers
         var dnsServerObjects: [[String: Any]] = dnsServers.enumerated().map { index, server in
             var object: [String: Any] = [
                 "tag": "dns-\(index)",
@@ -307,6 +303,7 @@ public struct SingBoxConfiguration: Equatable, Sendable {
         domainSuffixes: [String]?,
         disableCache: Bool
     ) -> [[String: Any]] {
+        let dnsServers = Self.defaultDoHResolvers
         var rules: [[String: Any]] = []
         for index in 0..<(dnsServers.count - 1) {
             var evaluate: [String: Any] = [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openrung-mobile-app",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openrung-mobile-app",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "dependencies": {
         "@maplibre/maplibre-react-native": "^11.3.6",
         "@noble/ed25519": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openrung-mobile-app",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
## Summary
- remove the unused custom DNS resolver initializer parameters from both Android and iOS so an empty resolver list cannot generate an invalid configuration
- keep both generators bound to their fixed non-empty DoH resolver lists internally
- update the Android and iOS startup-test comments to describe resolver failover
- bump the app version to 0.3.6

## Validation
- npm run version:check
- npm test -- --runInBand (262 tests)
- npm run lint (passes with 5 existing warnings)
- xcodebuild test -project ios/OpenRung.xcodeproj -scheme OpenRungTests -destination id=21F1D7C8-B537-41D8-A9EA-B5BD28B74A5F -derivedDataPath /private/tmp/openrung-codex-0.3.6-2ab0-derived-data CODE_SIGNING_ALLOWED=NO (164 tests)
- GitHub Actions Android unit-test job