### PR TITLE
Vendor the cross-repo contract vectors and run them against the Kotlin, Swift, and TypeScript clients

### DIFF
--- a/.github/workflows/android-unit-test.yml
+++ b/.github/workflows/android-unit-test.yml
@@ -8,6 +8,7 @@ on:
       - 'package-lock.json'
       - 'react-native.config.js'
       - 'SINGBOX_VERSION'
+      - 'testdata/contract/**'
       - '.github/workflows/android-unit-test.yml'
   push:
     branches: [main]
@@ -17,6 +18,7 @@ on:
       - 'package-lock.json'
       - 'react-native.config.js'
       - 'SINGBOX_VERSION'
+      - 'testdata/contract/**'
       - '.github/workflows/android-unit-test.yml'
   workflow_dispatch:
 

--- a/.github/workflows/javascript-quality.yml
+++ b/.github/workflows/javascript-quality.yml
@@ -22,6 +22,11 @@ jobs:
       - run: npm ci
       - name: Guard native broker transports
         run: npm run transport:check
+      # Compares the vendored contract vectors against the pinned openrung ref. Needs network:
+      # a copy that has silently drifted from upstream is the failure this guards, so an
+      # unreachable upstream fails rather than passing.
+      - name: Check vendored contract vectors
+        run: npm run contract:check
       - name: Run ESLint
         run: npm run lint
 

--- a/README.md
+++ b/README.md
@@ -155,8 +155,36 @@ android/             RN Android app + ported VPN service and bridge.
   punchbridge/       Go gomobile adapters over pinned brokerapi, punchcore, and
                      wsscore modules, injected into the generated libbox AAR.
 ios/                 RN iOS app + PacketTunnel extension (xcodegen).
