### PR TITLE
iOS: restore NSLocationWhenInUseUsageDescription with a real purpose string

### DIFF
--- a/ios/OpenRung/Info.plist
+++ b/ios/OpenRung/Info.plist
@@ -26,6 +26,17 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<!-- Required even though OpenRung never uses location. MapLibre links CoreLocation
+	     and references CLLocationManager, and the MapLibre React Native pod is linked
+	     into the app binary too, so the API is *reachable* — which is all Apple's check
+	     looks at ("a purpose string is still required" even when the app never calls it).
+	     Keep this key, and keep it NON-EMPTY: a blank value is rejected as ITMS-90738
+	     (which is why it was deleted in a8f88c1) and a missing one as ITMS-90683, so
+	     deleting it and blanking it are both wrong. Nothing in the app requests
+	     authorization, so no permission prompt is ever shown; this text surfaces only if
+	     something asks, and in Settings > Privacy. -->
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>OpenRung does not use your location. The relay map is built with a component that can display your position, but the app never requests or collects it.</string>
 	<key>RCTNewArchEnabled</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>


### PR DESCRIPTION
The 0.3.7 build 13 TestFlight upload succeeded but came back with:

> **ITMS-90683**: Missing purpose string in Info.plist — … should contain a `NSLocationWhenInUseUsageDescription` key with a user-facing purpose string …

## Why it fires when the app has no location code

Apple's check asks only whether a sensitive API is **reachable**, not whether it is called — the warning says so itself ("While your app might not use these APIs, a purpose string is still required"). Verified against the shipped archive:

| Binary | links CoreLocation | references `CLLocationManager` |
|---|---|---|
| `OpenRung.app/OpenRung` | ✓ | ✓ (MapLibre RN pod is statically linked in) |
| `Frameworks/MapLibre.framework/MapLibre` | ✓ | ✓ |
| `PlugIns/PacketTunnel.appex/PacketTunnel` | ✗ | ✗ |

Nothing in `ios/OpenRung`, `ios/PacketTunnel`, `ios/Shared` or `src/` touches CoreLocation, and the map never enables a user-location puck. The reachable symbol comes entirely from MapLibre.

## This is the inverse of a fix already in the tree

- `a8f88c1` (v0.2.5) — *"iOS: drop empty NSLocationWhenInUseUsageDescription (fixes ITMS-90738)"*. An **empty** value was rejected, so the key was deleted.
- Deleting it is what produces **ITMS-90683** — a **missing** value.

Only a present, non-empty string satisfies both. The added comment records that explicitly, because the commit history makes deletion look like the established answer and this is the second lap around the loop.

## The string

> OpenRung does not use your location. The relay map is built with a component that can display your position, but the app never requests or collects it.

Deliberately honest rather than boilerplate: a VPN app declaring location access invites suspicion, so it states plainly that the app does not use it. **Adding the key cannot cause a permission prompt** — iOS prompts only when something requests authorization, and nothing does. The text is reachable only from that dialog and Settings → Privacy.

## Scope

No build-number bump, by request — this rides along with the next release rather than justifying an upload of its own. It does mean build 13, already on TestFlight, still carries the warning; it's advisory and does not affect that build's usability.

Verified: `plutil -lint` passes, the value reads back non-empty, the app target's `INFOPLIST_FILE` is this file (the archive's resolved `CFBundleShortVersionString = 0.3.7` confirms it feeds the shipped bundle), and the extension needs no key of its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)