### PR TITLE
Reject tunnel addresses whose DNS successor escapes the TUN prefix

### DIFF
--- a/android/app/src/main/java/com/openrung/net/SingBoxConfiguration.kt
+++ b/android/app/src/main/java/com/openrung/net/SingBoxConfiguration.kt
@@ -450,18 +450,36 @@ data class SingBoxConfiguration(
          */
         val DEFAULT_TUNNEL_DNS_ADDRESS = tunnelDnsAddress(DEFAULT_TUNNEL_IPV4_ADDRESS)
 
-        /** Next IPv4 address after [tunnelIPv4Address], mirroring sing-tun's derivation. */
+        /**
+         * Next IPv4 address after [tunnelIPv4Address], mirroring sing-tun's derivation.
+         *
+         * sing-tun only performs that derivation when the successor stays inside the TUN
+         * prefix (HasNextAddress: prefix.Contains(addr.Next())); otherwise it hijacks no IPv4
+         * address at all. A tunnel address whose successor escapes the prefix is therefore
+         * rejected here — returning it would hand probes an address sing-box never hijacks
+         * and fail them on a healthy tunnel.
+         */
         fun tunnelDnsAddress(tunnelIPv4Address: String): String {
+            val prefixLength = tunnelIPv4Address
+                .substringAfter("/", missingDelimiterValue = "")
+                .toIntOrNull()
+            require(prefixLength != null && prefixLength in 0..32) {
+                "tunnel address is not an IPv4 prefix: $tunnelIPv4Address"
+            }
             val octets = tunnelIPv4Address.substringBefore("/").split(".")
-            require(octets.size == 4) { "tunnel address is not IPv4: $tunnelIPv4Address" }
+            require(octets.size == 4) { "tunnel address is not an IPv4 prefix: $tunnelIPv4Address" }
             val value = octets.fold(0L) { acc, octet ->
                 val part = requireNotNull(octet.toIntOrNull()) {
-                    "tunnel address is not IPv4: $tunnelIPv4Address"
+                    "tunnel address is not an IPv4 prefix: $tunnelIPv4Address"
                 }
-                require(part in 0..255) { "tunnel address is not IPv4: $tunnelIPv4Address" }
+                require(part in 0..255) { "tunnel address is not an IPv4 prefix: $tunnelIPv4Address" }
                 (acc shl 8) or part.toLong()
             }
             val next = value + 1
+            val networkShift = 32 - prefixLength
+            require(value shr networkShift == next shr networkShift) {
+                "tunnel address $tunnelIPv4Address has no successor inside its prefix for sing-tun to hijack"
+            }
             return (24 downTo 0 step 8).joinToString(".") { shift -> ((next shr shift) and 0xFF).toString() }
         }
 

--- a/android/app/src/test/java/com/openrung/net/SingBoxConfigurationDnsTest.kt
+++ b/android/app/src/test/java/com/openrung/net/SingBoxConfigurationDnsTest.kt
@@ -216,6 +216,10 @@ class SingBoxConfigurationDnsTest {
             "172.19.0.1",
             "fdfe:dcba:9876::1/126",
             "bogus/30",
+            // Kotlin's split keeps empty components, so these malformed shapes never
+            // collapsed into a valid-looking address; pinned for parity with the iOS suite.
+            "1..2.3.4/24",
+            "1.2.3.4//24",
         ).forEach { invalid ->
             assertThrows(IllegalArgumentException::class.java) {
                 SingBoxConfiguration.tunnelDnsAddress(invalid)

--- a/android/app/src/test/java/com/openrung/net/SingBoxConfigurationDnsTest.kt
+++ b/android/app/src/test/java/com/openrung/net/SingBoxConfigurationDnsTest.kt
@@ -9,6 +9,7 @@ import kotlinx.serialization.json.jsonPrimitive
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.net.URI
@@ -200,8 +201,26 @@ class SingBoxConfigurationDnsTest {
             ),
         )
         // Octet carry, so a future tunnel address change cannot silently derive a wrong hijack
-        // address.
-        assertEquals("10.0.1.0", SingBoxConfiguration.tunnelDnsAddress("10.0.0.255/30"))
+        // address. The /23 keeps the successor inside the prefix.
+        assertEquals("10.0.1.0", SingBoxConfiguration.tunnelDnsAddress("10.0.0.255/23"))
+    }
+
+    @Test
+    fun `tunnel addresses whose dns successor escapes the prefix are rejected`() {
+        // sing-tun refuses to derive a hijack address whose successor escapes the TUN prefix
+        // (HasNextAddress), so returning one here would fail every probe on a healthy tunnel:
+        // the last address of a prefix must be rejected, exactly like a non-IPv4 input.
+        listOf(
+            "10.0.0.255/30",
+            "172.19.0.3/30",
+            "172.19.0.1",
+            "fdfe:dcba:9876::1/126",
+            "bogus/30",
+        ).forEach { invalid ->
+            assertThrows(IllegalArgumentException::class.java) {
+                SingBoxConfiguration.tunnelDnsAddress(invalid)
+            }
+        }
     }
 
     @Test

--- a/ios/OpenRungTests/DnsConfigurationTests.swift
+++ b/ios/OpenRungTests/DnsConfigurationTests.swift
@@ -151,7 +151,12 @@ final class DnsConfigurationTests: XCTestCase {
         // sing-tun refuses to derive a hijack address whose successor escapes the TUN prefix
         // (HasNextAddress), so returning one here would fail every probe on a healthy tunnel:
         // the last address of a prefix must be rejected, exactly like a non-IPv4 input.
-        for invalid in ["10.0.0.255/30", "172.19.0.3/30", "172.19.0.1", "fdfe:dcba:9876::1/126", "bogus/30"] {
+        // The last two guard the split behavior: omitting empty subsequences would collapse
+        // them into a valid-looking address.
+        for invalid in [
+            "10.0.0.255/30", "172.19.0.3/30", "172.19.0.1", "fdfe:dcba:9876::1/126", "bogus/30",
+            "1..2.3.4/24", "1.2.3.4//24",
+        ] {
             XCTAssertNil(SingBoxConfiguration.tunnelDnsAddress(for: invalid), invalid)
         }
 

--- a/ios/OpenRungTests/DnsConfigurationTests.swift
+++ b/ios/OpenRungTests/DnsConfigurationTests.swift
@@ -145,7 +145,15 @@ final class DnsConfigurationTests: XCTestCase {
             SingBoxConfiguration.defaultTunnelDnsAddress
         )
         // Octet carry, so a future tunnel address change cannot silently derive a wrong address.
-        XCTAssertEqual(SingBoxConfiguration.tunnelDnsAddress(for: "10.0.0.255/30"), "10.0.1.0")
+        // The /23 keeps the successor inside the prefix.
+        XCTAssertEqual(SingBoxConfiguration.tunnelDnsAddress(for: "10.0.0.255/23"), "10.0.1.0")
+
+        // sing-tun refuses to derive a hijack address whose successor escapes the TUN prefix
+        // (HasNextAddress), so returning one here would fail every probe on a healthy tunnel:
+        // the last address of a prefix must be rejected, exactly like a non-IPv4 input.
+        for invalid in ["10.0.0.255/30", "172.19.0.3/30", "172.19.0.1", "fdfe:dcba:9876::1/126", "bogus/30"] {
+            XCTAssertNil(SingBoxConfiguration.tunnelDnsAddress(for: invalid), invalid)
+        }
 
         // An explicit dns_address on the tun inbound would replace the derived hijack address
         // and silently invalidate the probe target above.

--- a/ios/Shared/SingBoxConfiguration.swift
+++ b/ios/Shared/SingBoxConfiguration.swift
@@ -36,20 +36,39 @@ public struct SingBoxConfiguration: Equatable, Sendable {
     /// resolver (1.1.1.1) is NOT tagged, matches no rule, and dies on the TCP-only proxy
     /// outbound, so the fresh-DNS probe must target this address. It is also what libbox reports
     /// to `NEDNSSettings`, so it is exactly where system lookups already go.
-    public static let defaultTunnelDnsAddress = tunnelDnsAddress(for: defaultTunnelIPv4Address)
-
-    /// Next IPv4 address after `tunnelIPv4Address`, mirroring sing-tun's derivation.
-    public static func tunnelDnsAddress(for tunnelIPv4Address: String) -> String {
-        let octets = tunnelIPv4Address.split(separator: "/")[0].split(separator: ".")
-        precondition(octets.count == 4, "tunnel address is not IPv4: \(tunnelIPv4Address)")
-        let value = octets.reduce(UInt32(0)) { accumulated, octet in
-            guard let part = UInt32(octet), part <= 255 else {
-                preconditionFailure("tunnel address is not IPv4: \(tunnelIPv4Address)")
-            }
-            return accumulated << 8 | part
+    public static let defaultTunnelDnsAddress: String = {
+        guard let address = tunnelDnsAddress(for: defaultTunnelIPv4Address) else {
+            preconditionFailure(
+                "default tunnel address has no derivable DNS address: \(defaultTunnelIPv4Address)"
+            )
         }
-        let next = value &+ 1
-        return [24, 16, 8, 0].map { String((next >> UInt32($0)) & 0xFF) }.joined(separator: ".")
+        return address
+    }()
+
+    /// Next IPv4 address after `tunnelIPv4Address`, mirroring sing-tun's derivation, or nil for
+    /// input that is not an IPv4 prefix.
+    ///
+    /// sing-tun only performs that derivation when the successor stays inside the TUN prefix
+    /// (HasNextAddress: prefix.Contains(addr.Next())); otherwise it hijacks no IPv4 address at
+    /// all. A tunnel address whose successor escapes the prefix therefore also yields nil —
+    /// returning it would hand probes an address sing-box never hijacks and fail them on a
+    /// healthy tunnel.
+    public static func tunnelDnsAddress(for tunnelIPv4Address: String) -> String? {
+        let parts = tunnelIPv4Address.split(separator: "/")
+        guard parts.count == 2, let prefixLength = Int(parts[1]), (0...32).contains(prefixLength) else {
+            return nil
+        }
+        let octets = parts[0].split(separator: ".")
+        guard octets.count == 4 else { return nil }
+        var value: UInt64 = 0
+        for octet in octets {
+            guard let part = UInt64(octet), part <= 255 else { return nil }
+            value = value << 8 | part
+        }
+        let next = value + 1
+        let networkShift = UInt64(32 - prefixLength)
+        guard value >> networkShift == next >> networkShift else { return nil }
+        return [24, 16, 8, 0].map { String((next >> UInt64($0)) & 0xFF) }.joined(separator: ".")
     }
 
     public let relay: RelayDescriptor

--- a/ios/Shared/SingBoxConfiguration.swift
+++ b/ios/Shared/SingBoxConfiguration.swift
@@ -54,11 +54,13 @@ public struct SingBoxConfiguration: Equatable, Sendable {
     /// returning it would hand probes an address sing-box never hijacks and fail them on a
     /// healthy tunnel.
     public static func tunnelDnsAddress(for tunnelIPv4Address: String) -> String? {
-        let parts = tunnelIPv4Address.split(separator: "/")
+        // omittingEmptySubsequences: false, or malformed input like "1..2.3.4/24" and
+        // "1.2.3.4//24" collapses to a valid-looking shape.
+        let parts = tunnelIPv4Address.split(separator: "/", omittingEmptySubsequences: false)
         guard parts.count == 2, let prefixLength = Int(parts[1]), (0...32).contains(prefixLength) else {
             return nil
         }
-        let octets = parts[0].split(separator: ".")
+        let octets = parts[0].split(separator: ".", omittingEmptySubsequences: false)
         guard octets.count == 4 else { return nil }
         var value: UInt64 = 0
         for octet in octets {


### PR DESCRIPTION
## What

The DNS hijack-address helpers — `tunnelDnsAddress` in `android/.../SingBoxConfiguration.kt` and `tunnelDnsAddress(for:)` in `ios/Shared/SingBoxConfiguration.swift` — incremented the TUN IPv4 address without checking the result stays inside the prefix. They now parse the full prefix and fail when the successor escapes it:

- **Kotlin**: throws `IllegalArgumentException` (the helper's existing `require` idiom). A bare address with no `/len` is now also rejected, matching the Go reference.
- **Swift**: returns `String?` (nil on invalid input or an escaping successor) instead of `preconditionFailure`, since a precondition can't be unit-tested. `defaultTunnelDnsAddress` derives through a guard with a clear crash message, so it stays a non-optional `String` and its call sites (packet-tunnel probe, `NEDNSSettings`) are unchanged.

Tests: the octet-carry case moved from `10.0.0.255/30` to `10.0.0.255/23` (still exercises the carry to `10.0.1.0`, successor now contained), and both platforms gained rejection cases: `10.0.0.255/30`, `172.19.0.3/30`, bare `172.19.0.1`, an IPv6 prefix, and garbage — the same invalid set as the Go reference test.

## Why

The pinned sing-tun (v0.8.11-0.20260603045801) derives the hijack address only when `prefix.Contains(addr.Next())` (`Inet4DNSAddress` in tun.go, `HasNextAddress` in stack.go); otherwise it hijacks **no** IPv4 address. A prefix-blind helper returning the escaping successor (e.g. `10.0.1.0` for `10.0.0.255/30`) would point the fresh-DNS probes at an address sing-box never hijacks and fail them on a healthy tunnel. Harmless today only because the shipping `172.19.0.1/30`'s successor (`172.19.0.2`) is contained — this fails closed before any future tunnel-address change can trip it silently.

Mirrors openrung repo PR #144 commit d9c20b3 (`TunnelDNSAddress` in `internal/client/singbox_config.go`), the reference implementation.

## Reviewer notes

- The containment check is one shift comparison in 64-bit space, which also correctly rejects `/32` (no room for a successor) and `255.255.255.255` overflow under `/0`.
- Shipping default asserted unchanged on both platforms: `172.19.0.1/30 → 172.19.0.2`.
- Verified: full Android unit suite (`:app:testDebugUnitTest`) passes; full iOS `OpenRungTests` bundle passes on the iPhone 17 Pro simulator (iOS is not in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)