+testdata/contract/   Contract vectors vendored from openrung/openrung, with the
+                     pinned ref in pin.json. See "Contract vectors" below.
 docs/                CONTRACT.md (binding), ARCHITECTURE.md (overview).
 ```
+
+### Contract vectors
+
+`testdata/contract/` holds golden vectors that four suites across two repos run
+against the same expectations: the failure-classification token set, the
+relay-directory decode, and the broker-front list. They are **copies** —
+`contract/vectors/` in `openrung/openrung` is the only source of truth, and
+`pin.json` records the ref they came from plus a digest per file.
+
+```bash
+npm run contract:check   # local digests + byte-identical to the pinned ref
+npm run contract:sync    # re-vendor from the pinned ref after moving it
+```
+
+Fix a vector upstream, then move the ref and re-sync here; editing a vendored
+copy in place makes `contract:check` fail. The check runs in CI and needs
+network on purpose: a copy that has quietly drifted from upstream is exactly
+what it exists to catch, so an unreachable upstream fails rather than passing.
+
+The suites that consume them are `__tests__/contract/` (Jest),
+`ContractClassificationVectorsTest` / `ContractBrokerFrontsTest` (Android unit
+tests, run by `android-unit-test.yml`), and `ContractClassificationVectorsTests`
+/ `ContractBrokerFrontsTests` (XCTest, run locally — there is no iOS CI job).
+Each file's `suites` field says which suites the contract expects; `pin.json`
+records which of those this repo runs today and, for any it does not yet, the
+reason. `contract:check` fails on a declared consumer that is neither.
 
 ## Building
 

--- a/__tests__/contract/brokerFrontVectors.test.ts
+++ b/__tests__/contract/brokerFrontVectors.test.ts
@@ -1,0 +1,53 @@
+/**
+ * The TypeScript half of the shared broker-front snapshot.
+ *
+ * This repo owns no racing: it hands native brokerapi a single primary and Go races the built-in
+ * candidates, so the phases and the candidate ordering in the vectors are the Go suite's to assert
+ * and deliberately not checked here. What is checked is the claim this side can actually make —
+ * that every front this app hardcodes still appears in the canonical list — which is what catches
+ * a front rotated in openrung and not here, the case where a blocked user quietly loses a
+ * fallback.
+ */
+import vectors from '../../testdata/contract/broker_fronts.json';
+import { AppConfig } from '../../src/config';
+
+const EXPECTED_VERSION = 1;
+const SUITE = 'ts';
+
+describe('broker front contract vectors', () => {
+  it('runs the version and the suite it was written for', () => {
+    expect(vectors.version).toBe(EXPECTED_VERSION);
+    expect(vectors.suites).toContain(SUITE);
+  });
+
+  it('configures a primary that is one of the canonical fronts', () => {
+    expect(vectors.default_order).toContain(AppConfig.DEFAULT_BROKER_URL);
+  });
+
+  it('posts telemetry to a canonical front', () => {
+    // A telemetry target off the canonical list would send the pre-VPN IP and the stable client id
+    // somewhere the directory contract never vouched for.
+    expect(vectors.default_order).toContain(AppConfig.TELEMETRY_BROKER_URL);
+  });
+
+  it('keeps the canonical list non-empty and free of duplicates', () => {
+    expect(vectors.default_order.length).toBeGreaterThan(0);
+    expect(new Set(vectors.default_order).size).toBe(vectors.default_order.length);
+  });
+
+  it('leaves the phase ordering to the suite that implements it', () => {
+    // Guard against this suite growing assertions it cannot honestly make: the phases describe
+    // brokerapi's race, which no TypeScript here performs.
+    const phased = vectors.phases.flatMap(phase => phase.urls);
+    expect([...phased].sort()).toEqual([...vectors.default_order].sort());
+  });
+
+  it('does not confuse the directory fronts with the update-manifest channel', () => {
+    // Separate channel with its own candidate list and its own check (npm run transport:check).
+    // Conflating them would let a manifest-only host look like an approved directory front.
+    const manifestOnly = AppConfig.UPDATE_MANIFEST_URLS.filter(
+      url => !vectors.default_order.some(front => url.startsWith(front)),
+    );
+    expect(manifestOnly.length).toBeGreaterThan(0);
+  });
+});

--- a/__tests__/contract/relayDecodeVectors.test.ts
+++ b/__tests__/contract/relayDecodeVectors.test.ts
@@ -1,0 +1,121 @@
+/**
+ * The TypeScript half of the shared relay-decode contract.
+ *
+ * The rows come from testdata/contract/relay_decode.json, vendored from openrung/openrung and
+ * checked against the pinned ref by `npm run contract:check`. The same rows run against Go's
+ * decoder and selector in that repo, so a divergence here is a real disagreement between two
+ * clients about which relays a user can reach — not a stale local fixture.
+ */
+import vectors from '../../testdata/contract/relay_decode.json';
+import {
+  effectiveNodeClass,
+  isUsable,
+  orderedCandidates,
+  selectFirstUsable,
+  serverTimeMs,
+} from '../../src/model/relay';
+import type { RelayDescriptor, RelayListResponse } from '../../src/model/relay';
+
+/** The version this suite was written against; bumping the file means revisiting these tests. */
+const EXPECTED_VERSION = 2;
+
+/** This suite's identifier in the file's `suites` declaration. */
+const SUITE = 'ts';
+
+type VectorCase = (typeof vectors)['cases'][number];
+
+function response(testCase: VectorCase): RelayListResponse {
+  return testCase.body as unknown as RelayListResponse;
+}
+
+describe('relay decode contract vectors', () => {
+  it('runs the version and the suite it was written for', () => {
+    expect(vectors.version).toBe(EXPECTED_VERSION);
+    expect(vectors.suites).toContain(SUITE);
+  });
+
+  it('covers every case in the file', () => {
+    // Guards the failure mode the vectors exist to prevent: a suite that iterates the rows,
+    // asserts nothing, and reports green. If a case is added upstream, this count moves and the
+    // suite has to be looked at rather than silently skipping it.
+    expect(vectors.cases.map(testCase => testCase.id)).toEqual([
+      'api_two_relays',
+      'unusable_mix',
+      'forward_compatible',
+    ]);
+  });
+
+  describe.each(vectors.cases.map(testCase => [testCase.id, testCase] as const))(
+    '%s',
+    (_id, testCase) => {
+      const decoded = response(testCase);
+
+      it('decodes the signed envelope', () => {
+        const expected = testCase.expect;
+        expect(decoded.count).toBe(expected.count);
+        expect(decoded.server_time).toBe(expected.server_time);
+        expect(decoded.not_after).toBe(expected.not_after);
+        expect(decoded.key_id).toBe(expected.key_id);
+        expect(decoded.channel).toBe(expected.channel);
+        expect(decoded.limit).toBe(expected.limit);
+        // serverTimeMs must parse what the broker actually sends.
+        expect(serverTimeMs(decoded)).toBe(Date.parse(expected.server_time));
+      });
+
+      it('decodes each descriptor', () => {
+        const expected = testCase.expect as {
+          relays?: Record<string, unknown>[];
+          relay_ids?: string[];
+        };
+
+        if (expected.relay_ids) {
+          // Broker order is preserved: the filter is score-free and never reorders.
+          expect(decoded.relays.map(relay => relay.id)).toEqual(expected.relay_ids);
+          return;
+        }
+
+        expect(decoded.relays).toHaveLength(expected.relays!.length);
+        expected.relays!.forEach((want, index) => {
+          const relay = decoded.relays[index] as unknown as Record<string, unknown>;
+          for (const [field, value] of Object.entries(want)) {
+            if (field === 'effective_node_class') {
+              expect(effectiveNodeClass(relay.node_class as string | undefined)).toBe(value);
+              continue;
+            }
+            // Fields this model does not carry are another suite's to assert; `relay_version` is
+            // the canonical name, and the TypeScript model exposes only the legacy wire name.
+            if (field === 'relay_version') {
+              continue;
+            }
+            if (value === null) {
+              // null means "absent on the wire"; TypeScript's no-value representation is undefined.
+              expect(relay[field]).toBeUndefined();
+              continue;
+            }
+            expect(relay[field]).toEqual(value);
+          }
+        });
+      });
+
+      it.each(testCase.usability.map(probe => [probe.now, probe] as const))(
+        'filters and selects at %s',
+        (_now, probe) => {
+          const now = Date.parse(probe.now);
+          const relays = decoded.relays as RelayDescriptor[];
+
+          expect(relays.filter(relay => isUsable(relay, now)).map(relay => relay.id)).toEqual(
+            probe.usable_ids,
+          );
+          expect(orderedCandidates(relays, now).map(relay => relay.id)).toEqual(probe.usable_ids);
+          expect(selectFirstUsable(relays, now)?.id ?? null).toBe(probe.first_usable_id ?? null);
+        },
+      );
+    },
+  );
+
+  it('leaves the wire-schema rejections to the suites that own them', () => {
+    // The invalid bodies are rejected by native brokerapi before any TypeScript sees them, so this
+    // suite must not be listed as one of their consumers.
+    expect(vectors.invalid.suites).not.toContain(SUITE);
+  });
+});

--- a/__tests__/contract/relayDecodeVectors.test.ts
+++ b/__tests__/contract/relayDecodeVectors.test.ts
@@ -82,9 +82,12 @@ describe('relay decode contract vectors', () => {
               expect(effectiveNodeClass(relay.node_class as string | undefined)).toBe(value);
               continue;
             }
-            // Fields this model does not carry are another suite's to assert; `relay_version` is
-            // the canonical name, and the TypeScript model exposes only the legacy wire name.
-            if (field === 'relay_version') {
+            // Fields this model does not carry are another suite's to assert: `relay_version` is
+            // the canonical name and the TypeScript model exposes only the legacy wire name, and
+            // `wss_fronts` is consumed by the native tunnel layer, never declared on
+            // RelayDescriptor. Asserting them here would only pass through the untyped cast and
+            // fake coverage the TypeScript decoder does not have.
+            if (field === 'relay_version' || field === 'wss_fronts') {
               continue;
             }
             if (value === null) {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -153,6 +153,12 @@ android {
             // FailureClassifierErrnoTest runs under Robolectric, which needs the merged
             // Android resources available to the JVM unit-test classpath.
             includeAndroidResources = true
+            // The cross-repo contract vectors live at the repo root, outside this module.
+            // Passing the directory explicitly keeps the suites off a relative path that
+            // depends on whichever working directory Gradle happens to use.
+            all {
+                it.systemProperty 'openrung.contractVectors', "${rootDir}/../testdata/contract"
+            }
         }
     }
 

--- a/android/app/src/test/java/com/openrung/config/ContractBrokerFrontsTest.kt
+++ b/android/app/src/test/java/com/openrung/config/ContractBrokerFrontsTest.kt
@@ -1,0 +1,78 @@
+package com.openrung.config
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * The Kotlin half of the shared broker-front snapshot.
+ *
+ * This app owns no racing — it hands native brokerapi a primary and Go races the built-in
+ * candidates — so the phases and candidate ordering in the vectors belong to the Go suite and are
+ * deliberately not asserted here. What this side can claim, and what catches a front rotated in
+ * openrung and not here, is that every front the app hardcodes is still one of the canonical ones.
+ * A front that quietly stops existing is a fallback a blocked user no longer has.
+ *
+ * Plain JUnit: no `android.system` values are involved, so Robolectric is unnecessary.
+ */
+class ContractBrokerFrontsTest {
+
+    private companion object {
+        const val EXPECTED_VERSION = 1
+        const val SUITE = "kotlin"
+    }
+
+    private val vectors = Json
+        .parseToJsonElement(
+            File(
+                requireNotNull(System.getProperty("openrung.contractVectors")) {
+                    "openrung.contractVectors is unset; the Gradle unit-test task should supply it"
+                },
+                "broker_fronts.json",
+            ).readText(),
+        )
+        .jsonObject
+
+    private val canonicalFronts: List<String>
+        get() = vectors["default_order"]!!.jsonArray.map { it.jsonPrimitive.content }
+
+    @Test
+    fun `runs the version and the suite it was written for`() {
+        assertEquals(EXPECTED_VERSION, vectors["version"]!!.jsonPrimitive.int)
+        assertTrue(
+            vectors["suites"]!!.jsonArray.map { it.jsonPrimitive.content }.contains(SUITE),
+        )
+    }
+
+    @Test
+    fun `every hardcoded broker front is one of the canonical fronts`() {
+        val fronts = canonicalFronts
+        AppConfig.DEFAULT_BROKER_URLS.forEach { url ->
+            assertTrue("$url is not in the canonical front list $fronts", fronts.contains(url))
+        }
+        assertTrue(AppConfig.DEFAULT_BROKER_URLS.isNotEmpty())
+    }
+
+    @Test
+    fun `the configured primary and telemetry target are canonical fronts`() {
+        val fronts = canonicalFronts
+        assertTrue(fronts.contains(AppConfig.DEFAULT_BROKER_URL))
+        // A telemetry target off the canonical list would carry the pre-VPN IP and the stable
+        // client id to a host the directory contract never vouched for.
+        assertTrue(fronts.contains(AppConfig.TELEMETRY_BROKER_URL))
+    }
+
+    @Test
+    fun `the app carries a strict subset of the canonical fronts`() {
+        // Recorded rather than asserted as equality: this app deliberately ships fewer fronts than
+        // brokerapi races. The test exists so that gap stays a known one — if the app ever grew to
+        // the full list, this is where that shows up.
+        assertTrue(AppConfig.DEFAULT_BROKER_URLS.size <= canonicalFronts.size)
+    }
+}

--- a/android/app/src/test/java/com/openrung/vpn/ContractClassificationVectorsTest.kt
+++ b/android/app/src/test/java/com/openrung/vpn/ContractClassificationVectorsTest.kt
@@ -1,0 +1,167 @@
+package com.openrung.vpn
+
+import android.app.Application
+import android.system.ErrnoException
+import android.system.OsConstants
+import com.openrung.net.WssTicketStatusException
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+import java.net.ConnectException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+import java.util.concurrent.CancellationException
+import javax.net.ssl.SSLHandshakeException
+
+/**
+ * The Kotlin half of the shared failure-classification contract.
+ *
+ * The rows come from testdata/contract/classification.json, vendored from openrung/openrung and
+ * checked against the pinned ref by `npm run contract:check`. The same rows run against Go's
+ * classifier in that repo and against Swift's in [ios/OpenRungTests], so a divergence here means
+ * two clients would file the same failure under different tokens on one dashboard.
+ *
+ * Runs under Robolectric for the same reason [FailureClassifierErrnoTest] does: a stubbed
+ * `android.jar` reports every `OsConstants` value as 0 and has no working [ErrnoException].
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = Application::class)
+class ContractClassificationVectorsTest {
+
+    private companion object {
+        /** The version this suite was written against; a bump upstream means revisiting it. */
+        const val EXPECTED_VERSION = 1
+
+        /** This suite's identifier in the file's `suites` declaration. */
+        const val SUITE = "kotlin"
+
+        /**
+         * Set by the Gradle unit-test task (see `testOptions.unitTests` in build.gradle) so the
+         * path does not depend on a working directory.
+         */
+        val vectorDir: File = File(
+            requireNotNull(System.getProperty("openrung.contractVectors")) {
+                "openrung.contractVectors is unset; the Gradle unit-test task should supply it"
+            },
+        )
+    }
+
+    private val vectors: JsonObject =
+        Json.parseToJsonElement(File(vectorDir, "classification.json").readText()).jsonObject
+
+    private fun string(owner: JsonObject, key: String): String? =
+        owner[key]?.jsonPrimitive?.contentOrNull
+
+    /** The suites that must run a row: the kind's list, narrowed by the row's own when it has one. */
+    private fun suitesFor(row: JsonObject): List<String> {
+        val own = row["suites"]?.jsonArray?.map { it.jsonPrimitive.content }
+        if (own != null) return own
+        val kind = string(row, "kind")
+        return vectors["kinds"]!!.jsonObject[kind]!!.jsonObject["suites"]!!
+            .jsonArray.map { it.jsonPrimitive.content }
+    }
+
+    @Test
+    fun `runs the version and the suite it was written for`() {
+        assertEquals(EXPECTED_VERSION, vectors["version"]!!.jsonPrimitive.int)
+        assertTrue(
+            "the file must declare this suite as a consumer",
+            vectors["suites"]!!.jsonArray.map { it.jsonPrimitive.content }.contains(SUITE),
+        )
+    }
+
+    @Test
+    fun `every row this suite claims classifies to the shared token`() {
+        var ran = 0
+        vectors["cases"]!!.jsonArray.forEach { element ->
+            val row = element.jsonObject
+            val id = string(row, "id")!!
+            if (!suitesFor(row).contains(SUITE)) return@forEach
+            // Winsock numbers only a Windows network stack produces; Android never sees them.
+            if (string(row, "platform") == "windows") return@forEach
+
+            val error = errorFor(row) ?: return@forEach
+            ran++
+            assertEquals(id, string(row, "expect"), FailureClassifier.classify(error.value))
+        }
+        // A suite that silently matched no row would pass while asserting nothing.
+        assertTrue("no rows ran; the vectors or the kind mapping changed shape", ran >= 20)
+    }
+
+    /**
+     * Wraps the built error so a legitimately null error (the `none` kind) is distinguishable from
+     * a kind this suite does not construct.
+     */
+    private class Built(val value: Throwable?)
+
+    private fun errorFor(row: JsonObject): Built? {
+        val input = row["input"]!!.jsonObject
+        val wrapped = input["wrapped"]?.jsonPrimitive?.booleanOrNull == true
+        // The shape the connect pipeline actually produces: the real cause under a generic wrapper.
+        fun wrap(error: Throwable): Throwable =
+            if (wrapped) IllegalStateException("relay is not reachable", error) else error
+
+        return when (string(row, "kind")) {
+            "none" -> Built(null)
+            "cancellation" -> Built(wrap(CancellationException("user stopped the tunnel")))
+            "selection" -> Built(wrap(selectionSentinel(string(input, "sentinel")!!)))
+            "http_status" -> Built(
+                wrap(WssTicketStatusException(input["status"]!!.jsonPrimitive.int, null)),
+            )
+            "errno" -> Built(errnoError(string(input, "symbol")!!, wrapped))
+            "dns" -> when (string(input, "subkind")) {
+                "not_found" -> Built(wrap(UnknownHostException("Unable to resolve host")))
+                else -> null
+            }
+            "tls" -> Built(wrap(SSLHandshakeException("TLS failure")))
+            "permission" -> Built(wrap(SecurityException("VPN permission revoked")))
+            "process_exit" -> Built(wrap(EngineStartException("engine failed", null)))
+            "timeout" -> Built(wrap(SocketTimeoutException("connect timed out")))
+            "unrecognized" -> Built(RuntimeException(string(input, "message")))
+            // deadline and wss_reason are declared go-only; suitesFor already filtered them out.
+            else -> null
+        }
+    }
+
+    private fun selectionSentinel(sentinel: String): Throwable = when (sentinel) {
+        "no_relays_available" -> RelaySelectionException.NoRelaysAvailable("broker returned no relays")
+        "relay_not_in_list" -> RelaySelectionException.RelayNotInList("target relay not offered")
+        "no_relay_in_country" -> RelaySelectionException.NoRelayInCountry("no relay in country")
+        "no_usable_relay" -> RelaySelectionException.NoUsableRelay("no usable relay")
+        else -> throw AssertionError("unknown selection sentinel $sentinel")
+    }
+
+    private fun errnoError(symbol: String, wrapped: Boolean): Throwable {
+        val errno = ErrnoException("connect", osConstant(symbol))
+        // Android surfaces a socket errno as a ConnectException carrying it as the cause.
+        return if (wrapped) {
+            ConnectException("failed to connect to /203.0.113.10:443").apply { initCause(errno) }
+        } else {
+            errno
+        }
+    }
+
+    private fun osConstant(symbol: String): Int = when (symbol) {
+        "ECONNREFUSED" -> OsConstants.ECONNREFUSED
+        "ECONNRESET" -> OsConstants.ECONNRESET
+        "ENETUNREACH" -> OsConstants.ENETUNREACH
+        "EHOSTUNREACH" -> OsConstants.EHOSTUNREACH
+        "ETIMEDOUT" -> OsConstants.ETIMEDOUT
+        "EACCES" -> OsConstants.EACCES
+        "EPERM" -> OsConstants.EPERM
+        "EPIPE" -> OsConstants.EPIPE
+        else -> throw AssertionError("unknown errno symbol $symbol")
+    }
+}

--- a/ios/OpenRung.xcodeproj/project.pbxproj
+++ b/ios/OpenRung.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		0483F1444764AB1812DC4A79 /* GeoIpClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 135777353E0B842A0E8E1A49 /* GeoIpClient.swift */; };
 		064EE332A9DA0543E819E36C /* EngineStopSignal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 007F9F5B484B9408D05F255E /* EngineStopSignal.swift */; };
 		069A422F72032F6301328723 /* AppConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4783169BE46FEE9B0472504 /* AppConfig.swift */; };
+		08F12A1BB6BE2540FEF05AEB /* ContractBrokerFrontsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77C0ADAE13A64A7038DFE0A6 /* ContractBrokerFrontsTests.swift */; };
+		0BB5CA3297B33DA737F31BBB /* libPods-OpenRung.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 12FF9930B90F3614926A60E9 /* libPods-OpenRung.a */; };
 		0EDBAE2EAFCBE31BD3D98EC9 /* NativeBrokerTransportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E1EF79FDA717F2ED5A32F0 /* NativeBrokerTransportTests.swift */; };
 		1001D8102F7EA1A694366DFF /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A9B3E3F0BA7E28C5D05A1731 /* Images.xcassets */; };
 		101812ACF2D87E69B666B516 /* DeviceAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E77D10C22E8939116D44BD /* DeviceAttributes.swift */; };
@@ -157,13 +159,13 @@
 		E934E6591F0F72952629EE42 /* StartupPathVerification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23D668BED08950120483C704 /* StartupPathVerification.swift */; };
 		EAD1DFA9AB52E6A93CB60890 /* FailureClassifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F3B6378B98E464A9F306E7 /* FailureClassifier.swift */; };
 		EB4BB9C6B76C65809224DF35 /* RelayDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC6AEF8D510DD407C368119F /* RelayDescriptor.swift */; };
-		ECF478EF0EEC0C64EC7E7844 /* libPods-OpenRung.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F071030BB72CA2FAD8CA9201 /* libPods-OpenRung.a */; };
 		ED0AA86BCFC9211195B7081E /* ClientIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD4088394FB9EBCF808F81C2 /* ClientIdentity.swift */; };
 		F394E6F8661ECC0CFB89B18F /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 81CC00C2F7324111F25D07A0 /* UIKit.framework */; };
 		F6D4EDF154A64B658BBAA677 /* TelemetrySession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A5299A99DA8ED8C75B1E25B /* TelemetrySession.swift */; };
 		F7CB06F189A040EFBFCC13B0 /* WssFallbackPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6778C7AC035DF5A9549A7A2D /* WssFallbackPolicy.swift */; };
 		F82F4E03FAD0D3DFDB106718 /* OpenRungVpnModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 719ACF45718CBF52773FCD6C /* OpenRungVpnModule.swift */; };
 		F86A7ADA4A7D12D83097E59C /* PunchFallbackPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1997F12E9E5BEAC8521C7D78 /* PunchFallbackPolicyTests.swift */; };
+		F9E733A69CC079063D275F8E /* ContractClassificationVectorsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76DC959804E5611F0EA09267 /* ContractClassificationVectorsTests.swift */; };
 		FBB5A1494BB10EC5CC265A5C /* geosite-cn.srs in Resources */ = {isa = PBXBuildFile; fileRef = F68B4299B0EAD00601A47FF2 /* geosite-cn.srs */; };
 		FDD249EAC97CC2DF789CBCE6 /* SplitTunnelConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88FBD70740FE33FC9CC6564B /* SplitTunnelConfig.swift */; };
 		FE4024439B637E56ABC50688 /* PunchRecoveryCircuitBreaker.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2A2060BBC10DA73835172CD /* PunchRecoveryCircuitBreaker.swift */; };
@@ -227,17 +229,16 @@
 		069A5BBA8E1C40AC3EABFD68 /* OpenRungBrokerCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenRungBrokerCoordinatorTests.swift; sourceTree = "<group>"; };
 		091BB47D3F7E77446C73342D /* Network.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Network.framework; path = System/Library/Frameworks/Network.framework; sourceTree = SDKROOT; };
 		11E1EF79FDA717F2ED5A32F0 /* NativeBrokerTransportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeBrokerTransportTests.swift; sourceTree = "<group>"; };
+		12FF9930B90F3614926A60E9 /* libPods-OpenRung.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-OpenRung.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		135777353E0B842A0E8E1A49 /* GeoIpClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeoIpClient.swift; sourceTree = "<group>"; };
 		174E944F053F54F691E59C74 /* OpenRungTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = OpenRungTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		1997F12E9E5BEAC8521C7D78 /* PunchFallbackPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PunchFallbackPolicyTests.swift; sourceTree = "<group>"; };
 		1EAA8B2F5746A87534F0C87B /* PacketTunnel.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = PacketTunnel.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		1FE575C8C524F31D6CD8423C /* PunchRecoveryCircuitBreakerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PunchRecoveryCircuitBreakerTests.swift; sourceTree = "<group>"; };
-		213128529885E52353BB956E /* Pods-OpenRung.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OpenRung.release.xcconfig"; path = "Target Support Files/Pods-OpenRung/Pods-OpenRung.release.xcconfig"; sourceTree = "<group>"; };
 		23D668BED08950120483C704 /* StartupPathVerification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupPathVerification.swift; sourceTree = "<group>"; };
 		25CB8E64CF645C0DD1375294 /* EngineDirectories.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EngineDirectories.swift; sourceTree = "<group>"; };
 		274F2564F2D6019FBBD3B92A /* LibboxBrokerTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibboxBrokerTransport.swift; sourceTree = "<group>"; };
 		28019235E34D443A26534186 /* PhysicalNetworkEpochMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhysicalNetworkEpochMonitor.swift; sourceTree = "<group>"; };
-		28F504AF83FD862F959E73DD /* Pods-OpenRung.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OpenRung.debug.xcconfig"; path = "Target Support Files/Pods-OpenRung/Pods-OpenRung.debug.xcconfig"; sourceTree = "<group>"; };
 		293D5236C6FC627E5993262E /* SplitTunnelConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitTunnelConfigurationTests.swift; sourceTree = "<group>"; };
 		2D55BA84C5D35B80DFF05F1A /* DnsProbeMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DnsProbeMessage.swift; sourceTree = "<group>"; };
 		31A10C67D3636F8903463D9E /* WssLifecycleAndConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WssLifecycleAndConfigurationTests.swift; sourceTree = "<group>"; };
@@ -252,6 +253,7 @@
 		584A04475F28B3CAC39B501E /* ConnectionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionStatus.swift; sourceTree = "<group>"; };
 		5A5941A8CF4A810D424C4147 /* OpenRungBrokerModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenRungBrokerModule.swift; sourceTree = "<group>"; };
 		5F4DB9A32A2B929C586861C2 /* WssFallbackPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WssFallbackPolicyTests.swift; sourceTree = "<group>"; };
+		64E041CF3AC773667B76E896 /* Pods-OpenRung.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OpenRung.debug.xcconfig"; path = "Target Support Files/Pods-OpenRung/Pods-OpenRung.debug.xcconfig"; sourceTree = "<group>"; };
 		66C3AC37AF7128A85A7F7CC7 /* NativeBrokerTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeBrokerTransport.swift; sourceTree = "<group>"; };
 		6778C7AC035DF5A9549A7A2D /* WssFallbackPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WssFallbackPolicy.swift; sourceTree = "<group>"; };
 		683F07997A392045B7540E47 /* BrokerClientError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrokerClientError.swift; sourceTree = "<group>"; };
@@ -260,6 +262,8 @@
 		6A5299A99DA8ED8C75B1E25B /* TelemetrySession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetrySession.swift; sourceTree = "<group>"; };
 		6F2C000CBB239AC6AD0AD566 /* TelemetryClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryClientTests.swift; sourceTree = "<group>"; };
 		719ACF45718CBF52773FCD6C /* OpenRungVpnModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenRungVpnModule.swift; sourceTree = "<group>"; };
+		76DC959804E5611F0EA09267 /* ContractClassificationVectorsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContractClassificationVectorsTests.swift; sourceTree = "<group>"; };
+		77C0ADAE13A64A7038DFE0A6 /* ContractBrokerFrontsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContractBrokerFrontsTests.swift; sourceTree = "<group>"; };
 		7A07146C137269D283F062DB /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7EC4D45896D45D90A17A3E83 /* WssNativeClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WssNativeClient.swift; sourceTree = "<group>"; };
 		80ADBA548D57C01CAE8FA99B /* PunchNativeClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PunchNativeClient.swift; sourceTree = "<group>"; };
@@ -304,6 +308,7 @@
 		D8FF4517B34B4819F6DCD4D1 /* RelayReachabilityError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayReachabilityError.swift; sourceTree = "<group>"; };
 		DC6AEF8D510DD407C368119F /* RelayDescriptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayDescriptor.swift; sourceTree = "<group>"; };
 		DD4088394FB9EBCF808F81C2 /* ClientIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientIdentity.swift; sourceTree = "<group>"; };
+		DD966C970814006E2933C234 /* Pods-OpenRung.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OpenRung.release.xcconfig"; path = "Target Support Files/Pods-OpenRung/Pods-OpenRung.release.xcconfig"; sourceTree = "<group>"; };
 		E015EBBA482879150C779611 /* OpenRung.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = OpenRung.entitlements; sourceTree = "<group>"; };
 		E0C2DC3997620B7904DF0937 /* PunchNativeClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PunchNativeClientTests.swift; sourceTree = "<group>"; };
 		E2570C01745DA49558877810 /* CountryGeo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountryGeo.swift; sourceTree = "<group>"; };
@@ -315,7 +320,6 @@
 		ECC225DFB311B748621B135B /* PacketTunnelDnsProbeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PacketTunnelDnsProbeTests.swift; sourceTree = "<group>"; };
 		ED28831CA960E8B89D5D7D04 /* OpenRungVpnModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OpenRungVpnModule.m; sourceTree = "<group>"; };
 		EFA54F7B4B2DCC1F8706FD7C /* TelemetryOutboxState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryOutboxState.swift; sourceTree = "<group>"; };
-		F071030BB72CA2FAD8CA9201 /* libPods-OpenRung.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-OpenRung.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F19AE6300C331CB6C7B2B9E8 /* Libbox.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Libbox.xcframework; path = ThirdParty/Libbox.xcframework; sourceTree = "<group>"; };
 		F68B4299B0EAD00601A47FF2 /* geosite-cn.srs */ = {isa = PBXFileReference; path = "geosite-cn.srs"; sourceTree = "<group>"; };
 		F9C369738D2565177A979FAC /* ProbeTargets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProbeTargets.swift; sourceTree = "<group>"; };
@@ -348,7 +352,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				767680B070BBDB21811EA1F0 /* LibboxKit.framework in Frameworks */,
-				ECF478EF0EEC0C64EC7E7844 /* libPods-OpenRung.a in Frameworks */,
+				0BB5CA3297B33DA737F31BBB /* libPods-OpenRung.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -427,6 +431,8 @@
 			children = (
 				9771BD2BC7057921FF185C4C /* BrokerClientTests.swift */,
 				CC60C417C2C56A9F45E90C8D /* ConnectionStateSnapshotTests.swift */,
+				77C0ADAE13A64A7038DFE0A6 /* ContractBrokerFrontsTests.swift */,
+				76DC959804E5611F0EA09267 /* ContractClassificationVectorsTests.swift */,
 				CF68A64E6FB095B8FD6A3F3F /* DnsConfigurationTests.swift */,
 				C9657758A00C98E294119901 /* DnsProbeMessageTests.swift */,
 				E89C58EA730C659109459911 /* FailureClassifierTests.swift */,
@@ -469,19 +475,9 @@
 				EC15DA1827B19848080D3452 /* libresolv.tbd */,
 				091BB47D3F7E77446C73342D /* Network.framework */,
 				81CC00C2F7324111F25D07A0 /* UIKit.framework */,
-				F071030BB72CA2FAD8CA9201 /* libPods-OpenRung.a */,
+				12FF9930B90F3614926A60E9 /* libPods-OpenRung.a */,
 			);
 			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		A69125F8D6C9E58412A729FB /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				28F504AF83FD862F959E73DD /* Pods-OpenRung.debug.xcconfig */,
-				213128529885E52353BB956E /* Pods-OpenRung.release.xcconfig */,
-			);
-			name = Pods;
-			path = Pods;
 			sourceTree = "<group>";
 		};
 		AFDFC1D16B3A792D974E4A5D /* PacketTunnel */ = {
@@ -530,8 +526,18 @@
 				3F24A472F75132572E2891A1 /* Shared */,
 				A1C815B9A63C637692C1C541 /* Frameworks */,
 				E73A5155909F9EFE9F13A6A1 /* Products */,
-				A69125F8D6C9E58412A729FB /* Pods */,
+				FC6F0F14B71066D3B9AD39EB /* Pods */,
 			);
+			sourceTree = "<group>";
+		};
+		FC6F0F14B71066D3B9AD39EB /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				64E041CF3AC773667B76E896 /* Pods-OpenRung.debug.xcconfig */,
+				DD966C970814006E2933C234 /* Pods-OpenRung.release.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -575,16 +581,16 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F19D0D1C8CB7FB1B6B178E82 /* Build configuration list for PBXNativeTarget "OpenRung" */;
 			buildPhases = (
-				C0E9A186E25E9069B7D74612 /* [CP] Check Pods Manifest.lock */,
+				7EA3770EB75BE1CA54501EC5 /* [CP] Check Pods Manifest.lock */,
 				BC3282E3662088C7CF8F8BC7 /* Sources */,
 				7272F5C7D4F2765DAB69942D /* Resources */,
 				6E9C330AAB907426FF017F77 /* Frameworks */,
 				141D130B421160859A220937 /* Embed Foundation Extensions */,
 				E5A73D1935A290882F2E847C /* Embed Frameworks */,
 				7645E65DA025354651549041 /* Bundle React Native code and images */,
-				8B411FD72E120A902598712F /* [MapLibre React Native] Remove MapLibre.xcframework-ios.signature */,
-				99F36AD960D83B15B6928462 /* [CP] Embed Pods Frameworks */,
-				69F71ADAB77D5909548CAF0A /* [CP] Copy Pods Resources */,
+				E2608592904EE5E6C2EA3886 /* [MapLibre React Native] Remove MapLibre.xcframework-ios.signature */,
+				E57405222858E19D1346246A /* [CP] Embed Pods Frameworks */,
+				CBC76B09CB04A0577A93CEA3 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -594,7 +600,7 @@
 			);
 			name = OpenRung;
 			packageProductDependencies = (
-				8B6EB88A67F938EB01353AE3 /* MapLibre */,
+				6B034497C6F2B64E9641D7F3 /* MapLibre */,
 			);
 			productName = OpenRung;
 			productReference = 81B10868A3F7FA99A84696A4 /* OpenRung.app */;
@@ -652,7 +658,7 @@
 			mainGroup = F4646C7E57CBAA9E0DF5661F;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
-				F8FDD7F60E40A1B51A20E6EE /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */,
+				EACA0ACD094AF23DC4E123FC /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = E73A5155909F9EFE9F13A6A1 /* Products */;
@@ -692,23 +698,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		69F71ADAB77D5909548CAF0A /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-OpenRung/Pods-OpenRung-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-OpenRung/Pods-OpenRung-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-OpenRung/Pods-OpenRung-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		7645E65DA025354651549041 /* Bundle React Native code and images */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -729,43 +718,7 @@
 			shellPath = /bin/sh;
 			shellScript = "set -e\n\nWITH_ENVIRONMENT=\"$REACT_NATIVE_PATH/scripts/xcode/with-environment.sh\"\nREACT_NATIVE_XCODE=\"$REACT_NATIVE_PATH/scripts/react-native-xcode.sh\"\n\n/bin/sh -c \"\\\"$WITH_ENVIRONMENT\\\" \\\"$REACT_NATIVE_XCODE\\\"\"\n";
 		};
-		8B411FD72E120A902598712F /* [MapLibre React Native] Remove MapLibre.xcframework-ios.signature */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "[MapLibre React Native] Remove MapLibre.xcframework-ios.signature";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "rm -rf \"$CONFIGURATION_BUILD_DIR/MapLibre.xcframework-ios.signature\"";
-		};
-		99F36AD960D83B15B6928462 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-OpenRung/Pods-OpenRung-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-OpenRung/Pods-OpenRung-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-OpenRung/Pods-OpenRung-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		C0E9A186E25E9069B7D74612 /* [CP] Check Pods Manifest.lock */ = {
+		7EA3770EB75BE1CA54501EC5 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -785,6 +738,59 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		CBC76B09CB04A0577A93CEA3 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-OpenRung/Pods-OpenRung-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-OpenRung/Pods-OpenRung-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-OpenRung/Pods-OpenRung-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		E2608592904EE5E6C2EA3886 /* [MapLibre React Native] Remove MapLibre.xcframework-ios.signature */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "[MapLibre React Native] Remove MapLibre.xcframework-ios.signature";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "rm -rf \"$CONFIGURATION_BUILD_DIR/MapLibre.xcframework-ios.signature\"";
+		};
+		E57405222858E19D1346246A /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-OpenRung/Pods-OpenRung-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-OpenRung/Pods-OpenRung-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-OpenRung/Pods-OpenRung-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -864,6 +870,8 @@
 				3211CE2D43E97CFA91D9E7FF /* BrokerClientTests.swift in Sources */,
 				D2021049A4947FDF31F8DB88 /* ConnectionStateSnapshotTests.swift in Sources */,
 				006F36ED698121FA8DA045C3 /* ConnectionStatus.swift in Sources */,
+				08F12A1BB6BE2540FEF05AEB /* ContractBrokerFrontsTests.swift in Sources */,
+				F9E733A69CC079063D275F8E /* ContractClassificationVectorsTests.swift in Sources */,
 				319DAB39FFB8E6FA40C411B9 /* CountryGeo.swift in Sources */,
 				C434209DCAFA9B2D3BA91E84 /* DeviceAttributes.swift in Sources */,
 				DA63F6EDE23966103B89E919 /* DnsConfigurationTests.swift in Sources */,
@@ -986,7 +994,7 @@
 /* Begin XCBuildConfiguration section */
 		0D953B3D127C0BB08E644293 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 213128529885E52353BB956E /* Pods-OpenRung.release.xcconfig */;
+			baseConfigurationReference = DD966C970814006E2933C234 /* Pods-OpenRung.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = OpenRung/OpenRung.entitlements;
@@ -1196,7 +1204,7 @@
 		};
 		73BE8C16CB91640112F4357A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 28F504AF83FD862F959E73DD /* Pods-OpenRung.debug.xcconfig */;
+			baseConfigurationReference = 64E041CF3AC773667B76E896 /* Pods-OpenRung.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = OpenRung/OpenRung.entitlements;
@@ -1422,7 +1430,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		F8FDD7F60E40A1B51A20E6EE /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */ = {
+		EACA0ACD094AF23DC4E123FC /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/maplibre/maplibre-gl-native-distribution";
 			requirement = {
@@ -1433,9 +1441,9 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		8B6EB88A67F938EB01353AE3 /* MapLibre */ = {
+		6B034497C6F2B64E9641D7F3 /* MapLibre */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = F8FDD7F60E40A1B51A20E6EE /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */;
+			package = EACA0ACD094AF23DC4E123FC /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */;
 			productName = MapLibre;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/ios/OpenRungTests/ContractBrokerFrontsTests.swift
+++ b/ios/OpenRungTests/ContractBrokerFrontsTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import XCTest
+
+/// The Swift half of the shared broker-front snapshot.
+///
+/// This app owns no racing — it hands native brokerapi a primary and Go races the built-in
+/// candidates — so the phases and candidate ordering in the vectors belong to the Go suite and are
+/// deliberately not asserted here. What this side can claim, and what catches a front rotated in
+/// openrung and not here, is that every front the app hardcodes is still one of the canonical ones.
+/// A front that quietly stops existing is a fallback a blocked user no longer has.
+final class ContractBrokerFrontsTests: XCTestCase {
+
+    private static let expectedVersion = 1
+    private static let suite = "swift"
+
+    private var vectors: [String: Any] = [:]
+
+    override func setUpWithError() throws {
+        let url = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // OpenRungTests
+            .deletingLastPathComponent()  // ios
+            .deletingLastPathComponent()  // repository root
+            .appendingPathComponent("testdata/contract/broker_fronts.json")
+        vectors = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: Data(contentsOf: url)) as? [String: Any],
+            "broker_fronts.json is not a JSON object"
+        )
+    }
+
+    private func canonicalFronts() throws -> [String] {
+        try XCTUnwrap(vectors["default_order"] as? [String])
+    }
+
+    func testRunsTheVersionAndSuiteItWasWrittenFor() throws {
+        XCTAssertEqual(vectors["version"] as? Int, Self.expectedVersion)
+        let declared = try XCTUnwrap(vectors["suites"] as? [String])
+        XCTAssertTrue(declared.contains(Self.suite))
+    }
+
+    func testEveryHardcodedFrontIsCanonical() throws {
+        let fronts = try canonicalFronts()
+        XCTAssertFalse(AppConfig.defaultBrokerURLs.isEmpty)
+        for url in AppConfig.defaultBrokerURLs {
+            XCTAssertTrue(fronts.contains(url.absoluteString), "\(url) is not in the canonical front list")
+        }
+    }
+
+    func testPrimaryAndTelemetryTargetsAreCanonical() throws {
+        let fronts = try canonicalFronts()
+        XCTAssertTrue(fronts.contains(AppConfig.defaultBrokerURL.absoluteString))
+        // A telemetry target off the canonical list would carry the pre-VPN IP and the stable
+        // client id to a host the directory contract never vouched for.
+        XCTAssertTrue(fronts.contains(AppConfig.telemetryBrokerURL.absoluteString))
+    }
+
+    func testAppCarriesASubsetOfTheCanonicalFronts() throws {
+        // Recorded rather than asserted as equality: this app deliberately ships fewer fronts than
+        // brokerapi races. If it ever grew to the full list, this is where that shows up.
+        XCTAssertLessThanOrEqual(AppConfig.defaultBrokerURLs.count, try canonicalFronts().count)
+    }
+}

--- a/ios/OpenRungTests/ContractClassificationVectorsTests.swift
+++ b/ios/OpenRungTests/ContractClassificationVectorsTests.swift
@@ -1,0 +1,150 @@
+import Foundation
+import NetworkExtension
+import XCTest
+
+/// The Swift half of the shared failure-classification contract.
+///
+/// The rows come from testdata/contract/classification.json, vendored from openrung/openrung and
+/// checked against the pinned ref by `npm run contract:check`. The same rows run against Go's
+/// classifier in that repo and against Kotlin's in `ContractClassificationVectorsTest`, so a
+/// divergence here means two clients would file the same failure under different tokens on one
+/// dashboard.
+final class ContractClassificationVectorsTests: XCTestCase {
+
+    /// The version this suite was written against; a bump upstream means revisiting it.
+    private static let expectedVersion = 1
+
+    /// This suite's identifier in the file's `suites` declaration.
+    private static let suite = "swift"
+
+    /// Resolved from this file's own path rather than a bundle resource, so the vectors stay a
+    /// plain checked-in file that every suite reads the same way and the Xcode target needs no
+    /// resource wiring.
+    private static let vectorDirectory = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()  // OpenRungTests
+        .deletingLastPathComponent()  // ios
+        .deletingLastPathComponent()  // repository root
+        .appendingPathComponent("testdata/contract", isDirectory: true)
+
+    private var vectors: [String: Any] = [:]
+
+    override func setUpWithError() throws {
+        let url = Self.vectorDirectory.appendingPathComponent("classification.json")
+        let data = try Data(contentsOf: url)
+        vectors = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any],
+            "classification.json is not a JSON object"
+        )
+    }
+
+    func testRunsTheVersionAndSuiteItWasWrittenFor() throws {
+        XCTAssertEqual(vectors["version"] as? Int, Self.expectedVersion)
+        let declared = try XCTUnwrap(vectors["suites"] as? [String])
+        XCTAssertTrue(declared.contains(Self.suite), "the file must declare this suite as a consumer")
+    }
+
+    func testEveryClaimedRowClassifiesToTheSharedToken() throws {
+        let cases = try XCTUnwrap(vectors["cases"] as? [[String: Any]])
+        var ran = 0
+
+        for row in cases {
+            let id = try XCTUnwrap(row["id"] as? String)
+            guard suites(for: row).contains(Self.suite) else { continue }
+            // Winsock numbers only a Windows network stack produces; iOS never sees them.
+            guard (row["platform"] as? String) != "windows" else { continue }
+            guard let error = error(for: row) else { continue }
+
+            ran += 1
+            XCTAssertEqual(
+                FailureClassifier.classify(error),
+                row["expect"] as? String,
+                "vector \(id)"
+            )
+        }
+
+        // A suite that silently matched no row would pass while asserting nothing.
+        XCTAssertGreaterThanOrEqual(ran, 15, "no rows ran; the vectors or the kind mapping changed shape")
+    }
+
+    /// The suites that must run a row: the kind's list, narrowed by the row's own when it has one.
+    private func suites(for row: [String: Any]) -> [String] {
+        if let own = row["suites"] as? [String] { return own }
+        let kinds = vectors["kinds"] as? [String: Any] ?? [:]
+        let kind = kinds[row["kind"] as? String ?? ""] as? [String: Any] ?? [:]
+        return kind["suites"] as? [String] ?? []
+    }
+
+    private func error(for row: [String: Any]) -> Error? {
+        let input = row["input"] as? [String: Any] ?? [:]
+        let wrapped = input["wrapped"] as? Bool ?? false
+        // The shape the connect pipeline actually produces: the real cause under a wrapper the
+        // classifier has to unwrap.
+        func wrap(_ error: Error) -> Error {
+            wrapped ? PacketTunnelError.allRelaysFailed(error) : error
+        }
+
+        switch row["kind"] as? String {
+        case "cancellation":
+            return wrap(CancellationError())
+        case "selection":
+            switch input["sentinel"] as? String {
+            case "relay_not_in_list": return PacketTunnelError.relayNotAvailable
+            case "no_relay_in_country": return PacketTunnelError.noRelayInCountry("Peru")
+            case "no_usable_relay": return PacketTunnelError.noUsableRelay
+            default: return nil
+            }
+        case "http_status":
+            guard let status = input["status"] as? Int else { return nil }
+            return wrap(BrokerClientError.httpStatus(status))
+        case "errno":
+            guard let code = posixCode(input["symbol"] as? String) else { return nil }
+            let posix = POSIXError(code)
+            return wrapped
+                ? PacketTunnelError.relayUnreachable(host: "203.0.113.10", port: 443, underlying: posix)
+                : posix
+        case "dns":
+            guard input["subkind"] as? String == "not_found" else { return nil }
+            return wrap(URLError(.cannotFindHost))
+        case "tls":
+            switch input["subkind"] as? String {
+            case "not_tls": return wrap(URLError(.secureConnectionFailed))
+            case "unknown_authority": return wrap(URLError(.serverCertificateHasUnknownRoot))
+            case "hostname_mismatch": return wrap(URLError(.serverCertificateUntrusted))
+            case "cert_expired": return wrap(URLError(.serverCertificateHasBadDate))
+            default: return nil
+            }
+        case "permission":
+            return wrap(
+                NSError(domain: NEVPNErrorDomain, code: NEVPNError.configurationReadWriteFailed.rawValue)
+            )
+        case "process_exit":
+            return wrap(PacketTunnelProxyEngineError.engineStartFailed("engine failed"))
+        case "timeout":
+            return wrap(URLError(.timedOut))
+        case "unrecognized":
+            return NSError(
+                domain: "OpenRungContractVectors",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: input["message"] as? String ?? ""]
+            )
+        // `none` (Swift's classify takes a non-optional Error), `deadline`, and `wss_reason` are
+        // declared for other suites; `suites(for:)` already filtered them out.
+        default:
+            return nil
+        }
+    }
+
+    private func posixCode(_ symbol: String?) -> POSIXErrorCode? {
+        switch symbol {
+        case "ECONNREFUSED": return .ECONNREFUSED
+        case "ECONNRESET": return .ECONNRESET
+        case "ENETUNREACH": return .ENETUNREACH
+        case "EHOSTUNREACH": return .EHOSTUNREACH
+        case "ETIMEDOUT": return .ETIMEDOUT
+        case "EACCES": return .EACCES
+        case "EPERM": return .EPERM
+        case "EPIPE": return .EPIPE
+        default: return nil
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "ios": "react-native run-ios",
     "lint": "eslint .",
     "start": "react-native start",
+    "contract:check": "node scripts/check-contract-vectors.mjs",
+    "contract:sync": "node scripts/check-contract-vectors.mjs --sync",
     "test": "jest",
     "transport:check": "node scripts/check-broker-transports.mjs",
     "version:check": "node scripts/check-versions.mjs"

--- a/scripts/check-contract-vectors.mjs
+++ b/scripts/check-contract-vectors.mjs
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+
+/**
+ * Guard for the contract vectors vendored in testdata/contract.
+ *
+ * They are copies. openrung/openrung's contract/vectors is the source of truth, and a copy that
+ * drifts from it is worse than no copy at all: the Kotlin, Swift, and Jest suites keep passing
+ * against expectations the Go side has already moved on from, which reads as agreement between
+ * four clients that no longer agree.
+ *
+ * Two halves, because they fail differently:
+ *
+ *   local   the vendored bytes still hash to the digests in pin.json, the recorded version matches
+ *           the version inside each file, and every non-go suite the file declares is either wired
+ *           up here or listed as pending with a reason. No network.
+ *   remote  the vendored bytes are byte-identical to the pinned openrung ref. Needs network.
+ *
+ * Both run by default. `--offline` runs the local half only and says so on stderr — the point of
+ * the flag is a dev machine without network, not a way to make CI quiet, so it never downgrades a
+ * real mismatch into a pass.
+ *
+ * Usage: node scripts/check-contract-vectors.mjs [--offline] [--sync]
+ *        --sync rewrites the vendored copies and digests from the pinned ref.
+ */
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const vectorDir = path.join(root, 'testdata/contract');
+const pinPath = path.join(vectorDir, 'pin.json');
+
+const offline = process.argv.includes('--offline');
+const sync = process.argv.includes('--sync');
+const failures = [];
+const notes = [];
+
+function fail(message) {
+  failures.push(message);
+}
+
+function digest(bytes) {
+  return crypto.createHash('sha256').update(bytes).digest('hex');
+}
+
+function rawURL(pin, file) {
+  return `https://raw.githubusercontent.com/${pin.repo}/${pin.ref}/${pin.source_dir}/${file}`;
+}
+
+async function fetchUpstream(pin, file) {
+  const url = rawURL(pin, file);
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`GET ${url} -> HTTP ${response.status}`);
+  }
+  return Buffer.from(await response.arrayBuffer());
+}
+
+const pin = JSON.parse(fs.readFileSync(pinPath, 'utf8'));
+const pinned = Object.keys(pin.files);
+
+// --sync refreshes the copies before anything is checked, so a sync run ends green only if the
+// result also satisfies every check below.
+if (sync) {
+  if (offline) {
+    console.error('--sync needs the network; drop --offline.');
+    process.exit(2);
+  }
+  for (const file of pinned) {
+    const upstream = await fetchUpstream(pin, file);
+    fs.writeFileSync(path.join(vectorDir, file), upstream);
+    pin.files[file].sha256 = digest(upstream);
+    pin.files[file].version = JSON.parse(upstream.toString('utf8')).version;
+    pin.files[file].suites = JSON.parse(upstream.toString('utf8')).suites;
+    notes.push(`synced ${file} from ${pin.ref.slice(0, 12)}`);
+  }
+  fs.writeFileSync(pinPath, `${JSON.stringify(pin, null, 2)}\n`);
+}
+
+// The directory must hold exactly the pinned files plus pin.json: an unpinned vector file would be
+// consumed by the suites while nothing checked it against upstream.
+const present = fs
+  .readdirSync(vectorDir)
+  .filter(name => name.endsWith('.json') && name !== 'pin.json')
+  .sort();
+const declared = [...pinned].sort();
+if (present.join() !== declared.join()) {
+  fail(`testdata/contract holds [${present}] but pin.json pins [${declared}]`);
+}
+
+for (const [file, expected] of Object.entries(pin.files)) {
+  const filePath = path.join(vectorDir, file);
+  if (!fs.existsSync(filePath)) {
+    fail(`${file}: pinned but not vendored`);
+    continue;
+  }
+  const bytes = fs.readFileSync(filePath);
+  const actual = digest(bytes);
+  if (actual !== expected.sha256) {
+    fail(
+      `${file}: sha256 ${actual} does not match pin.json's ${expected.sha256}. ` +
+        'Edit the vectors in openrung/openrung, then re-vendor with `npm run contract:sync`.',
+    );
+    continue;
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(bytes.toString('utf8'));
+  } catch (error) {
+    fail(`${file}: not valid JSON (${error.message})`);
+    continue;
+  }
+  if (parsed.version !== expected.version) {
+    fail(`${file}: carries version ${parsed.version} but pin.json records ${expected.version}`);
+  }
+  if (parsed.suites.join() !== expected.suites.join()) {
+    fail(`${file}: declares suites [${parsed.suites}] but pin.json records [${expected.suites}]`);
+  }
+
+  // Every suite the file declares, other than the Go one that lives in openrung, must be accounted
+  // for here — wired up, or pending with a reason. Silence is what lets a declared consumer look
+  // like coverage it is not.
+  const pendingSuites = Object.keys(expected.pending_suites ?? {});
+  for (const suite of parsed.suites.filter(name => name !== 'go')) {
+    const wired = (expected.local_suites ?? []).includes(suite);
+    const pending = pendingSuites.includes(suite);
+    if (!wired && !pending) {
+      fail(
+        `${file}: declares suite "${suite}", which this repo neither runs (local_suites) nor ` +
+          'records as pending with a reason (pending_suites)',
+      );
+    }
+    if (wired && pending) {
+      fail(`${file}: suite "${suite}" is listed as both wired and pending`);
+    }
+  }
+  for (const [suite, reason] of Object.entries(expected.pending_suites ?? {})) {
+    if (!parsed.suites.includes(suite)) {
+      fail(`${file}: pending suite "${suite}" is not one the file declares`);
+    }
+    if (typeof reason !== 'string' || reason.trim() === '') {
+      fail(`${file}: pending suite "${suite}" carries no reason`);
+    }
+  }
+  for (const suite of expected.local_suites ?? []) {
+    if (!parsed.suites.includes(suite)) {
+      fail(`${file}: local suite "${suite}" is not one the file declares`);
+    }
+  }
+}
+
+if (offline) {
+  console.error(
+    'contract:check --offline: skipped the comparison against ' +
+      `${pin.repo}@${pin.ref.slice(0, 12)}. Local digests only; run without --offline before merging.`,
+  );
+} else if (failures.length === 0) {
+  for (const file of pinned) {
+    let upstream;
+    try {
+      upstream = await fetchUpstream(pin, file);
+    } catch (error) {
+      // Never downgrade an unreachable upstream to a pass: an unchecked copy is the whole failure
+      // mode this script exists for.
+      fail(
+        `${file}: could not read the pinned copy (${error.message}). ` +
+          'Use --offline only when the network is genuinely unavailable.',
+      );
+      continue;
+    }
+    if (!upstream.equals(fs.readFileSync(path.join(vectorDir, file)))) {
+      fail(
+        `${file}: differs from ${pin.repo}@${pin.ref.slice(0, 12)}:${pin.source_dir}/${file}. ` +
+          'Re-vendor with `npm run contract:sync`, or move the pin if upstream moved on purpose.',
+      );
+    } else {
+      notes.push(`${file} matches ${pin.repo}@${pin.ref.slice(0, 12)}`);
+    }
+  }
+}
+
+for (const note of notes) {
+  console.log(`ok  ${note}`);
+}
+if (failures.length > 0) {
+  console.error('\ncontract vector check failed:');
+  for (const failure of failures) {
+    console.error(`  - ${failure}`);
+  }
+  process.exit(1);
+}
+console.log(`ok  ${pinned.length} contract vector files verified`);

