### PR TITLE
App size: stub libbox NativeShellSession to unlink Tailscale (~12 MB per binary)

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -150,6 +150,17 @@ those literals fails the build and forces the tag set to be re-reviewed. The tag
 set now materially defines the shipped binary, so it is part of the GPL
 corresponding-source recipe and must stay recorded here.
 
+The tag trim alone does not unlink `tailscale.com`: libbox's
+`native_shell_session.go` is gated only by OS and imports
+`protocol/tailscale/tailssh`, whose files build under `with_gvisor` (not
+`with_tailscale`), so the kept `with_gvisor` tag re-links the entire Tailscale
+module (~12 MB per binary). Both build scripts therefore also swap the build
+tags on `experimental/libbox/native_shell_session{,_stub}.go` so the stub
+(which reports "not supported") always compiles and the `tailssh` importer
+never does. OpenRung has no `NativeShellSession` callers. Same
+assert-then-replace tripwire; this swap is likewise part of the recorded
+corresponding-source recipe.
+
 The Android build targets all four ABIs at the **AAR** layer but ships an
 **arm64-only release APK** — two artifacts, two distinct checks:
 

--- a/android/build-libbox-release.sh
+++ b/android/build-libbox-release.sh
@@ -179,6 +179,55 @@ print(
 PATCH_TAGS
 # ---------------------------------------------------------------------------
 
+# --- OpenRung app-size trim (part 2): unlink the Tailscale closure -----------
+# The tag trim above is not enough to drop tailscale.com from the binary:
+# libbox's native_shell_session.go is gated only by OS (linux||android||darwin
+# ||ios) and imports protocol/tailscale/tailssh, whose files build under
+# with_gvisor — NOT with_tailscale. Keeping with_gvisor therefore re-links the
+# entire Tailscale module (magicsock, DERP, gliderssh, embedded wireguard-go),
+# measured ~12 MB per binary. OpenRung never exposes NativeShellSession (no
+# Kotlin/Swift callers), and sing-box already ships a stub
+# (native_shell_session_stub.go) whose methods report "not supported". Swap the
+# two files' build tags so the stub always compiles and the tailssh importer
+# never does — the datapath tags (with_gvisor, with_quic) stay untouched.
+# Assert-then-replace, same tripwire contract as the tag patch above.
+python3 - "$work_dir/source/experimental/libbox" <<'PATCH_SHELL_SESSION'
+import os
+import sys
+
+root = sys.argv[1]
+swaps = [
+    (
+        "native_shell_session.go",
+        "//go:build linux || android || darwin || ios",
+        "//go:build openrung_never",
+    ),
+    (
+        "native_shell_session_stub.go",
+        "//go:build !linux && !android && !darwin && !ios",
+        "//go:build !openrung_never",
+    ),
+]
+for name, old, new in swaps:
+    path = os.path.join(root, name)
+    with open(path, "r", encoding="utf-8") as handle:
+        text = handle.read()
+    if old + "\n" not in text:
+        sys.exit(
+            "error: %s build tag changed for this SINGBOX_VERSION; re-review "
+            "OpenRung's Tailscale shell-session stub swap.\nexpected: %s"
+            % (name, old)
+        )
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(text.replace(old + "\n", new + "\n", 1))
+
+print(
+    "openrung: stubbed libbox native shell session "
+    "(unlinks tailscale.com/tailssh from the with_gvisor build)"
+)
+PATCH_SHELL_SESSION
+# ---------------------------------------------------------------------------
+
 # gomobile applications must use a single generated Go runtime. A standalone
 # punchbridge.aar would duplicate go.Seq/go.Universe and its native runtime next
 # to libbox.aar, so merge the bindings (and the sagernet-QUIC session layer)

--- a/ios/build-libbox-release.sh
+++ b/ios/build-libbox-release.sh
@@ -188,6 +188,55 @@ print(
 PATCH_TAGS
 # ---------------------------------------------------------------------------
 
+# --- OpenRung app-size trim (part 2): unlink the Tailscale closure -----------
+# The tag trim above is not enough to drop tailscale.com from the binary:
+# libbox's native_shell_session.go is gated only by OS (linux||android||darwin
+# ||ios) and imports protocol/tailscale/tailssh, whose files build under
+# with_gvisor — NOT with_tailscale. Keeping with_gvisor therefore re-links the
+# entire Tailscale module (magicsock, DERP, gliderssh, embedded wireguard-go),
+# measured ~12 MB per binary. OpenRung never exposes NativeShellSession (no
+# Kotlin/Swift callers), and sing-box already ships a stub
+# (native_shell_session_stub.go) whose methods report "not supported". Swap the
+# two files' build tags so the stub always compiles and the tailssh importer
+# never does — the datapath tags (with_gvisor, with_quic) stay untouched.
+# Assert-then-replace, same tripwire contract as the tag patch above.
+python3 - "$work_dir/source/experimental/libbox" <<'PATCH_SHELL_SESSION'
+import os
+import sys
+
+root = sys.argv[1]
+swaps = [
+    (
+        "native_shell_session.go",
+        "//go:build linux || android || darwin || ios",
+        "//go:build openrung_never",
+    ),
+    (
+        "native_shell_session_stub.go",
+        "//go:build !linux && !android && !darwin && !ios",
+        "//go:build !openrung_never",
+    ),
+]
+for name, old, new in swaps:
+    path = os.path.join(root, name)
+    with open(path, "r", encoding="utf-8") as handle:
+        text = handle.read()
+    if old + "\n" not in text:
+        sys.exit(
+            "error: %s build tag changed for this SINGBOX_VERSION; re-review "
+            "OpenRung's Tailscale shell-session stub swap.\nexpected: %s"
+            % (name, old)
+        )
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(text.replace(old + "\n", new + "\n", 1))
+
+print(
+    "openrung: stubbed libbox native shell session "
+    "(unlinks tailscale.com/tailssh from the with_gvisor build)"
+)
+PATCH_SHELL_SESSION
+# ---------------------------------------------------------------------------
+
 # The gomobile-generated Objective-C APIs, native transports, and sing-box
 # engine must share libbox's Go runtime. A standalone punch framework would
 # duplicate go.Seq/go.Universe and the native Go runtime. Only the thin bindings


### PR DESCRIPTION
## Problem

The #61 libbox tag trim dropped `with_tailscale`, but the shipped binaries **still contain the entire Tailscale stack** — magicsock, DERP, gliderssh, and an embedded copy of wireguard-go (that's where the residual "wireguard" strings come from). Verified by string analysis of the shipped v0.3.7 `libbox.so` (1161 `tailscale.com/derp|magicsock` hits).

Leak path in the pinned sing-box source:

- `experimental/libbox/native_shell_session.go` is gated only by OS (`linux || android || darwin || ios`) and imports `protocol/tailscale/tailssh`
- `tailssh`'s files are gated on **`with_gvisor`**, not `with_tailscale` — so keeping `with_gvisor` silently re-links the whole module

## Fix

Both `build-libbox-release.sh` scripts gain a second assert-then-replace patch step (same tripwire contract as the existing `PATCH_TAGS` block): swap the build tags on `native_shell_session.go` (→ `openrung_never`) and `native_shell_session_stub.go` (→ `!openrung_never`) so the stub — which sing-box already ships, with the same exported API reporting "not supported" — always compiles and the `tailssh` importer never does.

- OpenRung has no `NativeShellSession` callers anywhere in Kotlin or Swift
- The datapath tags (`with_gvisor`, `with_quic`) are untouched — this does not repeat the previously reverted gvisor/quic experiment
- RELEASE.md's corresponding-source recipe updated (the swap materially defines the shipped binary)

## Measured

linux/arm64 probe binary importing `experimental/libbox` + `include` with the exact shipping tag set, built from the pinned `SINGBOX_VERSION` source with and without the swap:

| build | size | magicsock strings |
|---|---|---|
| shipping tags | 36.8 MB | present |
| shipping tags + this swap | 24.9 MB (**−11.9 MB**) | 0 |

Projected: release APK ~88 → ~76 MB; iOS `.app` ~124 → ~100 MB (the Go blob is statically linked into both the main app and PacketTunnel.appex, so the saving lands twice).

## Verification

- `bash -n` passes on both scripts (what android-punch-check runs)
- The new patch block was executed against a fresh copy of the pinned source: asserts hold, tags swapped as intended
- A probe build against a source tree patched exactly this way compiles cleanly with the shipping tags and links no tailscale code
- Not run here: a full gomobile AAR/xcframework build (CI's cache key includes the build scripts, so the release pipeline rebuilds from scratch); the usual on-device connect smoke test before shipping still applies

🤖 Generated with [Claude Code](https://claude.com/claude-code)