### PR TITLE
About us: add a Donate button linking to the Every.org donation page

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -43,6 +43,12 @@ export const AppConfig = {
   /** Public policy covering app and network data handling. */
   PRIVACY_URL: 'https://www.openrung.org/privacy',
 
+  /**
+   * Every.org donation page for the OpenRung Foundation, opened in the system browser from the
+   * About screen's donate button. The `code` query param attributes donations to the mobile app.
+   */
+  DONATE_URL: 'https://www.every.org/openrung-foundation?code=af922628#/donate',
+
   /** Public website and official social profiles shown on the About screen. */
   WEBSITE_URL: 'https://openrung.org/',
   GITHUB_URL: 'https://github.com/openrung',
@@ -92,7 +98,8 @@ export const AppConfig = {
    * destinations NEVER come from the manifest, so even a validly-signed (let alone forged)
    * manifest cannot redirect users to a hostile download. iOS uses TESTFLIGHT_URL.
    */
-  UPDATE_URL_ANDROID: 'https://github.com/openrung/openrung-mobile-app/releases/latest',
+  UPDATE_URL_ANDROID:
+    'https://github.com/openrung/openrung-mobile-app/releases/latest',
 
   /** Minimum interval between successful update-manifest checks (cold start + app foreground). */
   UPDATE_CHECK_INTERVAL_MS: 6 * 3_600_000,
@@ -113,7 +120,8 @@ export const AppConfig = {
   MANIFEST_SIGNING_KEYS: [
     {
       keyId: 'a71d7615b7af163b', // active (seed in GitHub secret OPENRUNG_MANIFEST_SIGNING_SEED_B64)
-      publicKeyHex: '3443068d4cb27dd474dee11155c365a44df6a24c560b8ae2cb019487b555bfc7',
+      publicKeyHex:
+        '3443068d4cb27dd474dee11155c365a44df6a24c560b8ae2cb019487b555bfc7',
     },
   ],
 } as const;

--- a/src/i18n/strings/ar.ts
+++ b/src/i18n/strings/ar.ts
@@ -59,8 +59,7 @@ export const ar: Partial<Strings> = {
 
   // Relay speed test (settings + diagnostics).
   speedTestSettingTitle: 'اختبار سرعة المُرحّل',
-  speedTestReady:
-    'تنزيل 10 MB عبر المُرحّل النشط والإبلاغ عن النتيجة.',
+  speedTestReady: 'تنزيل 10 MB عبر المُرحّل النشط والإبلاغ عن النتيجة.',
   speedTestRequiresConnection: 'اتصل بمُرحّل قبل إجراء اختبار السرعة.',
   speedTestRunning: 'جار اختبار سرعة التنزيل عبر المُرحّل…',
   speedTestResult: (mbps: number) => `سرعة التنزيل: ${mbps.toFixed(1)} Mbps`,
@@ -114,14 +113,17 @@ export const ar: Partial<Strings> = {
     'أرسل رابط TestFlight ليتمكّن الآخرون من تثبيت نسخة iOS التجريبية.',
   shareTestFlightMessage: 'انضم إلى نسخة OpenRung التجريبية عبر TestFlight:',
   shareTestFlightErrorTitle: 'تعذّرت مشاركة OpenRung',
-  shareTestFlightErrorBody:
-    'تعذّرت مشاركة رابط TestFlight. حاول مرة أخرى.',
+  shareTestFlightErrorBody: 'تعذّرت مشاركة رابط TestFlight. حاول مرة أخرى.',
 
   // Home overlay and about screen.
   homeTagline: 'شبكة المُرحّلات',
   aboutMissionLead: 'نؤمن بأن الوصول إلى الإنترنت حق، وليس امتيازًا',
   aboutMissionBody:
     'وليس ورقة مساومة يتداولها أصحاب السلطة. إن الحق في المعلومات متأصل في إنسانيتنا، ولا ينبغي السماح لأي جدار ناري بمَحوه. ومع ذلك، يعيش اليوم مليارات البشر خلف جدران بُنيت لإبقاء المعلومات خارجًا والصمت داخلًا؛ حيث يُرجع بحث Google خطأ 404، وقد يكون طرح سؤال أمرًا خطيرًا، وينتهي الفضول عند صفحة محجوبة.\n\nوُجد OpenRung ليغيّر ذلك.\n\nنحن نبني سُلّمًا يتجاوز تلك الجدران. يشارك أشخاص عاديون حول العالم اتصالاتهم كي يتمكن شخص على الجانب الآخر من جدار ناري من الوصول إلى الإنترنت المفتوح.\n\nالمعلومات قوة، وهذه القوة ملك لنا، لا لمن يريدون انتزاعها منا.',
+  aboutSupportHeader: 'ادعمونا',
+  donateTitle: 'تبرّع',
+  donateSubtitle:
+    'ساعدنا على إبقاء السلّم قائمًا. تذهب التبرعات إلى مؤسسة OpenRung.',
   aboutLegalHeader: 'الشؤون القانونية',
   aboutFollowHeader: 'تابعنا',
 
@@ -150,7 +152,8 @@ export const ar: Partial<Strings> = {
   splitTunnelAppPickerClose: 'إغلاق',
   splitTunnelApplyHint:
     'تُطبَّق التغييرات فورًا؛ يعيد النفق الاتصال لبضع ثوانٍ.',
-  splitTunnelResetHint: 'تُعاد إعدادات إيران والصين إلى الوضع الافتراضي عند إعادة تشغيل التطبيق.',
+  splitTunnelResetHint:
+    'تُعاد إعدادات إيران والصين إلى الوضع الافتراضي عند إعادة تشغيل التطبيق.',
   splitTunnelResetHintWithApps:
     'تُعاد إعدادات إيران والصين إلى الوضع الافتراضي عند إعادة تشغيل التطبيق؛ أما التطبيقات المستثناة فتُحفظ.',
 
@@ -158,7 +161,8 @@ export const ar: Partial<Strings> = {
   updateRequiredTitle: 'التحديث مطلوب',
   updateRequiredBody:
     'لم يعد بإمكان هذا الإصدار من OpenRung الاتصال بشبكة المُرحّلات. ثبّت أحدث إصدار للمتابعة.',
-  updateVersionTransition: (current: string, latest: string) => `v${current} -> v${latest}`,
+  updateVersionTransition: (current: string, latest: string) =>
+    `v${current} -> v${latest}`,
   updateActionNow: 'تحديث',
   updateActionLater: 'لاحقًا',
   updateContinueAnyway: 'المتابعة على أي حال',

--- a/src/i18n/strings/en.ts
+++ b/src/i18n/strings/en.ts
@@ -25,8 +25,10 @@ export const en = {
   languageSettingSubtitle: 'Use system language or choose one for OpenRung.',
   versionSettingTitle: 'Version',
   speedTestSettingTitle: 'Relay speed test',
-  speedTestReady: 'Download 10 MB through the active relay and report the result.',
-  speedTestRequiresConnection: 'Connect to a relay before running the speed test.',
+  speedTestReady:
+    'Download 10 MB through the active relay and report the result.',
+  speedTestRequiresConnection:
+    'Connect to a relay before running the speed test.',
   speedTestRunning: 'Testing download speed through the relay…',
   speedTestResult: (mbps: number) => `Download speed: ${mbps.toFixed(1)} Mbps`,
   speedTestError: (error: string) => `Speed test failed: ${error}`,
@@ -47,7 +49,8 @@ export const en = {
   statusConnected: 'Connected',
   statusDisconnecting: 'Disconnecting',
   statusFailed: 'Failed',
-  mapContentDescription: 'Map of available exit nodes across the Asia-Pacific region',
+  mapContentDescription:
+    'Map of available exit nodes across the Asia-Pacific region',
   mapLoading: 'locating available exit nodes…',
   mapFailed: "couldn't load exit nodes — tap to retry",
   mapNodesAvailable: (count: number) => `${count} locations available`,
@@ -57,7 +60,8 @@ export const en = {
   viewToggleMap: 'Map',
   viewToggleList: 'List',
   listContentDescription: 'List of available exit nodes',
-  listRelayCount: (count: number) => (count === 1 ? '1 relay' : `${count} relays`),
+  listRelayCount: (count: number) =>
+    count === 1 ? '1 relay' : `${count} relays`,
   debugSettingTitle: 'Debug',
   debugSettingSubtitle: 'Connection console and diagnostics.',
   debugTitle: 'Debug console',
@@ -68,7 +72,8 @@ export const en = {
     'OpenRung is free software licensed under GPL-3.0-or-later because it links sing-box. The complete corresponding source for this build is available at the link below.',
   licensesSourceTitle: 'Source code',
   privacyPolicyTitle: 'Privacy policy',
-  privacyPolicySubtitle: 'How OpenRung handles beta diagnostics and personal information.',
+  privacyPolicySubtitle:
+    'How OpenRung handles beta diagnostics and personal information.',
   licensesFullTextTitle: 'Full license texts',
   licensesFullTextSubtitle: 'GNU GPL-3.0 and third-party notices.',
   licensesComponentsHeader: 'Components',
@@ -83,7 +88,8 @@ export const en = {
   shareTestFlightSubtitle: 'Send a TestFlight link that installs the iOS beta.',
   shareTestFlightMessage: 'Join the OpenRung beta on TestFlight:',
   shareTestFlightErrorTitle: 'Unable to share OpenRung',
-  shareTestFlightErrorBody: 'The TestFlight link could not be shared. Try again.',
+  shareTestFlightErrorBody:
+    'The TestFlight link could not be shared. Try again.',
 
   // --- Redesigned shell (tabs, home overlay, about) ---
   tabHome: 'Home',
@@ -100,6 +106,10 @@ export const en = {
   aboutMissionLead: 'We believe internet access is a right, not a privilege',
   aboutMissionBody:
     'and not a bargaining chip to be traded away by those in power. The right to information is written into who we are as human beings - and no firewall should be allowed to erase it. Yet today billions of people live behind walls built to keep information out and keep silence in, where a Google search returns 404, a question can be dangerous and curiosity ends at a blocked page.\n\nOpenRung exists to change that.\n\nWe are building a ladder over those walls. Ordinary people around the world share their connections so that someone on the other side of a firewall can reach the open internet.\n\nInformation is power - and that power belongs to us, and not to those who would take it from us.',
+  aboutSupportHeader: 'Support us',
+  donateTitle: 'Donate',
+  donateSubtitle:
+    'Help keep the ladder standing. Donations go to the OpenRung Foundation.',
   aboutLegalHeader: 'Legal',
   aboutFollowHeader: 'Follow us',
 
@@ -137,7 +147,8 @@ export const en = {
     'changes apply immediately; the tunnel reconnects for a few seconds.',
   // Two variants because the APPS section is Android-only: on iOS the footer must not mention a
   // bypassed-apps list the user cannot see.
-  splitTunnelResetHint: 'the Iran and China presets reset when you restart the app.',
+  splitTunnelResetHint:
+    'the Iran and China presets reset when you restart the app.',
   splitTunnelResetHintWithApps:
     'the Iran and China presets reset when you restart the app; bypassed apps are kept.',
 
@@ -145,7 +156,8 @@ export const en = {
   updateRequiredTitle: 'Update required',
   updateRequiredBody:
     'This version of OpenRung can no longer connect to the relay network. Install the latest release to keep going.',
-  updateVersionTransition: (current: string, latest: string) => `v${current} -> v${latest}`,
+  updateVersionTransition: (current: string, latest: string) =>
+    `v${current} -> v${latest}`,
   updateActionNow: 'UPDATE',
   updateActionLater: 'Later',
   updateContinueAnyway: 'Continue anyway',

--- a/src/i18n/strings/fa.ts
+++ b/src/i18n/strings/fa.ts
@@ -16,7 +16,8 @@ export const fa: Partial<Strings> = {
   settingsTitle: 'تنظیمات',
   backContentDescription: 'بازگشت',
   languageSettingTitle: 'زبان',
-  languageSettingSubtitle: 'از زبان سیستم استفاده کنید یا زبانی برای OpenRung انتخاب کنید.',
+  languageSettingSubtitle:
+    'از زبان سیستم استفاده کنید یا زبانی برای OpenRung انتخاب کنید.',
   versionSettingTitle: 'نسخه',
   languageSystem: 'پیش‌فرض سیستم',
   languageEnglish: 'English',
@@ -59,7 +60,8 @@ export const fa: Partial<Strings> = {
 
   // Relay speed test.
   speedTestSettingTitle: 'تست سرعت رله',
-  speedTestReady: 'از طریق رله فعال، 10 MB دانلود می‌کند و نتیجه را گزارش می‌دهد.',
+  speedTestReady:
+    'از طریق رله فعال، 10 MB دانلود می‌کند و نتیجه را گزارش می‌دهد.',
   speedTestRequiresConnection: 'پیش از اجرای تست سرعت، به یک رله متصل شوید.',
   speedTestRunning: 'در حال تست سرعت دانلود از طریق رله…',
   speedTestResult: (mbps: number) => `سرعت دانلود: ${mbps.toFixed(1)} Mbps`,
@@ -67,7 +69,8 @@ export const fa: Partial<Strings> = {
   speedTestAction: 'اجرا',
 
   // Map view (exit nodes).
-  mapContentDescription: 'نقشهٔ گره‌های خروجی موجود در سراسر منطقهٔ آسیا-اقیانوسیه',
+  mapContentDescription:
+    'نقشهٔ گره‌های خروجی موجود در سراسر منطقهٔ آسیا-اقیانوسیه',
   mapLoading: 'در حال یافتن گره‌های خروجی موجود…',
   mapFailed: 'بارگذاری گره‌های خروجی ناموفق بود — برای تلاش دوباره ضربه بزنید',
   mapNodesAvailable: (count: number) => `${count} مکان موجود`,
@@ -122,6 +125,10 @@ export const fa: Partial<Strings> = {
   aboutMissionLead: 'ما باور داریم دسترسی به اینترنت یک حق است، نه یک امتیاز',
   aboutMissionBody:
     'و نه ابزار چانه‌زنی در دست صاحبان قدرت. حق دسترسی به اطلاعات در سرشت انسانی ما ریشه دارد و هیچ دیوار آتشی نباید اجازه داشته باشد آن را از بین ببرد. با این حال، امروز میلیاردها نفر پشت دیوارهایی زندگی می‌کنند که برای بیرون نگه داشتن اطلاعات و درون نگه داشتن سکوت ساخته شده‌اند؛ جایی که جست‌وجوی Google خطای 404 برمی‌گرداند، پرسیدن یک سؤال می‌تواند خطرناک باشد و کنجکاوی به یک صفحهٔ مسدودشده ختم می‌شود.\n\nOpenRung برای تغییر این وضعیت به وجود آمده است.\n\nما در حال ساختن نردبانی بر فراز این دیوارها هستیم. مردم عادی در سراسر جهان اتصال خود را به اشتراک می‌گذارند تا کسی در سوی دیگر یک دیوار آتش بتواند به اینترنت آزاد دسترسی پیدا کند.\n\nاطلاعات قدرت است و این قدرت به ما تعلق دارد، نه به کسانی که می‌خواهند آن را از ما بگیرند.',
+  aboutSupportHeader: 'از ما حمایت کنید',
+  donateTitle: 'کمک مالی',
+  donateSubtitle:
+    'کمک کنید نردبان برپا بماند. کمک‌ها به بنیاد OpenRung می‌رسد.',
   aboutLegalHeader: 'حقوقی',
   aboutFollowHeader: 'ما را دنبال کنید',
 
@@ -137,20 +144,25 @@ export const fa: Partial<Strings> = {
   splitTunnelLanSubtitle:
     'به چاپگرها، تلویزیون‌ها و دیگر دستگاه‌های شبکهٔ محلی مستقیم دسترسی داشته باشید.',
   splitTunnelIranTitle: 'سایت‌ها و برنامه‌های ایرانی',
-  splitTunnelIranSubtitle: 'سرویس‌های ایرانی را مستقیم و با سرعت کامل هدایت کنید.',
+  splitTunnelIranSubtitle:
+    'سرویس‌های ایرانی را مستقیم و با سرعت کامل هدایت کنید.',
   splitTunnelChinaTitle: 'سایت‌ها و برنامه‌های چینی',
-  splitTunnelChinaSubtitle: 'سرویس‌های چینی را مستقیم و با سرعت کامل هدایت کنید.',
+  splitTunnelChinaSubtitle:
+    'سرویس‌های چینی را مستقیم و با سرعت کامل هدایت کنید.',
   splitTunnelAppsHeader: 'برنامه‌ها',
   splitTunnelAppsTitle: 'برنامه‌های خارج از VPN',
   splitTunnelAppsSubtitle: (count: number) =>
-    count === 1 ? '1 برنامه VPN را دور می‌زند.' : `${count} برنامه VPN را دور می‌زنند.`,
+    count === 1
+      ? '1 برنامه VPN را دور می‌زند.'
+      : `${count} برنامه VPN را دور می‌زنند.`,
   splitTunnelAppPickerTitle: 'برنامه‌های خارج از VPN',
   splitTunnelAppPickerLoading: 'در حال بارگذاری برنامه‌های نصب‌شده…',
   splitTunnelAppPickerEmpty: 'برنامهٔ قابل اجرا پیدا نشد.',
   splitTunnelAppPickerClose: 'بستن',
   splitTunnelApplyHint:
     'تغییرات بلافاصله اعمال می‌شوند؛ تونل برای چند ثانیه دوباره متصل می‌شود.',
-  splitTunnelResetHint: 'با راه‌اندازی مجدد برنامه، پیش‌تنظیم‌های ایران و چین بازنشانی می‌شوند.',
+  splitTunnelResetHint:
+    'با راه‌اندازی مجدد برنامه، پیش‌تنظیم‌های ایران و چین بازنشانی می‌شوند.',
   splitTunnelResetHintWithApps:
     'با راه‌اندازی مجدد برنامه، پیش‌تنظیم‌های ایران و چین بازنشانی می‌شوند؛ برنامه‌های کنارگذاشته‌شده حفظ می‌شوند.',
 
@@ -158,7 +170,8 @@ export const fa: Partial<Strings> = {
   updateRequiredTitle: 'به‌روزرسانی لازم است',
   updateRequiredBody:
     'این نسخه از OpenRung دیگر نمی‌تواند به شبکهٔ رله‌ها متصل شود. برای ادامه، آخرین نسخه را نصب کنید.',
-  updateVersionTransition: (current: string, latest: string) => `v${current} -> v${latest}`,
+  updateVersionTransition: (current: string, latest: string) =>
+    `v${current} -> v${latest}`,
   updateActionNow: 'به‌روزرسانی',
   updateActionLater: 'بعداً',
   updateContinueAnyway: 'به هر حال ادامه دهید',

--- a/src/i18n/strings/my.ts
+++ b/src/i18n/strings/my.ts
@@ -65,10 +65,11 @@ export const my: Partial<Strings> = {
     'လက်ရှိ ရီလေးမှတစ်ဆင့် 10 MB ကို ဒေါင်းလုဒ်လုပ်ပြီး ရလဒ်ကို ဖော်ပြပါ။',
   speedTestRequiresConnection:
     'အမြန်နှုန်း စမ်းသပ်မှု မလုပ်မီ ရီလေးတစ်ခုသို့ ချိတ်ဆက်ပါ။',
-  speedTestRunning:
-    'ရီလေးမှတစ်ဆင့် ဒေါင်းလုဒ် အမြန်နှုန်းကို စမ်းသပ်နေသည်…',
-  speedTestResult: (mbps: number) => `ဒေါင်းလုဒ် အမြန်နှုန်း: ${mbps.toFixed(1)} Mbps`,
-  speedTestError: (error: string) => `အမြန်နှုန်း စမ်းသပ်မှု မအောင်မြင်ပါ: ${error}`,
+  speedTestRunning: 'ရီလေးမှတစ်ဆင့် ဒေါင်းလုဒ် အမြန်နှုန်းကို စမ်းသပ်နေသည်…',
+  speedTestResult: (mbps: number) =>
+    `ဒေါင်းလုဒ် အမြန်နှုန်း: ${mbps.toFixed(1)} Mbps`,
+  speedTestError: (error: string) =>
+    `အမြန်နှုန်း စမ်းသပ်မှု မအောင်မြင်ပါ: ${error}`,
   speedTestAction: 'စမ်းသပ်မည်',
 
   // Map view (exit nodes).
@@ -88,9 +89,9 @@ export const my: Partial<Strings> = {
   viewToggleList: 'စာရင်း',
 
   // List view (exit nodes).
-  listContentDescription:
-    'ရနိုင်သော ထွက်ပေါက်ဆုံမှတ်များ၏ စာရင်း',
-  listRelayCount: (count: number) => (count === 1 ? 'ရီလေး 1 ခု' : `ရီလေး ${count} ခု`),
+  listContentDescription: 'ရနိုင်သော ထွက်ပေါက်ဆုံမှတ်များ၏ စာရင်း',
+  listRelayCount: (count: number) =>
+    count === 1 ? 'ရီလေး 1 ခု' : `ရီလေး ${count} ခု`,
 
   // Debug console.
   debugSettingTitle: 'အမှားရှာဖွေခြင်း',
@@ -124,8 +125,7 @@ export const my: Partial<Strings> = {
     'iOS beta ကို ထည့်သွင်းနိုင်ရန် TestFlight လင့်ခ်ကို ပေးပို့ပါ။',
   shareTestFlightMessage: 'TestFlight တွင် OpenRung beta သို့ ပါဝင်ပါ –',
   shareTestFlightErrorTitle: 'OpenRung ကို မျှဝေ၍မရပါ',
-  shareTestFlightErrorBody:
-    'TestFlight လင့်ခ်ကို မျှဝေ၍မရပါ။ ထပ်မံကြိုးစားပါ။',
+  shareTestFlightErrorBody: 'TestFlight လင့်ခ်ကို မျှဝေ၍မရပါ။ ထပ်မံကြိုးစားပါ။',
 
   // Home overlay and about screen.
   homeTagline: 'ရီလေး ကွန်ရက်',
@@ -133,9 +133,12 @@ export const my: Partial<Strings> = {
     'အင်တာနက် အသုံးပြုခွင့်သည် အခွင့်ထူးမဟုတ်ဘဲ အခွင့်အရေးဖြစ်သည်ဟု ကျွန်ုပ်တို့ ယုံကြည်သည်',
   aboutMissionBody:
     'အာဏာရှိသူများ အလဲအလှယ်လုပ်နိုင်သည့် အရာတစ်ခုလည်း မဟုတ်ပါ။ သတင်းအချက်အလက် သိရှိပိုင်ခွင့်သည် လူသားဖြစ်ခြင်း၏ အခြေခံအစိတ်အပိုင်းတစ်ခုဖြစ်ပြီး မည်သည့် firewall ကမျှ ထိုအခွင့်အရေးကို ဖျောက်ဖျက်ခွင့်မရှိပါ။ သို့သော် ယနေ့တွင် လူဘီလီယံပေါင်းများစွာသည် သတင်းအချက်အလက်ကို အပြင်တွင်ထားပြီး တိတ်ဆိတ်မှုကို အတွင်းတွင်ပိတ်ထားသော နံရံများနောက်၌ နေထိုင်နေကြရသည်။ ထိုနေရာများတွင် Google ရှာဖွေမှုက 404 ကိုသာ ပြသသည်၊ မေးခွန်းတစ်ခုမေးခြင်းသည် အန္တရာယ်ရှိနိုင်ပြီး စူးစမ်းလိုစိတ်သည် ပိတ်ဆို့ထားသော စာမျက်နှာတစ်ခုတွင် အဆုံးသတ်သွားသည်။\n\nOpenRung သည် ထိုအခြေအနေကို ပြောင်းလဲရန် တည်ရှိသည်။\n\nကျွန်ုပ်တို့သည် ထိုနံရံများကို ကျော်နိုင်မည့် လှေကားတစ်စင်း တည်ဆောက်နေသည်။ ကမ္ဘာတစ်ဝှမ်းရှိ သာမန်လူများက မိမိတို့၏ အင်တာနက်ချိတ်ဆက်မှုကို မျှဝေကြပြီး firewall ၏ အခြားတစ်ဖက်ရှိ တစ်စုံတစ်ယောက်ကို ပွင့်လင်းသော အင်တာနက်သို့ ရောက်ရှိနိုင်စေသည်။\n\nသတင်းအချက်အလက်သည် စွမ်းအားဖြစ်သည်။ ထိုစွမ်းအားသည် ကျွန်ုပ်တို့ပိုင်ဖြစ်ပြီး ကျွန်ုပ်တို့ထံမှ လုယူလိုသူများပိုင် မဟုတ်ပါ။',
+  aboutSupportHeader: 'ကျွန်ုပ်တို့ကို ထောက်ပံ့ပါ',
+  donateTitle: 'လှူဒါန်းရန်',
+  donateSubtitle:
+    'လှေကား ဆက်လက်ရပ်တည်နိုင်အောင် ကူညီပါ။ လှူဒါန်းငွေများသည် OpenRung Foundation သို့ ရောက်ရှိပါသည်။',
   aboutLegalHeader: 'ဥပဒေဆိုင်ရာ',
   aboutFollowHeader: 'ကျွန်ုပ်တို့ကို လိုက်နာပါ',
-
 
   // --- Split tunneling (settings row + screen + Android app picker) ---
   splitTunnelSettingTitle: 'ဥမင် ခွဲထုတ်ခြင်း',
@@ -167,7 +170,8 @@ export const my: Partial<Strings> = {
   splitTunnelAppPickerClose: 'ပိတ်မည်',
   splitTunnelApplyHint:
     'ပြောင်းလဲမှုများ ချက်ချင်း သက်ရောက်သည်။ ဥမင်သည် စက္ကန့်အနည်းငယ် ပြန်လည်ချိတ်ဆက်မည်။',
-  splitTunnelResetHint: 'အက်ပ်ကို ပြန်စတင်သည့်အခါ အီရန်နှင့် တရုတ် သတ်မှတ်ချက်များ ပြန်လည်သတ်မှတ်မည်။',
+  splitTunnelResetHint:
+    'အက်ပ်ကို ပြန်စတင်သည့်အခါ အီရန်နှင့် တရုတ် သတ်မှတ်ချက်များ ပြန်လည်သတ်မှတ်မည်။',
   splitTunnelResetHintWithApps:
     'အက်ပ်ကို ပြန်စတင်သည့်အခါ အီရန်နှင့် တရုတ် သတ်မှတ်ချက်များ ပြန်လည်သတ်မှတ်မည်။ ချွင်းချက်ပြုထားသော အက်ပ်များကို ထိန်းသိမ်းထားမည်။',
 
@@ -175,7 +179,8 @@ export const my: Partial<Strings> = {
   updateRequiredTitle: 'အပ်ဒိတ် လုပ်ရန် လိုအပ်သည်',
   updateRequiredBody:
     'ဤ OpenRung ဗားရှင်းသည် ရီလေး ကွန်ရက်သို့ ချိတ်ဆက်၍ မရတော့ပါ။ ဆက်လက်အသုံးပြုနိုင်ရန် နောက်ဆုံးထွက် ဗားရှင်းကို ထည့်သွင်းပါ။',
-  updateVersionTransition: (current: string, latest: string) => `v${current} -> v${latest}`,
+  updateVersionTransition: (current: string, latest: string) =>
+    `v${current} -> v${latest}`,
   updateActionNow: 'အပ်ဒိတ်လုပ်မည်',
   updateActionLater: 'နောက်မှ',
   updateContinueAnyway: 'မည်သို့ပင်ဖြစ်စေ ဆက်လုပ်မည်',

--- a/src/i18n/strings/ru.ts
+++ b/src/i18n/strings/ru.ts
@@ -16,7 +16,8 @@ export const ru: Partial<Strings> = {
   settingsTitle: 'Настройки',
   backContentDescription: 'Назад',
   languageSettingTitle: 'Язык',
-  languageSettingSubtitle: 'Используйте системный язык или выберите язык для OpenRung.',
+  languageSettingSubtitle:
+    'Используйте системный язык или выберите язык для OpenRung.',
   versionSettingTitle: 'Версия',
   languageSystem: 'Как в системе',
   languageEnglish: 'English',
@@ -59,15 +60,19 @@ export const ru: Partial<Strings> = {
 
   // Relay speed test (diagnostics).
   speedTestSettingTitle: 'Тест скорости ретранслятора',
-  speedTestReady: 'Загрузить 10 MB через активный ретранслятор и показать результат.',
-  speedTestRequiresConnection: 'Перед запуском теста скорости подключитесь к ретранслятору.',
+  speedTestReady:
+    'Загрузить 10 MB через активный ретранслятор и показать результат.',
+  speedTestRequiresConnection:
+    'Перед запуском теста скорости подключитесь к ретранслятору.',
   speedTestRunning: 'Проверка скорости загрузки через ретранслятор…',
-  speedTestResult: (mbps: number) => `Скорость загрузки: ${mbps.toFixed(1)} Mbps`,
+  speedTestResult: (mbps: number) =>
+    `Скорость загрузки: ${mbps.toFixed(1)} Mbps`,
   speedTestError: (error: string) => `Ошибка теста скорости: ${error}`,
   speedTestAction: 'ЗАПУСК',
 
   // Map view (exit-node overview).
-  mapContentDescription: 'Карта доступных выходных узлов в Азиатско-Тихоокеанском регионе',
+  mapContentDescription:
+    'Карта доступных выходных узлов в Азиатско-Тихоокеанском регионе',
   mapLoading: 'поиск доступных выходных узлов…',
   mapFailed: 'не удалось загрузить выходные узлы — нажмите, чтобы повторить',
   mapNodesAvailable: (count: number) => `доступно локаций: ${count}`,
@@ -117,37 +122,49 @@ export const ru: Partial<Strings> = {
 
   // Home overlay / about screen.
   homeTagline: 'сеть ретрансляторов',
-  aboutMissionLead: 'Мы верим, что доступ в интернет — это право, а не привилегия',
+  aboutMissionLead:
+    'Мы верим, что доступ в интернет — это право, а не привилегия',
   aboutMissionBody:
     'и не разменная монета в руках власть имущих. Право на информацию заложено в самой человеческой природе, и никакой файрвол не должен стирать его. Но сегодня миллиарды людей живут за стенами, возведёнными, чтобы не впускать информацию и не выпускать молчание; там поиск Google возвращает ошибку 404, вопрос может быть опасным, а любопытство заканчивается на заблокированной странице.\n\nOpenRung существует, чтобы изменить это.\n\nМы строим лестницу через эти стены. Обычные люди по всему миру делятся своим подключением, чтобы человек по другую сторону файрвола мог выйти в открытый интернет.\n\nИнформация — это сила, и эта сила принадлежит нам, а не тем, кто хочет её у нас отнять.',
+  aboutSupportHeader: 'Поддержите нас',
+  donateTitle: 'Пожертвовать',
+  donateSubtitle:
+    'Помогите лестнице устоять. Пожертвования идут в фонд OpenRung Foundation.',
   aboutLegalHeader: 'Правовая информация',
   aboutFollowHeader: 'Подписывайтесь',
 
   // --- Split tunneling (settings row + screen + Android app picker) ---
   splitTunnelSettingTitle: 'Раздельное туннелирование',
-  splitTunnelSettingSubtitleOn: 'Включено — выбранный трафик идёт мимо ретранслятора.',
-  splitTunnelSettingSubtitleOff: 'Выключено — весь трафик идёт через ретранслятор.',
+  splitTunnelSettingSubtitleOn:
+    'Включено — выбранный трафик идёт мимо ретранслятора.',
+  splitTunnelSettingSubtitleOff:
+    'Выключено — весь трафик идёт через ретранслятор.',
   splitTunnelHeader: 'Раздельное туннелирование',
   splitTunnelMasterTitle: 'Раздельное туннелирование',
-  splitTunnelMasterSubtitle: 'Отправлять выбранный трафик мимо туннеля ретранслятора.',
+  splitTunnelMasterSubtitle:
+    'Отправлять выбранный трафик мимо туннеля ретранслятора.',
   splitTunnelBypassHeader: 'Обход',
   splitTunnelLanTitle: 'Локальная сеть',
   splitTunnelLanSubtitle:
     'Прямой доступ к принтерам, телевизорам и другим устройствам локальной сети.',
   splitTunnelIranTitle: 'Иранские сайты и приложения',
-  splitTunnelIranSubtitle: 'Направлять иранские сервисы напрямую, на полной скорости.',
+  splitTunnelIranSubtitle:
+    'Направлять иранские сервисы напрямую, на полной скорости.',
   splitTunnelChinaTitle: 'Китайские сайты и приложения',
-  splitTunnelChinaSubtitle: 'Направлять китайские сервисы напрямую, на полной скорости.',
+  splitTunnelChinaSubtitle:
+    'Направлять китайские сервисы напрямую, на полной скорости.',
   splitTunnelAppsHeader: 'Приложения',
   splitTunnelAppsTitle: 'Приложения в обход',
-  splitTunnelAppsSubtitle: (count: number) => `приложений в обход VPN: ${count}`,
+  splitTunnelAppsSubtitle: (count: number) =>
+    `приложений в обход VPN: ${count}`,
   splitTunnelAppPickerTitle: 'Приложения в обход',
   splitTunnelAppPickerLoading: 'загрузка установленных приложений…',
   splitTunnelAppPickerEmpty: 'запускаемых приложений не найдено.',
   splitTunnelAppPickerClose: 'ЗАКРЫТЬ',
   splitTunnelApplyHint:
     'изменения применяются сразу; туннель переподключается на несколько секунд.',
-  splitTunnelResetHint: 'после перезапуска приложения наборы для Ирана и Китая сбрасываются.',
+  splitTunnelResetHint:
+    'после перезапуска приложения наборы для Ирана и Китая сбрасываются.',
   splitTunnelResetHintWithApps:
     'после перезапуска приложения наборы для Ирана и Китая сбрасываются; исключённые приложения сохраняются.',
 
@@ -155,7 +172,8 @@ export const ru: Partial<Strings> = {
   updateRequiredTitle: 'Требуется обновление',
   updateRequiredBody:
     'Эта версия OpenRung больше не может подключаться к сети ретрансляторов. Установите последний выпуск, чтобы продолжить пользоваться приложением.',
-  updateVersionTransition: (current: string, latest: string) => `v${current} -> v${latest}`,
+  updateVersionTransition: (current: string, latest: string) =>
+    `v${current} -> v${latest}`,
   updateActionNow: 'ОБНОВИТЬ',
   updateActionLater: 'Позже',
   updateContinueAnyway: 'Всё равно продолжить',

--- a/src/i18n/strings/tr.ts
+++ b/src/i18n/strings/tr.ts
@@ -16,7 +16,8 @@ export const tr: Partial<Strings> = {
   settingsTitle: 'Ayarlar',
   backContentDescription: 'Geri',
   languageSettingTitle: 'Dil',
-  languageSettingSubtitle: 'Sistem dilini kullanın veya OpenRung için bir dil seçin.',
+  languageSettingSubtitle:
+    'Sistem dilini kullanın veya OpenRung için bir dil seçin.',
   versionSettingTitle: 'Sürüm',
   languageSystem: 'Sistem varsayılanı',
   languageEnglish: 'English',
@@ -60,14 +61,16 @@ export const tr: Partial<Strings> = {
   // Relay speed test (diagnostics).
   speedTestSettingTitle: 'Röle hız testi',
   speedTestReady: 'Aktif röle üzerinden 10 MB indirin ve sonucu bildirin.',
-  speedTestRequiresConnection: 'Hız testini çalıştırmadan önce bir röleye bağlanın.',
+  speedTestRequiresConnection:
+    'Hız testini çalıştırmadan önce bir röleye bağlanın.',
   speedTestRunning: 'Röle üzerinden indirme hızı test ediliyor…',
   speedTestResult: (mbps: number) => `İndirme hızı: ${mbps.toFixed(1)} Mbps`,
   speedTestError: (error: string) => `Hız testi başarısız: ${error}`,
   speedTestAction: 'ÇALIŞTIR',
 
   // Exit node map view.
-  mapContentDescription: 'Asya-Pasifik bölgesindeki mevcut çıkış düğümlerinin haritası',
+  mapContentDescription:
+    'Asya-Pasifik bölgesindeki mevcut çıkış düğümlerinin haritası',
   mapLoading: 'mevcut çıkış düğümleri bulunuyor…',
   mapFailed: 'çıkış düğümleri yüklenemedi — yeniden denemek için dokunun',
   mapNodesAvailable: (count: number) => `${count} konum mevcut`,
@@ -112,7 +115,7 @@ export const tr: Partial<Strings> = {
     "Bu kopya birden fazla APK dosyasıyla yüklendiği için güvenle paylaşılamaz. Çevrimdışı paylaşım için bağımsız OpenRung APK'sını yükleyin.",
   shareTestFlightTitle: "OpenRung'u paylaş",
   shareTestFlightSubtitle:
-    "Başkalarının iOS betasını kurabilmesi için TestFlight bağlantısı gönderin.",
+    'Başkalarının iOS betasını kurabilmesi için TestFlight bağlantısı gönderin.',
   shareTestFlightMessage: "TestFlight'ta OpenRung betasına katılın:",
   shareTestFlightErrorTitle: 'OpenRung paylaşılamıyor',
   shareTestFlightErrorBody:
@@ -120,12 +123,16 @@ export const tr: Partial<Strings> = {
 
   // Home overlay and about screen.
   homeTagline: 'röle ağı',
-  aboutMissionLead: 'İnternete erişimin bir ayrıcalık değil, hak olduğuna inanıyoruz',
+  aboutMissionLead:
+    'İnternete erişimin bir ayrıcalık değil, hak olduğuna inanıyoruz',
   aboutMissionBody:
     'Bu hak, iktidardakilerin pazarlık konusu yapabileceği bir koz değildir. Bilgi edinme hakkı insan oluşumuzun özünde vardır ve hiçbir güvenlik duvarının bunu silmesine izin verilmemelidir. Yine de bugün milyarlarca insan, bilgiyi dışarıda ve sessizliği içeride tutmak için örülmüş duvarların arkasında yaşıyor; Google aramasının 404 döndürdüğü, soru sormanın tehlikeli olabildiği ve merakın engellenmiş bir sayfada sona erdiği yerlerde.\n\nOpenRung bunu değiştirmek için var.\n\nBu duvarların üzerinden bir merdiven inşa ediyoruz. Dünyanın dört bir yanındaki sıradan insanlar bağlantılarını paylaşıyor; böylece bir güvenlik duvarının diğer tarafındaki biri açık internete ulaşabiliyor.\n\nBilgi güçtür ve bu güç, onu bizden almak isteyenlere değil, bize aittir.',
+  aboutSupportHeader: 'Bize destek olun',
+  donateTitle: 'Bağış yap',
+  donateSubtitle:
+    'Merdivenin ayakta kalmasına yardım edin. Bağışlar OpenRung Vakfı’na gider.',
   aboutLegalHeader: 'Yasal',
   aboutFollowHeader: 'Bizi takip edin',
-
 
   // --- Split tunneling (settings row + screen + Android app picker) ---
   splitTunnelSettingTitle: 'Bölünmüş tünel',
@@ -144,14 +151,16 @@ export const tr: Partial<Strings> = {
   splitTunnelChinaSubtitle: 'Çin servislerini doğrudan, tam hızda yönlendirin.',
   splitTunnelAppsHeader: 'Uygulamalar',
   splitTunnelAppsTitle: 'Baypas edilen uygulamalar',
-  splitTunnelAppsSubtitle: (count: number) => `${count} uygulama VPN'i atlıyor.`,
+  splitTunnelAppsSubtitle: (count: number) =>
+    `${count} uygulama VPN'i atlıyor.`,
   splitTunnelAppPickerTitle: 'Baypas edilen uygulamalar',
   splitTunnelAppPickerLoading: 'yüklü uygulamalar getiriliyor…',
   splitTunnelAppPickerEmpty: 'başlatılabilir uygulama bulunamadı.',
   splitTunnelAppPickerClose: 'KAPAT',
   splitTunnelApplyHint:
     'değişiklikler hemen uygulanır; tünel birkaç saniyeliğine yeniden bağlanır.',
-  splitTunnelResetHint: 'uygulamayı yeniden başlattığınızda İran ve Çin ön ayarları sıfırlanır.',
+  splitTunnelResetHint:
+    'uygulamayı yeniden başlattığınızda İran ve Çin ön ayarları sıfırlanır.',
   splitTunnelResetHintWithApps:
     'uygulamayı yeniden başlattığınızda İran ve Çin ön ayarları sıfırlanır; hariç tutulan uygulamalar korunur.',
 
@@ -159,7 +168,8 @@ export const tr: Partial<Strings> = {
   updateRequiredTitle: 'Güncelleme gerekli',
   updateRequiredBody:
     "OpenRung'un bu sürümü artık röle ağına bağlanamıyor. Devam edebilmek için en son sürümü yükleyin.",
-  updateVersionTransition: (current: string, latest: string) => `v${current} -> v${latest}`,
+  updateVersionTransition: (current: string, latest: string) =>
+    `v${current} -> v${latest}`,
   updateActionNow: 'GÜNCELLE',
   updateActionLater: 'Daha sonra',
   updateContinueAnyway: 'Yine de devam et',

--- a/src/i18n/strings/vi.ts
+++ b/src/i18n/strings/vi.ts
@@ -16,7 +16,8 @@ export const vi: Partial<Strings> = {
   settingsTitle: 'Cài đặt',
   backContentDescription: 'Quay lại',
   languageSettingTitle: 'Ngôn ngữ',
-  languageSettingSubtitle: 'Dùng ngôn ngữ hệ thống hoặc chọn ngôn ngữ cho OpenRung.',
+  languageSettingSubtitle:
+    'Dùng ngôn ngữ hệ thống hoặc chọn ngôn ngữ cho OpenRung.',
   versionSettingTitle: 'Phiên bản',
   languageSystem: 'Mặc định hệ thống',
   languageEnglish: 'English',
@@ -59,10 +60,13 @@ export const vi: Partial<Strings> = {
 
   // Relay speed test (diagnostics).
   speedTestSettingTitle: 'Kiểm tra tốc độ relay',
-  speedTestReady: 'Tải xuống 10 MB qua relay đang hoạt động và báo cáo kết quả.',
-  speedTestRequiresConnection: 'Kết nối với relay trước khi chạy kiểm tra tốc độ.',
+  speedTestReady:
+    'Tải xuống 10 MB qua relay đang hoạt động và báo cáo kết quả.',
+  speedTestRequiresConnection:
+    'Kết nối với relay trước khi chạy kiểm tra tốc độ.',
   speedTestRunning: 'Đang kiểm tra tốc độ tải xuống qua relay…',
-  speedTestResult: (mbps: number) => `Tốc độ tải xuống: ${mbps.toFixed(1)} Mbps`,
+  speedTestResult: (mbps: number) =>
+    `Tốc độ tải xuống: ${mbps.toFixed(1)} Mbps`,
   speedTestError: (error: string) => `Kiểm tra tốc độ thất bại: ${error}`,
   speedTestAction: 'CHẠY',
 
@@ -78,7 +82,8 @@ export const vi: Partial<Strings> = {
   viewToggleMap: 'Bản đồ',
   viewToggleList: 'Danh sách',
   listContentDescription: 'Danh sách các nút thoát khả dụng',
-  listRelayCount: (count: number) => (count === 1 ? '1 relay' : `${count} relay`),
+  listRelayCount: (count: number) =>
+    count === 1 ? '1 relay' : `${count} relay`,
 
   // Debug console (diagnostics).
   debugSettingTitle: 'Gỡ lỗi',
@@ -116,9 +121,14 @@ export const vi: Partial<Strings> = {
 
   // Home overlay and about screen.
   homeTagline: 'mạng lưới relay',
-  aboutMissionLead: 'Chúng tôi tin rằng truy cập internet là một quyền, không phải đặc ân',
+  aboutMissionLead:
+    'Chúng tôi tin rằng truy cập internet là một quyền, không phải đặc ân',
   aboutMissionBody:
     'và không phải quân bài mặc cả để những người nắm quyền đem ra trao đổi. Quyền tiếp cận thông tin nằm trong chính bản chất con người, và không tường lửa nào được phép xóa bỏ quyền đó. Thế nhưng ngày nay, hàng tỷ người sống sau những bức tường được dựng lên để ngăn thông tin đi vào và giữ sự im lặng ở lại; nơi một tìm kiếm Google trả về lỗi 404, một câu hỏi có thể trở nên nguy hiểm và sự tò mò kết thúc tại một trang bị chặn.\n\nOpenRung tồn tại để thay đổi điều đó.\n\nChúng tôi đang dựng một chiếc thang vượt qua những bức tường ấy. Những người bình thường trên khắp thế giới chia sẻ kết nối của họ để ai đó ở phía bên kia tường lửa có thể tiếp cận internet mở.\n\nThông tin là sức mạnh, và sức mạnh đó thuộc về chúng ta, không thuộc về những kẻ muốn lấy nó khỏi tay chúng ta.',
+  aboutSupportHeader: 'Ủng hộ chúng tôi',
+  donateTitle: 'Quyên góp',
+  donateSubtitle:
+    'Giúp chiếc thang luôn đứng vững. Các khoản quyên góp được chuyển đến OpenRung Foundation.',
   aboutLegalHeader: 'Pháp lý',
   aboutFollowHeader: 'Theo dõi chúng tôi',
 
@@ -128,26 +138,30 @@ export const vi: Partial<Strings> = {
   splitTunnelSettingSubtitleOff: 'Tắt — toàn bộ lưu lượng đi qua relay.',
   splitTunnelHeader: 'Chia đường hầm',
   splitTunnelMasterTitle: 'Chia đường hầm',
-  splitTunnelMasterSubtitle: 'Gửi lưu lượng được chọn ra ngoài đường hầm relay.',
+  splitTunnelMasterSubtitle:
+    'Gửi lưu lượng được chọn ra ngoài đường hầm relay.',
   splitTunnelBypassHeader: 'Đi vòng',
   splitTunnelLanTitle: 'Mạng cục bộ',
   splitTunnelLanSubtitle:
     'Truy cập trực tiếp máy in, TV và các thiết bị mạng cục bộ khác.',
   splitTunnelIranTitle: 'Trang web & ứng dụng Iran',
-  splitTunnelIranSubtitle: 'Định tuyến trực tiếp các dịch vụ Iran với tốc độ tối đa.',
+  splitTunnelIranSubtitle:
+    'Định tuyến trực tiếp các dịch vụ Iran với tốc độ tối đa.',
   splitTunnelChinaTitle: 'Trang web & ứng dụng Trung Quốc',
   splitTunnelChinaSubtitle:
     'Định tuyến trực tiếp các dịch vụ Trung Quốc với tốc độ tối đa.',
   splitTunnelAppsHeader: 'Ứng dụng',
   splitTunnelAppsTitle: 'Ứng dụng đi vòng',
-  splitTunnelAppsSubtitle: (count: number) => `${count} ứng dụng không đi qua VPN.`,
+  splitTunnelAppsSubtitle: (count: number) =>
+    `${count} ứng dụng không đi qua VPN.`,
   splitTunnelAppPickerTitle: 'Ứng dụng đi vòng',
   splitTunnelAppPickerLoading: 'đang tải các ứng dụng đã cài…',
   splitTunnelAppPickerEmpty: 'không tìm thấy ứng dụng khởi chạy được.',
   splitTunnelAppPickerClose: 'ĐÓNG',
   splitTunnelApplyHint:
     'thay đổi áp dụng ngay; đường hầm sẽ kết nối lại trong vài giây.',
-  splitTunnelResetHint: 'các thiết lập sẵn cho Iran và Trung Quốc sẽ đặt lại khi bạn mở lại ứng dụng.',
+  splitTunnelResetHint:
+    'các thiết lập sẵn cho Iran và Trung Quốc sẽ đặt lại khi bạn mở lại ứng dụng.',
   splitTunnelResetHintWithApps:
     'các thiết lập sẵn cho Iran và Trung Quốc sẽ đặt lại khi bạn mở lại ứng dụng; các ứng dụng được bỏ qua vẫn được giữ.',
 
@@ -155,7 +169,8 @@ export const vi: Partial<Strings> = {
   updateRequiredTitle: 'Cần cập nhật',
   updateRequiredBody:
     'Phiên bản OpenRung này không còn kết nối được với mạng lưới relay. Hãy cài bản mới nhất để tiếp tục sử dụng.',
-  updateVersionTransition: (current: string, latest: string) => `v${current} -> v${latest}`,
+  updateVersionTransition: (current: string, latest: string) =>
+    `v${current} -> v${latest}`,
   updateActionNow: 'CẬP NHẬT',
   updateActionLater: 'Để sau',
   updateContinueAnyway: 'Vẫn tiếp tục',

--- a/src/i18n/strings/zh-CN.ts
+++ b/src/i18n/strings/zh-CN.ts
@@ -83,7 +83,8 @@ export const zhCN: Partial<Strings> = {
 
   // List view (relay exit nodes).
   listContentDescription: '可用出口节点列表',
-  listRelayCount: (count: number) => (count === 1 ? '1 个中继' : `${count} 个中继`),
+  listRelayCount: (count: number) =>
+    count === 1 ? '1 个中继' : `${count} 个中继`,
 
   // Debug console (diagnostics).
   debugSettingTitle: '调试',
@@ -119,6 +120,9 @@ export const zhCN: Partial<Strings> = {
   aboutMissionLead: '我们相信，互联网接入是一项权利，而不是特权',
   aboutMissionBody:
     '更不应成为掌权者用来交易的筹码。获取信息的权利根植于我们作为人的本质之中，任何防火墙都不应抹去它。然而今天，数十亿人生活在高墙之后；这些墙把信息挡在外面，把沉默困在里面。在那里，Google 搜索只返回 404，提出问题可能带来危险，好奇心止步于被屏蔽的页面。\n\nOpenRung 的存在就是为了改变这一切。\n\n我们正在搭建一架越过高墙的梯子。世界各地的普通人分享自己的网络连接，让防火墙另一边的人能够访问开放的互联网。\n\n信息就是力量，这份力量属于我们，而不属于那些企图从我们手中夺走它的人。',
+  aboutSupportHeader: '支持我们',
+  donateTitle: '捐助',
+  donateSubtitle: '帮助这架梯子继续矗立。捐款将用于 OpenRung 基金会。',
   aboutLegalHeader: '法律信息',
   aboutFollowHeader: '关注我们',
 
@@ -152,7 +156,8 @@ export const zhCN: Partial<Strings> = {
   updateRequiredTitle: '需要更新',
   updateRequiredBody:
     '当前版本的 OpenRung 已无法连接中继网络。请安装最新版本以继续使用。',
-  updateVersionTransition: (current: string, latest: string) => `v${current} -> v${latest}`,
+  updateVersionTransition: (current: string, latest: string) =>
+    `v${current} -> v${latest}`,
   updateActionNow: '立即更新',
   updateActionLater: '稍后',
   updateContinueAnyway: '仍然继续',

--- a/src/i18n/strings/zh-TW.ts
+++ b/src/i18n/strings/zh-TW.ts
@@ -75,7 +75,8 @@ export const zhTW: Partial<Strings> = {
   viewToggleMap: '地圖',
   viewToggleList: '清單',
   listContentDescription: '可用出口節點的清單',
-  listRelayCount: (count: number) => (count === 1 ? '1 個中繼' : `${count} 個中繼`),
+  listRelayCount: (count: number) =>
+    count === 1 ? '1 個中繼' : `${count} 個中繼`,
 
   // Debug console.
   debugSettingTitle: '除錯',
@@ -111,6 +112,9 @@ export const zhTW: Partial<Strings> = {
   aboutMissionLead: '我們相信，網際網路存取是一項權利，而不是特權',
   aboutMissionBody:
     '更不應成為掌權者用來交易的籌碼。取得資訊的權利根植於我們身而為人的本質之中，任何防火牆都不應抹去它。然而今天，數十億人生活在高牆之後；這些牆把資訊擋在外面，把沉默困在裡面。在那裡，Google 搜尋只回傳 404，提出問題可能帶來危險，好奇心止步於遭封鎖的頁面。\n\nOpenRung 的存在就是為了改變這一切。\n\n我們正在搭建一架越過高牆的梯子。世界各地的普通人分享自己的網路連線，讓防火牆另一邊的人能夠存取開放的網際網路。\n\n資訊就是力量，這份力量屬於我們，而不屬於那些企圖從我們手中奪走它的人。',
+  aboutSupportHeader: '支持我們',
+  donateTitle: '捐款',
+  donateSubtitle: '幫助這座梯子繼續屹立。捐款將用於 OpenRung 基金會。',
   aboutLegalHeader: '法律資訊',
   aboutFollowHeader: '關注我們',
 
@@ -144,7 +148,8 @@ export const zhTW: Partial<Strings> = {
   updateRequiredTitle: '需要更新',
   updateRequiredBody:
     '此版本的 OpenRung 已無法連線至中繼網路。請安裝最新版本以繼續使用。',
-  updateVersionTransition: (current: string, latest: string) => `v${current} -> v${latest}`,
+  updateVersionTransition: (current: string, latest: string) =>
+    `v${current} -> v${latest}`,
   updateActionNow: '更新',
   updateActionLater: '稍後',
   updateContinueAnyway: '仍要繼續',

--- a/src/screens/AboutScreen.tsx
+++ b/src/screens/AboutScreen.tsx
@@ -5,7 +5,14 @@
  * stays purely operational.
  */
 import React, { useCallback } from 'react';
-import { Linking, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import {
+  Linking,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { SettingPanel } from '../components/SettingPanel';
@@ -39,7 +46,12 @@ const SOCIAL_LINKS = [
     color: palette.bodyText,
     Icon: GitHubIcon,
   },
-  { label: 'OpenRung on X', url: AppConfig.X_URL, color: palette.bodyText, Icon: XIcon },
+  {
+    label: 'OpenRung on X',
+    url: AppConfig.X_URL,
+    color: palette.bodyText,
+    Icon: XIcon,
+  },
   {
     label: 'OpenRung on Threads',
     url: AppConfig.THREADS_URL,
@@ -66,9 +78,17 @@ const SOCIAL_LINKS = [
   },
 ] as const;
 
-export function AboutScreen({ onOpenLicenses }: AboutScreenProps): React.JSX.Element {
+export function AboutScreen({
+  onOpenLicenses,
+}: AboutScreenProps): React.JSX.Element {
   const s = useStrings();
   const insets = useSafeAreaInsets();
+
+  const onOpenDonate = useCallback(() => {
+    Linking.openURL(AppConfig.DONATE_URL).catch(() => {
+      // Ignore: no browser available.
+    });
+  }, []);
 
   const onOpenPrivacy = useCallback(() => {
     Linking.openURL(AppConfig.PRIVACY_URL).catch(() => {
@@ -107,7 +127,29 @@ export function AboutScreen({ onOpenLicenses }: AboutScreenProps): React.JSX.Ele
         <Text style={styles.mission}>{s.aboutMissionBody}</Text>
       </View>
 
-      <Text style={styles.sectionHeader}>{s.aboutLegalHeader.toUpperCase()}</Text>
+      <Text style={styles.sectionHeader}>
+        {s.aboutSupportHeader.toUpperCase()}
+      </Text>
+      <Pressable
+        accessibilityRole="link"
+        accessibilityLabel={s.donateTitle}
+        onPress={onOpenDonate}
+        style={({ pressed }) => [
+          styles.donateButton,
+          pressed && styles.donateButtonPressed,
+        ]}
+      >
+        <Text style={styles.donateHeart}>♥</Text>
+        <View style={styles.donateTextColumn}>
+          <Text style={styles.donateTitle}>{s.donateTitle}</Text>
+          <Text style={styles.donateSubtitle}>{s.donateSubtitle}</Text>
+        </View>
+        <Text style={styles.donateChevron}>›</Text>
+      </Pressable>
+
+      <Text style={styles.sectionHeader}>
+        {s.aboutLegalHeader.toUpperCase()}
+      </Text>
       <SettingPanel
         title={s.privacyPolicyTitle}
         subtitle={s.privacyPolicySubtitle}
@@ -119,7 +161,9 @@ export function AboutScreen({ onOpenLicenses }: AboutScreenProps): React.JSX.Ele
         onPress={onOpenLicenses}
       />
 
-      <Text style={styles.sectionHeader}>{s.aboutFollowHeader.toUpperCase()}</Text>
+      <Text style={styles.sectionHeader}>
+        {s.aboutFollowHeader.toUpperCase()}
+      </Text>
       <View style={styles.socialRow}>
         {SOCIAL_LINKS.map(({ label, url, color, Icon }) => (
           <Pressable
@@ -128,7 +172,10 @@ export function AboutScreen({ onOpenLicenses }: AboutScreenProps): React.JSX.Ele
             accessibilityLabel={label}
             hitSlop={6}
             onPress={() => onOpenSocial(url)}
-            style={({ pressed }) => [styles.socialButton, pressed && styles.socialButtonPressed]}
+            style={({ pressed }) => [
+              styles.socialButton,
+              pressed && styles.socialButtonPressed,
+            ]}
           >
             <Icon color={color} size={20} />
           </Pressable>
@@ -208,6 +255,56 @@ const styles = StyleSheet.create({
     fontFamily: monoFont,
     fontSize: 12,
     lineHeight: 18,
+  },
+  // Deliberately louder than SettingPanel rows: terminal-green border + glow
+  // and a tinted fill so the donate call-to-action stands out from Legal.
+  donateButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    borderRadius: 8,
+    backgroundColor: palette.fabBackground,
+    borderWidth: 1,
+    borderColor: palette.terminalGreen,
+    padding: 14,
+    shadowColor: tokens.glow,
+    shadowOpacity: 1,
+    shadowRadius: 12,
+    shadowOffset: { width: 0, height: 0 },
+    elevation: 6,
+  },
+  donateButtonPressed: {
+    opacity: 0.7,
+  },
+  donateHeart: {
+    color: palette.terminalGreen,
+    fontSize: 20,
+    textShadowColor: tokens.glow,
+    textShadowRadius: 10,
+  },
+  donateTextColumn: {
+    flex: 1,
+    gap: 2,
+  },
+  donateTitle: {
+    color: palette.terminalGreen,
+    fontFamily: monoFont,
+    fontWeight: 'bold',
+    fontSize: 15,
+    textShadowColor: tokens.glowSoft,
+    textShadowRadius: 8,
+  },
+  donateSubtitle: {
+    color: palette.bodyText,
+    fontFamily: monoFont,
+    fontSize: 12,
+    lineHeight: 17,
+  },
+  donateChevron: {
+    color: palette.terminalGreen,
+    fontFamily: monoFont,
+    fontSize: 20,
+    fontWeight: 'bold',
   },
   sectionHeader: {
     color: palette.dimText,


### PR DESCRIPTION
## What

Adds a "Support us" section to the About us tab — between the mission hero box and the Legal section — with a high-emphasis **Donate** button that opens the OpenRung Foundation's Every.org donation page (`https://www.every.org/openrung-foundation?code=af922628#/donate`) in the system browser.

## Why

Give users a visible way to support the project financially. The `code` query param attributes donations to the mobile app.

## Details

- The button is deliberately louder than the surrounding `SettingPanel` rows to draw attention: terminal-green border with a soft neon glow, glowing heart icon, green bold title, tinted fill — still within the app's terminal aesthetic.
- Opens via `Linking.openURL`, the same pattern as the privacy-policy and social links (an in-app webview was prototyped and dropped in favor of the default browser, so no new native dependency).
- Strings localized across all nine languages (en, fa, ar, tr, ru, vi, my, zh-CN, zh-TW).
- URL lives in `AppConfig.DONATE_URL`.

## Testing

- `tsc`, ESLint, Prettier, and all 280 Jest tests pass.
- Verified on the iPhone 17 simulator: section renders in the right spot, tapping the button opens Safari with the Every.org donate flow loaded.

## Reviewer note

For users in-region with the VPN off, every.org may be unreachable; if in-region donations matter later, a mirrored/relay-routed fallback could be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)