--- a/scripts/check-contract-vectors.mjs
+++ b/scripts/check-contract-vectors.mjs
@@ -50,7 +50,8 @@ function rawURL(pin, file) {
 
 async function fetchUpstream(pin, file) {
   const url = rawURL(pin, file);
-  const response = await fetch(url);
+  // Fail fast on a hung connection rather than riding out the CI job timeout.
+  const response = await fetch(url, { signal: AbortSignal.timeout(30_000) });
   if (!response.ok) {
     throw new Error(`GET ${url} -> HTTP ${response.status}`);
   }
@@ -60,19 +61,46 @@ async function fetchUpstream(pin, file) {
 const pin = JSON.parse(fs.readFileSync(pinPath, 'utf8'));
 const pinned = Object.keys(pin.files);
 
+// Bytes already downloaded this run (by --sync), so the remote half below never fetches twice.
+const upstreamCache = new Map();
+
 // --sync refreshes the copies before anything is checked, so a sync run ends green only if the
-// result also satisfies every check below.
+// result also satisfies every check below. It fetches and validates everything before writing
+// anything: a partial sync — some files rewritten, pin.json still holding the old digests — would
+// point the next contract:check's remediation text back at the sync that broke the tree.
 if (sync) {
   if (offline) {
     console.error('--sync needs the network; drop --offline.');
     process.exit(2);
   }
+  try {
+    await Promise.all(
+      pinned.map(async file => {
+        const upstream = await fetchUpstream(pin, file);
+        let parsed;
+        try {
+          parsed = JSON.parse(upstream.toString('utf8'));
+        } catch (error) {
+          throw new Error(`${file}: upstream copy is not valid JSON (${error.message})`);
+        }
+        if (typeof parsed.version !== 'number' || !Array.isArray(parsed.suites)) {
+          throw new Error(
+            `${file}: upstream copy lacks the version/suites fields the pin records`,
+          );
+        }
+        upstreamCache.set(file, { upstream, parsed });
+      }),
+    );
+  } catch (error) {
+    console.error(`contract:sync failed, leaving the tree untouched: ${error.message}`);
+    process.exit(2);
+  }
   for (const file of pinned) {
-    const upstream = await fetchUpstream(pin, file);
+    const { upstream, parsed } = upstreamCache.get(file);
     fs.writeFileSync(path.join(vectorDir, file), upstream);
     pin.files[file].sha256 = digest(upstream);
-    pin.files[file].version = JSON.parse(upstream.toString('utf8')).version;
-    pin.files[file].suites = JSON.parse(upstream.toString('utf8')).suites;
+    pin.files[file].version = parsed.version;
+    pin.files[file].suites = parsed.suites;
     notes.push(`synced ${file} from ${pin.ref.slice(0, 12)}`);
   }
   fs.writeFileSync(pinPath, `${JSON.stringify(pin, null, 2)}\n`);
@@ -115,7 +143,10 @@ for (const [file, expected] of Object.entries(pin.files)) {
   if (parsed.version !== expected.version) {
     fail(`${file}: carries version ${parsed.version} but pin.json records ${expected.version}`);
   }
-  if (parsed.suites.join() !== expected.suites.join()) {
+  const declaredSuites = Array.isArray(parsed.suites) ? parsed.suites : [];
+  if (!Array.isArray(parsed.suites)) {
+    fail(`${file}: declares no suites array, so its consumers cannot be accounted for`);
+  } else if (parsed.suites.join() !== (expected.suites ?? []).join()) {
     fail(`${file}: declares suites [${parsed.suites}] but pin.json records [${expected.suites}]`);
   }
 
@@ -123,7 +154,7 @@ for (const [file, expected] of Object.entries(pin.files)) {
   // for here — wired up, or pending with a reason. Silence is what lets a declared consumer look
   // like coverage it is not.
   const pendingSuites = Object.keys(expected.pending_suites ?? {});
-  for (const suite of parsed.suites.filter(name => name !== 'go')) {
+  for (const suite of declaredSuites.filter(name => name !== 'go')) {
     const wired = (expected.local_suites ?? []).includes(suite);
     const pending = pendingSuites.includes(suite);
     if (!wired && !pending) {
@@ -137,7 +168,7 @@ for (const [file, expected] of Object.entries(pin.files)) {
     }
   }
   for (const [suite, reason] of Object.entries(expected.pending_suites ?? {})) {
-    if (!parsed.suites.includes(suite)) {
+    if (!declaredSuites.includes(suite)) {
       fail(`${file}: pending suite "${suite}" is not one the file declares`);
     }
     if (typeof reason !== 'string' || reason.trim() === '') {
@@ -145,7 +176,7 @@ for (const [file, expected] of Object.entries(pin.files)) {
     }
   }
   for (const suite of expected.local_suites ?? []) {
-    if (!parsed.suites.includes(suite)) {
+    if (!declaredSuites.includes(suite)) {
       fail(`${file}: local suite "${suite}" is not one the file declares`);
     }
   }
@@ -156,12 +187,23 @@ if (offline) {
     'contract:check --offline: skipped the comparison against ' +
       `${pin.repo}@${pin.ref.slice(0, 12)}. Local digests only; run without --offline before merging.`,
   );
-} else if (failures.length === 0) {
-  for (const file of pinned) {
-    let upstream;
-    try {
-      upstream = await fetchUpstream(pin, file);
-    } catch (error) {
+} else {
+  // Upstream drift is independent of the local bookkeeping checks above, so it is reported even
+  // when they failed — one red run should carry the whole story, not ration it across two.
+  const fetched = await Promise.all(
+    pinned.map(async file => {
+      if (upstreamCache.has(file)) {
+        return { file, upstream: upstreamCache.get(file).upstream };
+      }
+      try {
+        return { file, upstream: await fetchUpstream(pin, file) };
+      } catch (error) {
+        return { file, error };
+      }
+    }),
+  );
+  for (const { file, upstream, error } of fetched) {
+    if (error) {
       // Never downgrade an unreachable upstream to a pass: an unchecked copy is the whole failure
       // mode this script exists for.
       fail(
@@ -170,7 +212,11 @@ if (offline) {
       );
       continue;
     }
-    if (!upstream.equals(fs.readFileSync(path.join(vectorDir, file)))) {
+    const localPath = path.join(vectorDir, file);
+    if (!fs.existsSync(localPath)) {
+      continue; // already reported as "pinned but not vendored" above
+    }
+    if (!upstream.equals(fs.readFileSync(localPath))) {
       fail(
         `${file}: differs from ${pin.repo}@${pin.ref.slice(0, 12)}:${pin.source_dir}/${file}. ` +
           'Re-vendor with `npm run contract:sync`, or move the pin if upstream moved on purpose.',

--- a/src/model/relay.ts
+++ b/src/model/relay.ts
@@ -63,6 +63,21 @@ export interface ErrorResponse {
   error?: string;
 }
 
+/**
+ * The relay class a client should act on. Only the exact literal 'foundation' is the foundation
+ * class; an absent, unrecognized, or differently-cased value is 'volunteer'. The strictness is
+ * load-bearing rather than incidental — the foundation class gates the WSS transport, so a value
+ * that merely resembles 'foundation' must never be read as it, and a future class name must
+ * degrade to the less-privileged side instead of being rejected.
+ *
+ * Keep in sync with the Kotlin `RelayDescriptor.normalizedNodeClass()`, the Swift
+ * `RelayDescriptor.normalizedNodeClass()`, and Go's `relay.EffectiveNodeClass`. The shared
+ * contract vectors in testdata/contract/relay_decode.json pin all four against the same rows.
+ */
+export function effectiveNodeClass(nodeClass: string | undefined): 'foundation' | 'volunteer' {
+  return nodeClass === 'foundation' ? 'foundation' : 'volunteer';
+}
+
 function isNotBlank(value: string): boolean {
   return value.trim().length > 0;
 }

--- a/src/net/exitNodeDirectory.ts
+++ b/src/net/exitNodeDirectory.ts
@@ -1,6 +1,6 @@
 import { displayName } from '../model/countryGeo';
 import type { ExitNodeRegion } from '../model/exitNode';
-import { orderedCandidates, serverTimeMs } from '../model/relay';
+import { effectiveNodeClass, orderedCandidates, serverTimeMs } from '../model/relay';
 import type { RelayDescriptor, RelayListResponse } from '../model/relay';
 
 /**
@@ -54,8 +54,7 @@ export async function loadExitNodeDirectory(
       id: relay.id,
       label: (relay.label ?? '').trim() || null,
       // Absent/unknown node_class collapses to 'volunteer', matching the native decoders.
-      nodeClass:
-        relay.node_class === 'foundation' ? ('foundation' as const) : ('volunteer' as const),
+      nodeClass: effectiveNodeClass(relay.node_class),
     };
     const existing = regionsByKey.get(key);
     if (existing) {

--- a/testdata/contract/broker_fronts.json
+++ b/testdata/contract/broker_fronts.json
@@ -1,0 +1,98 @@
+{
+  "version": 1,
+  "contract": "openrung-broker-fronts-v1",
+  "suites": ["go", "kotlin", "swift", "ts"],
+  "comment": "Snapshot of the advertised broker-front list and the order discovery races it in. Consumed by the four suites named in 'suites', but not symmetrically, and the asymmetry is the point rather than an omission. The Go suite (contract/broker_fronts_test.go) checks the whole snapshot — the list, the phase partition, the hostname-shape classification, and the candidate ordering — against brokerapi's DefaultBrokerURLs, BrokerCandidates, and EndpointUnboundBrokerFront, because brokerapi owns all of it. The Kotlin, Swift, and Jest suites in openrung-mobile-app own no racing at all: they hand native brokerapi a single primary and let Go race the built-in candidates. What they can check, and what the mobile suites are for, is that every front they hardcode (AppConfig.DEFAULT_BROKER_URLS on Android, AppConfig.defaultBrokerURL on iOS, AppConfig.DEFAULT_BROKER_URL in TypeScript) still appears in 'default_order' here — which is what catches a front rotated in one repo and not the other. They must not assert the phases or the candidate ordering, which they do not implement. A front that silently disappears from one client is a front that client cannot fall back to when the others are blocked, so an existing entry may only change together with a bump of 'version' here and in every vendored copy. Rotating or adding a front is exactly such a change.",
+  "scope_note": "'default_order' is the relay-directory control plane only. openrung-mobile-app's UPDATE_MANIFEST_URLS is a different channel with its own candidate list and its own check (npm run transport:check); do not conflate the two lists.",
+  "phase_note": "Discovery races the fronts in two phases. Phase 1 holds every front whose TLS connection authenticates that endpoint. Phase 2 starts only after every phase-1 front has failed, and holds fronts dialed without SNI onto a shared CDN edge whose certificate proves only 'an edge of this provider', never this endpoint — the Ed25519 relay-list signature is what makes them trustworthy, so they are tried last. A front is assigned to a phase by the shape of its hostname, not by matching this deployment's own endpoints, so a fork or a rotated endpoint is classified the same way.",
+  "default_order": [
+    "https://broker.openrung.org/",
+    "https://d2r7mdpyevvs1m.cloudfront.net/",
+    "https://cdn-edge-cxdnhsg2aadmaubj.z02.azurefd.net/"
+  ],
+  "phases": [
+    {
+      "phase": 1,
+      "name": "endpoint_bound",
+      "urls": [
+        "https://broker.openrung.org/",
+        "https://d2r7mdpyevvs1m.cloudfront.net/"
+      ]
+    },
+    {
+      "phase": 2,
+      "name": "endpoint_unbound",
+      "urls": [
+        "https://cdn-edge-cxdnhsg2aadmaubj.z02.azurefd.net/"
+      ]
+    }
+  ],
+  "classification": [
+    {"url": "https://broker.openrung.org/", "endpoint_unbound": false},
+    {"url": "https://d2r7mdpyevvs1m.cloudfront.net/", "endpoint_unbound": false, "note": "Dialed without SNI, but the CloudFront distribution still serves this deployment's own certificate, so the connection authenticates the endpoint."},
+    {"url": "https://cdn-edge-cxdnhsg2aadmaubj.z02.azurefd.net/", "endpoint_unbound": true},
+    {"url": "https://anything.azurefd.net/", "endpoint_unbound": true, "note": "Matched by hostname shape: the bare Front Door endpoint form."},
+    {"url": "https://anything.a01.azurefd.net/", "endpoint_unbound": true, "note": "And the zoned form, where the zone is a letter followed by two digits."},
+    {"url": "https://anything.zz9.azurefd.net/", "endpoint_unbound": false, "note": "Not a zone shape (two letters), so it is not the shared-edge path."},
+    {"url": "https://front-door.example.org/", "endpoint_unbound": false, "note": "A custom domain pointed at Front Door keeps ordinary SNI and ordinary verification."},
+    {"url": "https://anything.azurefd.net:8443/", "endpoint_unbound": false, "note": "Only the standard HTTPS port takes the shared-edge path."},
+    {"url": "http://anything.azurefd.net/", "endpoint_unbound": false, "note": "Cleartext broker URLs are refused outright before any front classification."},
+    {"url": "not a url", "endpoint_unbound": false}
+  ],
+  "candidates_note": "The discovery order a client builds from its configured primary. A genuine user override runs alone before the built-in fronts (override_first), so it cannot be starved by the defaults' stagger; merely persisting one of the defaults as the primary must not reorder anything.",
+  "candidates": [
+    {
+      "id": "no_primary",
+      "primary": "",
+      "expect_urls": [
+        "https://broker.openrung.org/",
+        "https://d2r7mdpyevvs1m.cloudfront.net/",
+        "https://cdn-edge-cxdnhsg2aadmaubj.z02.azurefd.net/"
+      ],
+      "expect_override_first": false
+    },
+    {
+      "id": "primary_is_a_default",
+      "primary": "https://broker.openrung.org/",
+      "expect_urls": [
+        "https://broker.openrung.org/",
+        "https://d2r7mdpyevvs1m.cloudfront.net/",
+        "https://cdn-edge-cxdnhsg2aadmaubj.z02.azurefd.net/"
+      ],
+      "expect_override_first": false
+    },
+    {
+      "id": "primary_is_a_default_with_whitespace",
+      "primary": "  https://broker.openrung.org/  ",
+      "expect_urls": [
+        "https://broker.openrung.org/",
+        "https://d2r7mdpyevvs1m.cloudfront.net/",
+        "https://cdn-edge-cxdnhsg2aadmaubj.z02.azurefd.net/"
+      ],
+      "expect_override_first": false
+    },
+    {
+      "id": "genuine_override",
+      "primary": "https://broker.example.org/",
+      "expect_urls": [
+        "https://broker.example.org/",
+        "https://broker.openrung.org/",
+        "https://d2r7mdpyevvs1m.cloudfront.net/",
+        "https://cdn-edge-cxdnhsg2aadmaubj.z02.azurefd.net/"
+      ],
+      "expect_override_first": true
+    },
+    {
+      "id": "default_without_trailing_slash",
+      "primary": "https://broker.openrung.org",
+      "note": "Comparison is on the exact string, not a normalized URL, so a default written without its trailing slash is treated as a genuine override and is attempted alone first. Pinned because it changes the discovery order, not just the list.",
+      "expect_urls": [
+        "https://broker.openrung.org",
+        "https://broker.openrung.org/",
+        "https://d2r7mdpyevvs1m.cloudfront.net/",
+        "https://cdn-edge-cxdnhsg2aadmaubj.z02.azurefd.net/"
+      ],
+      "expect_override_first": true
+    }
+  ]
+}

--- a/testdata/contract/classification.json
+++ b/testdata/contract/classification.json
@@ -1,0 +1,215 @@
+{
+  "version": 1,
+  "contract": "openrung-failure-classification-v1",
+  "suites": ["go", "kotlin", "swift"],
+  "comment": "Golden cross-repo vectors for the client failure-classification contract: the closed failure_reason token set the broker's 'Failure reasons' dashboard groups by. Consumed by the three suites named in 'suites' — Go (internal/clienttelemetry/contract_vectors_test.go, against internal/clienttelemetry/classify.go) in this repo, and Kotlin (FailureClassifierTest, against FailureClassifier.kt) and Swift (FailureClassifierTests, against FailureClassifier.swift) in openrung-mobile-app, which vendors this file and checks the vendored copy against a pinned openrung ref. Because the token of a deployed client cannot be renegotiated, an existing row may only change together with a bump of 'version' here and in every vendored copy, so the change lands in all three suites at once. Each row states the 'kind' of input it describes; 'kinds' below says which suites can construct that kind, and a row may narrow that further with its own 'suites' plus a 'note' saying why. A suite must run every row it claims and must not silently skip one.",
+  "no_typescript_note": "There is deliberately no 'ts' suite here, unlike the sibling relay_decode.json and broker_fronts.json. The React Native layer never sees a connect failure to classify: Android's VPN service, iOS's PacketTunnel, and native brokerapi own that path and report the token themselves, and openrung-mobile-app has no TypeScript classifier for a Jest suite to run these rows against. Adding one would mean writing a fourth classifier, not wiring up an existing one. The Go suite checks that every suite listed in 'suites' claims at least one row, so a suite named here but consuming nothing fails rather than passing vacuously.",
+  "windows_note": "Rows with platform 'windows' carry raw Winsock numbers. Only a Windows network stack produces them, so the Kotlin and Swift suites skip them. The Go classifier matches them on every platform — they sit far above every errno a POSIX kernel returns (Linux tops out at 133, darwin at 106), so they cannot collide with a real POSIX errno — which is what lets CI exercise these rows on Linux and macOS. Classification is by numeric code only, never by message text: Windows localizes its socket error strings.",
+  "tokens": [
+    "",
+    "cancelled",
+    "timeout",
+    "no_relays_available",
+    "relay_not_in_list",
+    "no_relay_in_country",
+    "no_usable_relay",
+    "rate_limited",
+    "connection_refused",
+    "connection_reset",
+    "network_unreachable",
+    "dns_failure",
+    "tls_handshake",
+    "permission_denied",
+    "process_exited",
+    "unknown",
+    "wss_transport_failed",
+    "ws_upgrade",
+    "http_401",
+    "http_403",
+    "http_421",
+    "http_502",
+    "http_503",
+    "http_other",
+    "ws_subprotocol",
+    "dns_bogon",
+    "tls_reset",
+    "response_reset",
+    "tls_not_tls",
+    "cert_expired",
+    "cert_verify",
+    "tls_alert",
+    "tcp_timeout",
+    "tls_timeout",
+    "response_timeout",
+    "handshake_timeout",
+    "unclassified"
+  ],
+  "token_patterns": [
+    "^http_[0-9]{3}$"
+  ],
+  "errno_pair_exceptions_note": "Errno rows pair one-to-one by default: R names P and P names R back. A row that points at a pair already spoken for is the exception and must be listed here with a reason, because an unrestricted many-to-one pairing would let a new errno row hide behind any existing pair carrying the same token — add ENETDOWN pointing at errno_wsaenetunreach and both the pair check and the token-set check pass while WSAENETDOWN goes unmapped. Requiring the collapse to be declared here makes that a visible edit to a shared table rather than one inconspicuous field on a new row.",
+  "errno_pair_exceptions": [
+    {
+      "id": "errno_eperm",
+      "defers_to": "errno_eacces",
+      "reason": "Winsock has no distinct socket EPERM; WSAEACCES covers what POSIX splits between EACCES and EPERM, so both POSIX rows collapse onto the one Windows row."
+    },
+    {
+      "id": "errno_econnrefused_wrapped",
+      "defers_to": "errno_econnrefused",
+      "reason": "Not a distinct condition: the same errno as errno_econnrefused, wrapped, to prove the chain is walked. It shares that row's Windows counterpart rather than needing one of its own."
+    }
+  ],
+  "kinds": {
+    "none": {
+      "suites": ["go", "kotlin"],
+      "input": "{}",
+      "description": "No error at all. Swift's classify() takes a non-optional Error and cannot express it."
+    },
+    "cancellation": {
+      "suites": ["go", "kotlin", "swift"],
+      "input": "{wrapped: bool} — when wrapped, the suite nests the cancellation inside a generic wrapper error and must still get the same token.",
+      "description": "Local intent: the user stopped the connect, or the enclosing task/coroutine was cancelled."
+    },
+    "deadline": {
+      "suites": ["go"],
+      "input": "{}",
+      "description": "The connect context's own deadline fired (context.DeadlineExceeded). Kotlin and Swift have no distinct type for it — their platforms raise the ordinary timeout error, covered by the 'timeout' kind — and Kotlin's coroutine timeout is a CancellationException, which is 'cancelled' by design."
+    },
+    "selection": {
+      "suites": ["go", "kotlin", "swift"],
+      "input": "{sentinel: string} — the relay-selection sentinel the connect pipeline raised.",
+      "description": "Relay selection failed before any socket was opened. Distinct tokens so the dashboard can tell 'broker gave nothing' from 'none usable' from a bad target id/country."
+    },
+    "http_status": {
+      "suites": ["go", "kotlin", "swift"],
+      "input": "{status: int} — the broker/CDN HTTP status carried by the error.",
+      "description": "A broker request came back with a non-2xx status. 429 is its own token; every other status is interpolated as http_<status>."
+    },
+    "errno": {
+      "suites": ["go", "kotlin", "swift"],
+      "input": "{symbol: string, code: int} — code is present only for platform 'windows'; POSIX numbers differ per kernel, so POSIX rows name the symbol and each suite resolves it locally.",
+      "description": "A socket-level failure surfacing a raw errno. Every errno row carries 'pair': the id of the row on the other platform that describes the same underlying condition, which must expect the same token. Pairing is many-to-one where the platforms disagree on granularity (EACCES and EPERM both pair with WSAEACCES). The Go suite checks the pairing, so a Winsock code added — or forgotten — without its POSIX counterpart fails there rather than becoming a silent per-platform divergence in the field."
+    },
+    "dns": {
+      "suites": ["go", "kotlin", "swift"],
+      "input": "{subkind: 'not_found'|'timeout'}",
+      "description": "Name resolution failed. Checked before the generic timeout rule so a name-lookup timeout keeps the more actionable token."
+    },
+    "tls": {
+      "suites": ["go", "kotlin", "swift"],
+      "input": "{subkind: 'not_tls'|'unknown_authority'|'hostname_mismatch'|'cert_expired'}",
+      "description": "TLS handshake or certificate rejection. The client taxonomy collapses every shape to one token; only wsscore's WSS taxonomy splits them further."
+    },
+    "permission": {
+      "suites": ["go", "kotlin", "swift"],
+      "input": "{subkind: 'os_permission'}",
+      "description": "The OS refused the operation: revoked VPN consent, or a denied tunnel-device open. EACCES/EPERM are covered as errno rows instead."
+    },
+    "process_exit": {
+      "suites": ["go", "kotlin", "swift"],
+      "input": "{}",
+      "description": "The tunnel engine died on arrival — a sing-box subprocess on desktop, the embedded libbox/sing-box engine on mobile."
+    },
+    "timeout": {
+      "suites": ["go", "kotlin", "swift"],
+      "input": "{subkind: 'io_timeout'}",
+      "description": "A generic i/o timeout that carries no errno, matched only after every typed rule above so a refused or reset dial is never mislabeled."
+    },
+    "unrecognized": {
+      "suites": ["go", "kotlin", "swift"],
+      "input": "{message: string}",
+      "description": "An error matching no rule. The residual must stay 'unknown' — the dashboard measures the ladder's coverage by its share."
+    },
+    "wss_reason": {
+      "suites": ["go"],
+      "input": "{reason: string} — a token as produced by wsscore's dial classifier.",
+      "description": "Projection of wsscore's own closed WSS taxonomy (wsscore/README.md) through the consumer-side allowlist: a recognized token passes through verbatim, anything else degrades to wss_transport_failed rather than reaching telemetry. Go-only: on iOS the native WSS error already carries wsscore's token, and Android projects brokerapi's bounded failure kinds instead."
+    }
+  },
+  "cases": [
+    {"id": "none", "kind": "none", "input": {}, "expect": ""},
+
+    {"id": "cancelled", "kind": "cancellation", "input": {"wrapped": false}, "expect": "cancelled"},
+    {"id": "cancelled_wrapped", "kind": "cancellation", "input": {"wrapped": true}, "expect": "cancelled"},
+
+    {"id": "deadline_exceeded", "kind": "deadline", "input": {}, "expect": "timeout"},
+
+    {"id": "selection_no_relays_available", "kind": "selection", "input": {"sentinel": "no_relays_available"}, "expect": "no_relays_available", "suites": ["go", "kotlin"], "note": "iOS has no sentinel for an empty broker list: PacketTunnelError.allRelaysFailed covers it and reports no_usable_relay."},
+    {"id": "selection_relay_not_in_list", "kind": "selection", "input": {"sentinel": "relay_not_in_list"}, "expect": "relay_not_in_list"},
+    {"id": "selection_no_relay_in_country", "kind": "selection", "input": {"sentinel": "no_relay_in_country"}, "expect": "no_relay_in_country"},
+    {"id": "selection_no_usable_relay", "kind": "selection", "input": {"sentinel": "no_usable_relay"}, "expect": "no_usable_relay"},
+
+    {"id": "http_429", "kind": "http_status", "input": {"status": 429}, "expect": "rate_limited"},
+    {"id": "http_403", "kind": "http_status", "input": {"status": 403}, "expect": "http_403"},
+    {"id": "http_451", "kind": "http_status", "input": {"status": 451}, "expect": "http_451"},
+    {"id": "http_500", "kind": "http_status", "input": {"status": 500}, "expect": "http_500"},
+    {"id": "http_503", "kind": "http_status", "input": {"status": 503}, "expect": "http_503"},
+
+    {"id": "errno_econnrefused", "kind": "errno", "pair": "errno_wsaeconnrefused", "platform": "posix", "input": {"symbol": "ECONNREFUSED"}, "expect": "connection_refused"},
+    {"id": "errno_econnrefused_wrapped", "kind": "errno", "pair": "errno_wsaeconnrefused", "platform": "posix", "input": {"symbol": "ECONNREFUSED", "wrapped": true}, "expect": "connection_refused", "note": "Pins that the whole error chain is inspected: the suite nests the errno in whatever its connect pipeline wraps it with."},
+    {"id": "errno_econnreset", "kind": "errno", "pair": "errno_wsaeconnreset", "platform": "posix", "input": {"symbol": "ECONNRESET"}, "expect": "connection_reset"},
+    {"id": "errno_enetunreach", "kind": "errno", "pair": "errno_wsaenetunreach", "platform": "posix", "input": {"symbol": "ENETUNREACH"}, "expect": "network_unreachable"},
+    {"id": "errno_ehostunreach", "kind": "errno", "pair": "errno_wsaehostunreach", "platform": "posix", "input": {"symbol": "EHOSTUNREACH"}, "expect": "network_unreachable"},
+    {"id": "errno_etimedout", "kind": "errno", "pair": "errno_wsaetimedout", "platform": "posix", "input": {"symbol": "ETIMEDOUT"}, "expect": "timeout"},
+    {"id": "errno_eacces", "kind": "errno", "pair": "errno_wsaeacces", "platform": "posix", "input": {"symbol": "EACCES"}, "expect": "permission_denied"},
+    {"id": "errno_eperm", "kind": "errno", "pair": "errno_wsaeacces", "platform": "posix", "input": {"symbol": "EPERM"}, "expect": "permission_denied"},
+    {"id": "errno_epipe", "kind": "errno", "pair": "errno_wsaeconnaborted", "platform": "posix", "input": {"symbol": "EPIPE"}, "expect": "unknown", "note": "Deliberately unmapped. A write to a connection the peer already tore down is indistinguishable here from an ordinary shutdown race, and the taxonomy has no broken-pipe token; pinned so its Winsock twin (WSAECONNABORTED) stays unmapped too."},
+
+    {"id": "errno_wsaeconnrefused", "kind": "errno", "pair": "errno_econnrefused", "platform": "windows", "input": {"symbol": "WSAECONNREFUSED", "code": 10061}, "expect": "connection_refused"},
+    {"id": "errno_wsaeconnreset", "kind": "errno", "pair": "errno_econnreset", "platform": "windows", "input": {"symbol": "WSAECONNRESET", "code": 10054}, "expect": "connection_reset"},
+    {"id": "errno_wsaenetunreach", "kind": "errno", "pair": "errno_enetunreach", "platform": "windows", "input": {"symbol": "WSAENETUNREACH", "code": 10051}, "expect": "network_unreachable"},
+    {"id": "errno_wsaehostunreach", "kind": "errno", "pair": "errno_ehostunreach", "platform": "windows", "input": {"symbol": "WSAEHOSTUNREACH", "code": 10065}, "expect": "network_unreachable"},
+    {"id": "errno_wsaetimedout", "kind": "errno", "pair": "errno_etimedout", "platform": "windows", "input": {"symbol": "WSAETIMEDOUT", "code": 10060}, "expect": "timeout", "note": "Go's syscall.Errno.Timeout on Windows reports true only for its own invented EAGAIN/EWOULDBLOCK/ETIMEDOUT, so this needs an explicit rule or it lands in 'unknown'."},
+    {"id": "errno_wsaeacces", "kind": "errno", "pair": "errno_eacces", "platform": "windows", "input": {"symbol": "WSAEACCES", "code": 10013}, "expect": "permission_denied", "note": "The Winsock counterpart of errno_eacces: a WFP callout driver or an endpoint-security policy refusing the connect. Go's syscall.Errno.Is maps ERROR_ACCESS_DENIED and its own invented EACCES/EPERM to os.ErrPermission, but not this, so it needs an explicit rule at the permission rung or the same block reports permission_denied on POSIX and 'unknown' on Windows."},
+    {"id": "errno_wsaeconnaborted", "kind": "errno", "pair": "errno_epipe", "platform": "windows", "input": {"symbol": "WSAECONNABORTED", "code": 10053}, "expect": "unknown", "note": "Unmapped on purpose, matching errno_epipe: mapping the Winsock code alone would make the same broken connection report different tokens per platform."},
+
+    {"id": "dns_not_found", "kind": "dns", "input": {"subkind": "not_found"}, "expect": "dns_failure"},
+    {"id": "dns_timeout", "kind": "dns", "input": {"subkind": "timeout"}, "expect": "dns_failure", "suites": ["go"], "note": "Pins DNS-before-timeout ordering. Android and iOS cannot construct it: their resolvers report a lookup timeout as the ordinary timeout error, not as a DNS error."},
+
+    {"id": "tls_not_tls", "kind": "tls", "input": {"subkind": "not_tls"}, "expect": "tls_handshake"},
+    {"id": "tls_unknown_authority", "kind": "tls", "input": {"subkind": "unknown_authority"}, "expect": "tls_handshake"},
+    {"id": "tls_hostname_mismatch", "kind": "tls", "input": {"subkind": "hostname_mismatch"}, "expect": "tls_handshake"},
+    {"id": "tls_cert_expired", "kind": "tls", "input": {"subkind": "cert_expired"}, "expect": "tls_handshake", "note": "The WSS taxonomy splits an expired chain out as cert_expired (it overwhelmingly means a wrong device clock); the client taxonomy does not."},
+
+    {"id": "permission_os_denied", "kind": "permission", "input": {"subkind": "os_permission"}, "expect": "permission_denied"},
+
+    {"id": "process_exited", "kind": "process_exit", "input": {}, "expect": "process_exited"},
+
+    {"id": "timeout_io", "kind": "timeout", "input": {"subkind": "io_timeout"}, "expect": "timeout"},
+
+    {"id": "unrecognized", "kind": "unrecognized", "input": {"message": "something odd"}, "expect": "unknown"},
+
+    {"id": "wss_ws_upgrade", "kind": "wss_reason", "input": {"reason": "ws_upgrade"}, "expect": "ws_upgrade"},
+    {"id": "wss_http_401", "kind": "wss_reason", "input": {"reason": "http_401"}, "expect": "http_401"},
+    {"id": "wss_http_403", "kind": "wss_reason", "input": {"reason": "http_403"}, "expect": "http_403"},
+    {"id": "wss_http_421", "kind": "wss_reason", "input": {"reason": "http_421"}, "expect": "http_421"},
+    {"id": "wss_rate_limited", "kind": "wss_reason", "input": {"reason": "rate_limited"}, "expect": "rate_limited"},
+    {"id": "wss_http_502", "kind": "wss_reason", "input": {"reason": "http_502"}, "expect": "http_502"},
+    {"id": "wss_http_503", "kind": "wss_reason", "input": {"reason": "http_503"}, "expect": "http_503"},
+    {"id": "wss_http_other", "kind": "wss_reason", "input": {"reason": "http_other"}, "expect": "http_other"},
+    {"id": "wss_ws_subprotocol", "kind": "wss_reason", "input": {"reason": "ws_subprotocol"}, "expect": "ws_subprotocol"},
+    {"id": "wss_dns_bogon", "kind": "wss_reason", "input": {"reason": "dns_bogon"}, "expect": "dns_bogon"},
+    {"id": "wss_dns_failure", "kind": "wss_reason", "input": {"reason": "dns_failure"}, "expect": "dns_failure"},
+    {"id": "wss_cancelled", "kind": "wss_reason", "input": {"reason": "cancelled"}, "expect": "cancelled"},
+    {"id": "wss_connection_refused", "kind": "wss_reason", "input": {"reason": "connection_refused"}, "expect": "connection_refused"},
+    {"id": "wss_network_unreachable", "kind": "wss_reason", "input": {"reason": "network_unreachable"}, "expect": "network_unreachable"},
+    {"id": "wss_connection_reset", "kind": "wss_reason", "input": {"reason": "connection_reset"}, "expect": "connection_reset"},
+    {"id": "wss_tls_reset", "kind": "wss_reason", "input": {"reason": "tls_reset"}, "expect": "tls_reset"},
+    {"id": "wss_response_reset", "kind": "wss_reason", "input": {"reason": "response_reset"}, "expect": "response_reset"},
+    {"id": "wss_tls_not_tls", "kind": "wss_reason", "input": {"reason": "tls_not_tls"}, "expect": "tls_not_tls"},
+    {"id": "wss_cert_expired", "kind": "wss_reason", "input": {"reason": "cert_expired"}, "expect": "cert_expired"},
+    {"id": "wss_cert_verify", "kind": "wss_reason", "input": {"reason": "cert_verify"}, "expect": "cert_verify"},
+    {"id": "wss_tls_alert", "kind": "wss_reason", "input": {"reason": "tls_alert"}, "expect": "tls_alert"},
+    {"id": "wss_tls_handshake", "kind": "wss_reason", "input": {"reason": "tls_handshake"}, "expect": "tls_handshake"},
+    {"id": "wss_tcp_timeout", "kind": "wss_reason", "input": {"reason": "tcp_timeout"}, "expect": "tcp_timeout"},
+    {"id": "wss_tls_timeout", "kind": "wss_reason", "input": {"reason": "tls_timeout"}, "expect": "tls_timeout"},
+    {"id": "wss_response_timeout", "kind": "wss_reason", "input": {"reason": "response_timeout"}, "expect": "response_timeout"},
+    {"id": "wss_handshake_timeout", "kind": "wss_reason", "input": {"reason": "handshake_timeout"}, "expect": "handshake_timeout"},
+    {"id": "wss_unclassified", "kind": "wss_reason", "input": {"reason": "unclassified"}, "expect": "unclassified"},
+    {"id": "wss_degrade_empty", "kind": "wss_reason", "input": {"reason": ""}, "expect": "wss_transport_failed"},
+    {"id": "wss_degrade_future_token", "kind": "wss_reason", "input": {"reason": "future_token"}, "expect": "wss_transport_failed"},
+    {"id": "wss_degrade_unknown", "kind": "wss_reason", "input": {"reason": "unknown"}, "expect": "wss_transport_failed", "note": "'unknown' is not a wsscore token and must stay reserved for pre-taxonomy builds, so it degrades like any unrecognized value."},
+    {"id": "wss_degrade_hostname", "kind": "wss_reason", "input": {"reason": "d111111abcdef8.cloudfront.net"}, "expect": "wss_transport_failed", "note": "A front hostname must never reach telemetry verbatim, whatever a future wsscore build puts in the field."}
+  ]
+}

--- a/testdata/contract/pin.json
+++ b/testdata/contract/pin.json
@@ -1,0 +1,57 @@
+{
+  "comment": "Pin for the contract vectors vendored beside this file. They are copies of contract/vectors/ in openrung/openrung, which is their only source of truth: edit them THERE, then re-vendor here with `npm run contract:sync`. `npm run contract:check` verifies both halves — that the local bytes still hash to the digests recorded here, and that they are byte-identical to the pinned openrung ref — so a copy that drifts from upstream fails instead of quietly testing this repo against stale expectations.",
+  "repo": "openrung/openrung",
+  "source_dir": "contract/vectors",
+  "ref": "653e3b6294ede95ad64a4c9f0d3be17a5d5a308d",
+  "ref_note": "The merge commit on openrung/openrung's main that carries contract/vectors (PR #138 introduced the directory, PR #139 reworked the relay-decode rejection codes). Move this to a newer main commit only together with `npm run contract:sync`, which re-vendors the files and rewrites the digests below to match.",
+  "suites_note": "'suites' is copied from each vector file and says which suites the contract expects to consume it. 'local_suites' is what THIS repo actually runs today, and 'pending_suites' is the difference, with a reason. contract:check fails when local_suites plus pending_suites does not account for every non-go suite the file declares, so an unwired consumer stays visible instead of reading as coverage.",
+  "files": {
+    "classification.json": {
+      "sha256": "4df7f767c4f3e47c090a7d7f074758faf6ca6fa31f87ee9e3cc1da1b6ca0118f",
+      "version": 1,
+      "suites": [
+        "go",
+        "kotlin",
+        "swift"
+      ],
+      "local_suites": [
+        "kotlin",
+        "swift"
+      ],
+      "pending_suites": {}
+    },
+    "relay_decode.json": {
+      "sha256": "7ba978939f90c6b99937b72aa95da8556e00d6b35f39d130eaec8edabcee3c46",
+      "version": 2,
+      "suites": [
+        "go",
+        "kotlin",
+        "swift",
+        "ts"
+      ],
+      "local_suites": [
+        "ts"
+      ],
+      "pending_suites": {
+        "kotlin": "RelayDescriptor.kt and RelaySelector.kt decode and filter the directory and are in scope for these vectors; wiring them is follow-up work, not a claim that the Kotlin decoder is exempt.",
+        "swift": "Same for RelayDescriptor.swift and RelaySelector.swift."
+      }
+    },
+    "broker_fronts.json": {
+      "sha256": "76644cb2bfdd7e25e1debe623f058c79b35dd15376f5d538ee42f026055235dc",
+      "version": 1,
+      "suites": [
+        "go",
+        "kotlin",
+        "swift",
+        "ts"
+      ],
+      "local_suites": [
+        "kotlin",
+        "swift",
+        "ts"
+      ],
+      "pending_suites": {}
+    }
+  }
+}

--- a/testdata/contract/relay_decode.json
+++ b/testdata/contract/relay_decode.json
@@ -1,0 +1,536 @@
+{
+  "version": 2,
+  "contract": "openrung-relay-decode-v1",
+  "suites": ["go", "kotlin", "swift", "ts"],
+  "comment": "Golden cross-repo vectors for decoding a signed relay directory into a client relay model, and for the usability filter applied to it. Consumed by the four suites named in 'suites' — Go (contract/relay_decode_test.go, against brokerapi's wire validation, internal/relay's model, and internal/client's selector) in this repo, and Kotlin, Swift, and Jest (src/model/relay.ts) in openrung-mobile-app, which vendors this file and checks the vendored copy against a pinned openrung ref. A decoder that drops or renames a field here silently changes which relays a deployed client will try, so an existing row may only change together with a bump of 'version' here and in every vendored copy, so the change lands in all four suites at once.",
+  "signing_note": "The bodies carry the in-body signing envelope (not_after, key_id, channel, limit) because those fields live INSIDE the signed body — in plain headers an attacker could rewrite them. They carry no real signature: the production signing key is offline, so no vector can be validly signed. Signature verification is brokerapi's own concern and is covered by its tests; these vectors pin what a client does with a body that has already been verified, which is exactly the boundary the mobile clients see (native brokerapi verifies, then hands the projected snapshot to Kotlin/Swift/TypeScript).",
+  "expectation_note": "In 'expect', null means the field is absent from the wire and the decoder must produce its own no-value representation (Go's zero value, TypeScript's undefined, a Kotlin/Swift null). 'effective_node_class' is the interpretation rule rather than a decoded field, and it is deliberately strict: only the exact literal 'foundation' is the foundation class, and an absent, unrecognized, or differently-cased value is 'volunteer'. That direction is load-bearing — the foundation class gates the WSS transport — so a value that merely resembles 'foundation' must never be read as it. The rule applies when reading a signed descriptor; do not implement it with an ingest-side validator that rejects unrecognized classes instead of degrading them (in this repo that is relay.NormalizeNodeClass, and relay.EffectiveNodeClass is the read-side rule). A suite asserts the expected keys its own model carries and ignores the rest — the TypeScript model, for one, exposes the version only under the legacy 'volunteer_version' name. 'relay_version' and 'volunteer_version' always carry the same value on the wire today; a body with only 'relay_version' is rejected outright (see the invalid case 'relay_version_without_alias'), so dropping the legacy alias is a breaking wire change, not a decoder change, and that is why no valid case pins a precedence between them.",
+  "cases": [
+    {
+      "id": "api_two_relays",
+      "description": "An ordinary signed API-channel page: one direct Foundation relay with geo and a WSS front, one tunnel volunteer relay behind the hub with punch fields, no geo, and only the legacy version alias.",
+      "body": {
+        "count": 2,
+        "server_time": "2026-08-17T12:00:00Z",
+        "not_after": "2026-08-17T12:30:00Z",
+        "key_id": "0f1a2b3c4d5e6f70",
+        "channel": "api",
+        "limit": 5,
+        "relays": [
+          {
+            "id": "relay_0883de4588ee3af0f925ec7e3ce18aa7",
+            "label": "kind-otter",
+            "public_host": "203.0.113.10",
+            "public_port": 443,
+            "city": "Seoul",
+            "country": "South Korea",
+            "country_code": "KR",
+            "latitude": 37.5665,
+            "longitude": 126.978,
+            "node_class": "foundation",
+            "protocol": "vless-reality-vision",
+            "client_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "reality_public_key": "hSN7wJowfoOdmnbRDW9BC9BXGCyPTM6PqFOQqUFvvXo",
+            "short_id": "0123abcd",
+            "server_name": "www.cloudflare.com",
+            "flow": "xtls-rprx-vision",
+            "exit_mode": "direct",
+            "max_sessions": 64,
+            "max_mbps": 200,
+            "relay_version": "0.4.1",
+            "volunteer_version": "0.4.1",
+            "transport": "direct",
+            "wss_fronts": [
+              {"id": "front-a", "url": "https://cdn-edge-a.example.net/api/v1/wss-bridge", "protocol_version": 1}
+            ],
+            "registered_at": "2026-08-17T09:00:00Z",
+            "last_heartbeat_at": "2026-08-17T11:59:00Z",
+            "expires_at": "2026-08-17T12:10:00Z"
+          },
+          {
+            "id": "relay_9c1f4d2ba07e5188cc31a6d0f4e27b53",
+            "public_host": "198.51.100.20",
+            "public_port": 8443,
+            "node_class": "volunteer",
+            "protocol": "vless-reality-vision",
+            "client_id": "b1e9f0c2-3d4a-4b5c-8d6e-7f8091a2b3c4",
+            "reality_public_key": "Q1RKb2hOZFhKbGJHRjVJRlJsYzNRZ1MyVjVJREF3TVRJ",
+            "short_id": "beef1234",
+            "server_name": "www.microsoft.com",
+            "flow": "xtls-rprx-vision",
+            "exit_mode": "direct",
+            "max_sessions": 8,
+            "max_mbps": 20,
+            "volunteer_version": "0.3.9",
+            "transport": "tunnel",
+            "punch_capable": true,
+            "punch_endpoint": "https://198.51.100.20:9444",
+            "registered_at": "2026-08-17T10:30:00Z",
+            "last_heartbeat_at": "2026-08-17T11:58:00Z",
+            "expires_at": "2026-08-17T12:05:00Z"
+          }
+        ]
+      },
+      "expect": {
+        "count": 2,
+        "server_time": "2026-08-17T12:00:00Z",
+        "not_after": "2026-08-17T12:30:00Z",
+        "key_id": "0f1a2b3c4d5e6f70",
+        "channel": "api",
+        "limit": 5,
+        "relays": [
+          {
+            "id": "relay_0883de4588ee3af0f925ec7e3ce18aa7",
+            "label": "kind-otter",
+            "public_host": "203.0.113.10",
+            "public_port": 443,
+            "city": "Seoul",
+            "country": "South Korea",
+            "country_code": "KR",
+            "latitude": 37.5665,
+            "longitude": 126.978,
+            "node_class": "foundation",
+            "effective_node_class": "foundation",
+            "protocol": "vless-reality-vision",
+            "client_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "reality_public_key": "hSN7wJowfoOdmnbRDW9BC9BXGCyPTM6PqFOQqUFvvXo",
+            "short_id": "0123abcd",
+            "server_name": "www.cloudflare.com",
+            "flow": "xtls-rprx-vision",
+            "exit_mode": "direct",
+            "max_sessions": 64,
+            "max_mbps": 200,
+            "relay_version": "0.4.1",
+            "volunteer_version": "0.4.1",
+            "transport": "direct",
+            "punch_capable": null,
+            "punch_endpoint": null,
+            "wss_fronts": [
+              {"id": "front-a", "url": "https://cdn-edge-a.example.net/api/v1/wss-bridge", "protocol_version": 1}
+            ],
+            "registered_at": "2026-08-17T09:00:00Z",
+            "last_heartbeat_at": "2026-08-17T11:59:00Z",
+            "expires_at": "2026-08-17T12:10:00Z"
+          },
+          {
+            "id": "relay_9c1f4d2ba07e5188cc31a6d0f4e27b53",
+            "label": null,
+            "public_host": "198.51.100.20",
+            "public_port": 8443,
+            "city": null,
+            "country": null,
+            "country_code": null,
+            "latitude": null,
+            "longitude": null,
+            "node_class": "volunteer",
+            "effective_node_class": "volunteer",
+            "protocol": "vless-reality-vision",
+            "client_id": "b1e9f0c2-3d4a-4b5c-8d6e-7f8091a2b3c4",
+            "reality_public_key": "Q1RKb2hOZFhKbGJHRjVJRlJsYzNRZ1MyVjVJREF3TVRJ",
+            "short_id": "beef1234",
+            "server_name": "www.microsoft.com",
+            "flow": "xtls-rprx-vision",
+            "exit_mode": "direct",
+            "max_sessions": 8,
+            "max_mbps": 20,
+            "relay_version": "0.3.9",
+            "volunteer_version": "0.3.9",
+            "transport": "tunnel",
+            "punch_capable": true,
+            "punch_endpoint": "https://198.51.100.20:9444",
+            "wss_fronts": null,
+            "registered_at": "2026-08-17T10:30:00Z",
+            "last_heartbeat_at": "2026-08-17T11:58:00Z",
+            "expires_at": "2026-08-17T12:05:00Z"
+          }
+        ]
+      },
+      "usability": [
+        {
+          "now": "2026-08-17T12:00:00Z",
+          "note": "Broker server_time: freshness is judged against it, never the device clock.",
+          "usable_ids": [
+            "relay_0883de4588ee3af0f925ec7e3ce18aa7",
+            "relay_9c1f4d2ba07e5188cc31a6d0f4e27b53"
+          ],
+          "first_usable_id": "relay_0883de4588ee3af0f925ec7e3ce18aa7"
+        },
+        {
+          "now": "2026-08-17T12:07:00Z",
+          "note": "The tunnel relay's lease has lapsed; expiry is exclusive, judged against the supplied instant.",
+          "usable_ids": ["relay_0883de4588ee3af0f925ec7e3ce18aa7"],
+          "first_usable_id": "relay_0883de4588ee3af0f925ec7e3ce18aa7"
+        },
+        {
+          "now": "2026-08-17T12:10:00Z",
+          "note": "expires_at exactly equal to now is NOT usable.",
+          "usable_ids": [],
+          "first_usable_id": null
+        }
+      ]
+    },
+    {
+      "id": "unusable_mix",
+      "description": "Every way a schema-valid relay can still fail the usability filter, plus one relay that passes. Broker order is preserved: the filter is score-free and never reorders.",
+      "body": {
+        "count": 8,
+        "server_time": "2026-08-17T12:00:00Z",
+        "not_after": "2026-08-17T12:30:00Z",
+        "key_id": "0f1a2b3c4d5e6f70",
+        "channel": "api",
+        "limit": 20,
+        "relays": [
+          {
+            "id": "relay_expired", "public_host": "203.0.113.11", "public_port": 443,
+            "protocol": "vless-reality-vision", "client_id": "11111111-1111-4111-8111-111111111111",
+            "reality_public_key": "key11", "short_id": "aa01", "server_name": "www.bing.com",
+            "flow": "xtls-rprx-vision", "exit_mode": "direct", "max_sessions": 8, "max_mbps": 20,
+            "volunteer_version": "0.4.1", "registered_at": "2026-08-17T09:00:00Z",
+            "last_heartbeat_at": "2026-08-17T11:00:00Z", "expires_at": "2026-08-17T11:55:00Z"
+          },
+          {
+            "id": "relay_wrong_protocol", "public_host": "203.0.113.12", "public_port": 443,
+            "protocol": "vless-reality", "client_id": "22222222-2222-4222-8222-222222222222",
+            "reality_public_key": "key22", "short_id": "aa02", "server_name": "www.bing.com",
+            "flow": "xtls-rprx-vision", "exit_mode": "direct", "max_sessions": 8, "max_mbps": 20,
+            "volunteer_version": "0.4.1", "registered_at": "2026-08-17T09:00:00Z",
+            "last_heartbeat_at": "2026-08-17T11:59:00Z", "expires_at": "2026-08-17T12:10:00Z"
+          },
+          {
+            "id": "relay_wrong_flow", "public_host": "203.0.113.13", "public_port": 443,
+            "protocol": "vless-reality-vision", "client_id": "33333333-3333-4333-8333-333333333333",
+            "reality_public_key": "key33", "short_id": "aa03", "server_name": "www.bing.com",
+            "flow": "", "exit_mode": "direct", "max_sessions": 8, "max_mbps": 20,
+            "volunteer_version": "0.4.1", "registered_at": "2026-08-17T09:00:00Z",
+            "last_heartbeat_at": "2026-08-17T11:59:00Z", "expires_at": "2026-08-17T12:10:00Z"
+          },
+          {
+            "id": "relay_dedicated_exit", "public_host": "203.0.113.14", "public_port": 443,
+            "protocol": "vless-reality-vision", "client_id": "44444444-4444-4444-8444-444444444444",
+            "reality_public_key": "key44", "short_id": "aa04", "server_name": "www.bing.com",
+            "flow": "xtls-rprx-vision", "exit_mode": "dedicated", "max_sessions": 8, "max_mbps": 20,
+            "volunteer_version": "0.4.1", "registered_at": "2026-08-17T09:00:00Z",
+            "last_heartbeat_at": "2026-08-17T11:59:00Z", "expires_at": "2026-08-17T12:10:00Z"
+          },
+          {
+            "id": "relay_blank_host", "public_host": "", "public_port": 443,
+            "protocol": "vless-reality-vision", "client_id": "55555555-5555-4555-8555-555555555555",
+            "reality_public_key": "key55", "short_id": "aa05", "server_name": "www.bing.com",
+            "flow": "xtls-rprx-vision", "exit_mode": "direct", "max_sessions": 8, "max_mbps": 20,
+            "volunteer_version": "0.4.1", "registered_at": "2026-08-17T09:00:00Z",
+            "last_heartbeat_at": "2026-08-17T11:59:00Z", "expires_at": "2026-08-17T12:10:00Z"
+          },
+          {
+            "id": "relay_zero_port", "public_host": "203.0.113.16", "public_port": 0,
+            "protocol": "vless-reality-vision", "client_id": "66666666-6666-4666-8666-666666666666",
+            "reality_public_key": "key66", "short_id": "aa06", "server_name": "www.bing.com",
+            "flow": "xtls-rprx-vision", "exit_mode": "direct", "max_sessions": 8, "max_mbps": 20,
+            "volunteer_version": "0.4.1", "registered_at": "2026-08-17T09:00:00Z",
+            "last_heartbeat_at": "2026-08-17T11:59:00Z", "expires_at": "2026-08-17T12:10:00Z"
+          },
+          {
+            "id": "relay_blank_reality_material", "public_host": "203.0.113.17", "public_port": 443,
+            "protocol": "vless-reality-vision", "client_id": "77777777-7777-4777-8777-777777777777",
+            "reality_public_key": "", "short_id": "", "server_name": "",
+            "flow": "xtls-rprx-vision", "exit_mode": "direct", "max_sessions": 8, "max_mbps": 20,
+            "volunteer_version": "0.4.1", "registered_at": "2026-08-17T09:00:00Z",
+            "last_heartbeat_at": "2026-08-17T11:59:00Z", "expires_at": "2026-08-17T12:10:00Z"
+          },
+          {
+            "id": "relay_good", "public_host": "203.0.113.18", "public_port": 443,
+            "protocol": "vless-reality-vision", "client_id": "88888888-8888-4888-8888-888888888888",
+            "reality_public_key": "key88", "short_id": "aa08", "server_name": "www.bing.com",
+            "flow": "xtls-rprx-vision", "exit_mode": "direct", "max_sessions": 8, "max_mbps": 20,
+            "volunteer_version": "0.4.1", "registered_at": "2026-08-17T09:00:00Z",
+            "last_heartbeat_at": "2026-08-17T11:59:00Z", "expires_at": "2026-08-17T12:10:00Z"
+          }
+        ]
+      },
+      "expect": {
+        "count": 8,
+        "server_time": "2026-08-17T12:00:00Z",
+        "not_after": "2026-08-17T12:30:00Z",
+        "key_id": "0f1a2b3c4d5e6f70",
+        "channel": "api",
+        "limit": 20,
+        "relay_ids": [
+          "relay_expired",
+          "relay_wrong_protocol",
+          "relay_wrong_flow",
+          "relay_dedicated_exit",
+          "relay_blank_host",
+          "relay_zero_port",
+          "relay_blank_reality_material",
+          "relay_good"
+        ]
+      },
+      "usability": [
+        {
+          "now": "2026-08-17T12:00:00Z",
+          "usable_ids": ["relay_good"],
+          "first_usable_id": "relay_good"
+        }
+      ]
+    },
+    {
+      "id": "forward_compatible",
+      "description": "A body from a newer broker: unknown top-level and per-relay fields must be ignored, not rejected, and every node_class a client cannot recognize — omitted, a future name, or a case variant — must be read as the volunteer class. Never as foundation: that class gates the WSS transport, so an unrecognized value has to degrade to the less-privileged side. The decoded field keeps whatever the wire carried; only the effective class is interpreted. An unrecognized class must also not make the relay unusable — dropping it would strand a client on a directory it merely does not fully understand.",
+      "body": {
+        "count": 3,
+        "server_time": "2026-08-17T12:00:00Z",
+        "not_after": "2026-08-17T12:30:00Z",
+        "key_id": "0f1a2b3c4d5e6f70",
+        "channel": "api",
+        "limit": 5,
+        "future_top_level_field": {"anything": [1, 2, 3]},
+        "relays": [
+          {
+            "id": "relay_forward",
+            "public_host": "2001:db8::10",
+            "public_port": 443,
+            "protocol": "vless-reality-vision",
+            "client_id": "99999999-9999-4999-8999-999999999999",
+            "reality_public_key": "key99",
+            "short_id": "aa09",
+            "server_name": "www.bing.com",
+            "flow": "xtls-rprx-vision",
+            "exit_mode": "direct",
+            "max_sessions": 8,
+            "max_mbps": 20,
+            "volunteer_version": "0.4.1",
+            "future_relay_field": "ignored",
+            "registered_at": "2026-08-17T09:00:00Z",
+            "last_heartbeat_at": "2026-08-17T11:59:00Z",
+            "expires_at": "2026-08-17T12:10:00Z"
+          },
+          {
+            "id": "relay_future_class",
+            "public_host": "203.0.113.30",
+            "public_port": 443,
+            "node_class": "partner",
+            "protocol": "vless-reality-vision",
+            "client_id": "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+            "reality_public_key": "keyee",
+            "short_id": "aa14",
+            "server_name": "www.bing.com",
+            "flow": "xtls-rprx-vision",
+            "exit_mode": "direct",
+            "max_sessions": 8,
+            "max_mbps": 20,
+            "volunteer_version": "0.5.0",
+            "registered_at": "2026-08-17T09:00:00Z",
+            "last_heartbeat_at": "2026-08-17T11:59:00Z",
+            "expires_at": "2026-08-17T12:10:00Z"
+          },
+          {
+            "id": "relay_case_variant_class",
+            "public_host": "203.0.113.31",
+            "public_port": 443,
+            "node_class": "Foundation",
+            "protocol": "vless-reality-vision",
+            "client_id": "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+            "reality_public_key": "keyff",
+            "short_id": "aa15",
+            "server_name": "www.bing.com",
+            "flow": "xtls-rprx-vision",
+            "exit_mode": "direct",
+            "max_sessions": 8,
+            "max_mbps": 20,
+            "volunteer_version": "0.5.0",
+            "registered_at": "2026-08-17T09:00:00Z",
+            "last_heartbeat_at": "2026-08-17T11:59:00Z",
+            "expires_at": "2026-08-17T12:10:00Z"
+          }
+        ]
+      },
+      "expect": {
+        "count": 3,
+        "server_time": "2026-08-17T12:00:00Z",
+        "not_after": "2026-08-17T12:30:00Z",
+        "key_id": "0f1a2b3c4d5e6f70",
+        "channel": "api",
+        "limit": 5,
+        "relays": [
+          {
+            "id": "relay_forward",
+            "label": null,
+            "public_host": "2001:db8::10",
+            "public_port": 443,
+            "node_class": null,
+            "effective_node_class": "volunteer",
+            "protocol": "vless-reality-vision",
+            "client_id": "99999999-9999-4999-8999-999999999999",
+            "reality_public_key": "key99",
+            "short_id": "aa09",
+            "server_name": "www.bing.com",
+            "flow": "xtls-rprx-vision",
+            "exit_mode": "direct",
+            "max_sessions": 8,
+            "max_mbps": 20,
+            "relay_version": "0.4.1",
+            "volunteer_version": "0.4.1",
+            "transport": null,
+            "punch_capable": null,
+            "punch_endpoint": null,
+            "wss_fronts": null,
+            "registered_at": "2026-08-17T09:00:00Z",
+            "last_heartbeat_at": "2026-08-17T11:59:00Z",
+            "expires_at": "2026-08-17T12:10:00Z"
+          },
+          {
+            "id": "relay_future_class",
+            "label": null,
+            "public_host": "203.0.113.30",
+            "public_port": 443,
+            "node_class": "partner",
+            "effective_node_class": "volunteer",
+            "protocol": "vless-reality-vision",
+            "client_id": "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+            "reality_public_key": "keyee",
+            "short_id": "aa14",
+            "server_name": "www.bing.com",
+            "flow": "xtls-rprx-vision",
+            "exit_mode": "direct",
+            "max_sessions": 8,
+            "max_mbps": 20,
+            "relay_version": "0.5.0",
+            "volunteer_version": "0.5.0",
+            "transport": null,
+            "punch_capable": null,
+            "punch_endpoint": null,
+            "wss_fronts": null,
+            "registered_at": "2026-08-17T09:00:00Z",
+            "last_heartbeat_at": "2026-08-17T11:59:00Z",
+            "expires_at": "2026-08-17T12:10:00Z"
+          },
+          {
+            "id": "relay_case_variant_class",
+            "label": null,
+            "public_host": "203.0.113.31",
+            "public_port": 443,
+            "node_class": "Foundation",
+            "effective_node_class": "volunteer",
+            "protocol": "vless-reality-vision",
+            "client_id": "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+            "reality_public_key": "keyff",
+            "short_id": "aa15",
+            "server_name": "www.bing.com",
+            "flow": "xtls-rprx-vision",
+            "exit_mode": "direct",
+            "max_sessions": 8,
+            "max_mbps": 20,
+            "relay_version": "0.5.0",
+            "volunteer_version": "0.5.0",
+            "transport": null,
+            "punch_capable": null,
+            "punch_endpoint": null,
+            "wss_fronts": null,
+            "registered_at": "2026-08-17T09:00:00Z",
+            "last_heartbeat_at": "2026-08-17T11:59:00Z",
+            "expires_at": "2026-08-17T12:10:00Z"
+          }
+        ]
+      },
+      "usability": [
+        {
+          "now": "2026-08-17T12:00:00Z",
+          "note": "An IPv6 public_host is usable; address family selection is a separate, later stage. A relay whose node_class the client cannot recognize stays usable — the class is provenance, not a usability condition.",
+          "usable_ids": ["relay_forward", "relay_future_class", "relay_case_variant_class"],
+          "first_usable_id": "relay_forward"
+        }
+      ]
+    }
+  ],
+  "invalid": {
+    "suites": ["go"],
+    "note": "Wire-schema rejections enforced by brokerapi before any client model sees the body. Kotlin and Swift inherit them through the same native module; the TypeScript model only ever receives an already-validated snapshot, so the Jest suite does not run these. Each case's 'reason' is a stable rejection code, not error wording: the Go suite translates it to the substring of brokerapi's current error message in its own non-vendored fixture (relayInvalidReasonMessages in contract/relay_decode_test.go), so a Go-internal reword changes that fixture instead of forcing a version bump and a re-vendor of this file.",
+    "cases": [
+      {
+        "id": "missing_count",
+        "reason": "relay_list_missing_required_field",
+        "body": {"server_time": "2026-08-17T12:00:00Z", "not_after": "2026-08-17T12:30:00Z", "key_id": "0f1a2b3c4d5e6f70", "channel": "api", "limit": 5, "relays": []}
+      },
+      {
+        "id": "missing_server_time",
+        "reason": "relay_list_missing_required_field",
+        "body": {"count": 0, "not_after": "2026-08-17T12:30:00Z", "key_id": "0f1a2b3c4d5e6f70", "channel": "api", "limit": 5, "relays": []}
+      },
+      {
+        "id": "missing_relays",
+        "reason": "relay_list_missing_required_field",
+        "body": {"count": 0, "server_time": "2026-08-17T12:00:00Z", "not_after": "2026-08-17T12:30:00Z", "key_id": "0f1a2b3c4d5e6f70", "channel": "api", "limit": 5}
+      },
+      {
+        "id": "relay_missing_client_id",
+        "reason": "relay_missing_required_field",
+        "body": {
+          "count": 1, "server_time": "2026-08-17T12:00:00Z", "not_after": "2026-08-17T12:30:00Z",
+          "key_id": "0f1a2b3c4d5e6f70", "channel": "api", "limit": 5,
+          "relays": [{
+            "id": "relay_incomplete", "public_host": "203.0.113.19", "public_port": 443,
+            "protocol": "vless-reality-vision", "reality_public_key": "keyaa", "short_id": "aa10",
+            "server_name": "www.bing.com", "flow": "xtls-rprx-vision", "exit_mode": "direct",
+            "max_sessions": 8, "max_mbps": 20, "volunteer_version": "0.4.1",
+            "registered_at": "2026-08-17T09:00:00Z", "last_heartbeat_at": "2026-08-17T11:59:00Z",
+            "expires_at": "2026-08-17T12:10:00Z"
+          }]
+        }
+      },
+      {
+        "id": "relay_version_without_alias",
+        "reason": "relay_missing_required_field",
+        "note": "The legacy volunteer_version alias is load-bearing: released native clients require it, so a broker that emits only relay_version is rejected here rather than silently decoding to a blank version. This is why no valid case pins relay_version/volunteer_version precedence — they never disagree on the wire.",
+        "body": {
+          "count": 1, "server_time": "2026-08-17T12:00:00Z", "not_after": "2026-08-17T12:30:00Z",
+          "key_id": "0f1a2b3c4d5e6f70", "channel": "api", "limit": 5,
+          "relays": [{
+            "id": "relay_no_alias", "public_host": "203.0.113.20", "public_port": 443,
+            "protocol": "vless-reality-vision", "client_id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+            "reality_public_key": "keybb", "short_id": "aa11", "server_name": "www.bing.com",
+            "flow": "xtls-rprx-vision", "exit_mode": "direct", "max_sessions": 8, "max_mbps": 20,
+            "relay_version": "0.4.1",
+            "registered_at": "2026-08-17T09:00:00Z", "last_heartbeat_at": "2026-08-17T11:59:00Z",
+            "expires_at": "2026-08-17T12:10:00Z"
+          }]
+        }
+      },
+      {
+        "id": "wss_front_missing_protocol_version",
+        "reason": "wss_front_missing_required_field",
+        "note": "The nested front shape is decoded strictly — it selects a censorship-circumvention transport, so it must not be normalized before wsscore sees it.",
+        "body": {
+          "count": 1, "server_time": "2026-08-17T12:00:00Z", "not_after": "2026-08-17T12:30:00Z",
+          "key_id": "0f1a2b3c4d5e6f70", "channel": "api", "limit": 5,
+          "relays": [{
+            "id": "relay_bad_front", "public_host": "203.0.113.21", "public_port": 443,
+            "protocol": "vless-reality-vision", "client_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+            "reality_public_key": "keycc", "short_id": "aa12", "server_name": "www.bing.com",
+            "flow": "xtls-rprx-vision", "exit_mode": "direct", "max_sessions": 8, "max_mbps": 20,
+            "volunteer_version": "0.4.1",
+            "wss_fronts": [{"id": "front-a", "url": "https://cdn-edge-a.example.net/api/v1/wss-bridge"}],
+            "registered_at": "2026-08-17T09:00:00Z", "last_heartbeat_at": "2026-08-17T11:59:00Z",
+            "expires_at": "2026-08-17T12:10:00Z"
+          }]
+        }
+      },
+      {
+        "id": "wss_front_unknown_field",
+        "reason": "unknown_field",
+        "body": {
+          "count": 1, "server_time": "2026-08-17T12:00:00Z", "not_after": "2026-08-17T12:30:00Z",
+          "key_id": "0f1a2b3c4d5e6f70", "channel": "api", "limit": 5,
+          "relays": [{
+            "id": "relay_extra_front_field", "public_host": "203.0.113.22", "public_port": 443,
+            "protocol": "vless-reality-vision", "client_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+            "reality_public_key": "keydd", "short_id": "aa13", "server_name": "www.bing.com",
+            "flow": "xtls-rprx-vision", "exit_mode": "direct", "max_sessions": 8, "max_mbps": 20,
+            "volunteer_version": "0.4.1",
+            "wss_fronts": [{"id": "front-a", "url": "https://cdn-edge-a.example.net/api/v1/wss-bridge", "protocol_version": 1, "weight": 3}],
+            "registered_at": "2026-08-17T09:00:00Z", "last_heartbeat_at": "2026-08-17T11:59:00Z",
+            "expires_at": "2026-08-17T12:10:00Z"
+          }]
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Follow-up to [openrung/openrung#138](https://github.com/openrung/openrung/pull/138) and [#139](https://github.com/openrung/openrung/pull/139), which added `contract/vectors/` there. Those files describe three contracts this app is a party to — the failure-classification token set, the relay-directory decode, and the broker-front list — and until now this side agreed with them by convention. That is how the same failure ends up under two different tokens on one dashboard, and how a front rotated in one repo quietly stops being a fallback in the other.

## Vendoring

`testdata/contract/` holds the copies; `pin.json` records the openrung ref plus a digest and version per file. `npm run contract:check` does both halves:

- **local** — the bytes still hash to the recorded digests, the recorded version matches the version inside each file, and every non-`go` suite the file declares is either wired up here or listed as pending with a reason.
- **remote** — the bytes are byte-identical to `contract/vectors/` at the pinned ref.

It needs network on purpose. A copy that has silently drifted from upstream is the entire failure mode, so an unreachable upstream fails rather than passing; `--offline` exists for a dev machine without network and says on stderr that it skipped the comparison. `npm run contract:sync` re-vendors after the pin moves. Both guards are verified:

```
- broker_fronts.json: sha256 e45020… does not match pin.json's 76644c…
- broker_fronts.json: declares suite "ts", which this repo neither runs (local_suites)
  nor records as pending with a reason (pending_suites)
```

## Suites

| Suite | Vectors | Runs against |
| --- | --- | --- |
| Kotlin (Robolectric) | classification | `FailureClassifier.kt` |
| Kotlin (JUnit) | broker_fronts | `AppConfig.DEFAULT_BROKER_URLS` |
| Swift (XCTest) | classification, broker_fronts | `FailureClassifier.swift`, `AppConfig` |
| Jest | relay_decode, broker_fronts | `src/model/relay.ts`, `src/config.ts` |

Each pins the vector version it was written against and asserts it ran a plausible number of rows, so a file that changes shape upstream fails rather than quietly matching nothing. Windows Winsock rows are skipped by `platform`; the go-only kinds (`deadline`, `wss_reason`, and the `none` row Swift cannot express) by the file's own suite declaration.

The mobile suites deliberately do **not** assert the broker-front phases or candidate ordering: this app hands native brokerapi a single primary and Go owns the racing. What they check is the claim this side can actually make — that every front the app hardcodes is still canonical.

## Two things worth a look

**`effectiveNodeClass` moved into `src/model/relay.ts`.** The read-side node-class rule was inline in `exitNodeDirectory.ts`. Asserting `effective_node_class` against a copy of that expression in the test would have been testing the test, so it is now a named export that `exitNodeDirectory.ts` calls — behavior identical, and it matches Kotlin's `normalizedNodeClass()`, Swift's, and Go's `relay.EffectiveNodeClass`.

**The Android workflow gained `testdata/contract/**` in its path filters.** The vectors live outside `android/`, so a re-vendor would not otherwise have run the suites that consume them.

## Pending, recorded rather than silent

`relay_decode.json` declares `kotlin` and `swift` as consumers and this PR wires only `ts` — `RelayDescriptor.kt` and `RelayDescriptor.swift` decode the directory too, and they are in scope for these vectors. `pin.json` records both as pending with that reason, and `contract:check` fails on a declared consumer that is neither wired nor explained, so the gap stays visible instead of reading as coverage. Happy to wire them in this PR or a follow-up.

## Verification

- `npm run contract:check` — 3 files match `openrung/openrung@653e3b6294ed`.
- Jest: `__tests__/contract` 20 passed. Full run is 27 suites / 130 tests failing **before and after** this branch (pre-existing component-render failures in this tree); this change adds 2 suites and 20 tests and no failures.
- Android: `./gradlew :app:testDebugUnitTest --tests "*Contract*"` — 6 tests, 0 failures.
- iOS: `xcodebuild test -only-testing:OpenRungTests/Contract…` on an iPhone 17 simulator — 6 tests, 0 failures. Note there is no iOS CI job, so these run locally only.
- `npx tsc --noEmit` clean; `npm run lint` error count unchanged (88, all pre-existing and none in the touched files).
- Mutation-checked all three suites: a wrong `expect` in a vendored row fails Kotlin (`errno_econnreset expected:<timeout> but was:<connection_reset>`), Swift (`vector tls_cert_expired`), and Jest.
- `ios/OpenRung.xcodeproj` regenerated with `ios/scripts/generate-project.sh` (xcodegen + pod install) so the new test files join the target; the Pods integration entries are present in identical counts before and after, and the `Podfile.lock` hermes-checksum churn from the local pod install was reverted.

The pin is `653e3b6` on `main`, not a branch commit: #138 and #139 are both merged, and #139 moved `relay_decode.json` to version 2 (stable rejection codes in the `invalid` section instead of Go error wording). That bump is what the Jest suite's version pin caught during development, which is the machinery working as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)