### PR TITLE
Advertise iOS 0.3.6 after TestFlight upload

### DIFF
--- a/release/update-policy.json
+++ b/release/update-policy.json
@@ -4,7 +4,7 @@
     "android": "0.0.0",
     "ios": "0.0.0"
   },
-  "ios_latest": "0.3.5",
+  "ios_latest": "0.3.6",
   "promote": "silent",
   "notice": {
     "id": "2026-08-release-0.3.5",


### PR DESCRIPTION
## Summary
- update the iOS latest release policy from 0.3.5 to 0.3.6 after the successful TestFlight upload

## Release status
- OpenRung 0.3.6 build 12 uploaded successfully to App Store Connect
- Apple reports the uploaded package is processing

## Validation
- npm run version:check
- node scripts/update-manifest.mjs check
- git diff --check