### PR TITLE
Build sing-box configs through the bound connectcore builder (D4: config builder)

### DIFF
--- a/android/app/src/main/java/com/openrung/net/SingBoxConfiguration.kt
+++ b/android/app/src/main/java/com/openrung/net/SingBoxConfiguration.kt
@@ -1,18 +1,13 @@
 package com.openrung.net
 
 import com.openrung.BuildConfig
-import com.openrung.model.RelayConstants
 import com.openrung.model.RelayDescriptor
-import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonObjectBuilder
-import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.buildJsonArray
+import io.nekohasekai.libbox.Libbox
+import kotlinx.serialization.json.add
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import kotlinx.serialization.json.putJsonObject
 
 /**
  * Split-tunneling emission input (split-tunnel spec §2). This is NOT the persisted config
@@ -34,46 +29,23 @@ data class SplitTunnelRules(
 
         /** Countries with bundled rule sets, in the canonical emission order. */
         val SUPPORTED_COUNTRIES: List<String> = listOf(COUNTRY_IR, COUNTRY_CN)
-
-        /**
-         * An in-country public resolver reached over the DIRECT path, so bypassed domains resolve
-         * to in-country CDN nodes instead of the relay exit's view of them.
-         *
-         * DoH over 443, never plaintext UDP/53: these queries leave the device on the user's real
-         * IP while the tunnel is up, so the local network, the ISP and anything else on the path
-         * must not get a cleartext list of the domains being bypassed (nor the chance to forge the
-         * answers). [server] stays an IP literal so no bootstrap lookup is needed, and TLS
-         * authenticates [tlsServerName] — the same shape the proxied DoH resolvers use.
-         */
-        data class DirectResolver(val server: String, val tlsServerName: String)
-
-        /**
-         * Null when the country has no encrypted public resolver we can currently stand behind.
-         * Its bypass then keeps its ROUTE rules — the traffic still takes the direct path — and
-         * only its lookups fall to the proxied DoH chain, resolving through the relay exit's view.
-         * That costs in-country CDN affinity and nothing else.
-         *
-         * A resolver goes in here only while its certificate actually validates. Anything else is
-         * worse than omitting it: sing-box would spend the full evaluate timeout failing the TLS
-         * handshake on EVERY bypassed lookup before the fallback runs, so users would pay latency
-         * for an in-country answer they can never receive. Never restore one on the strength of
-         * its documentation — verify the live endpoint first.
-         */
-        fun directResolver(country: String): DirectResolver? = when (country) {
-            // Shecan is Iran's usual public resolver, but every endpoint it publishes
-            // (178.22.122.100, 185.51.200.2, dns.shecan.ir) served an expired Let's Encrypt
-            // certificate as of 2026-08-12 (notAfter Jul 10 2026), on both 443 and 853. Electro
-            // (78.157.42.100) refuses both ports and Begzar's DoH host no longer resolves, so
-            // Iran has no verifiable encrypted resolver to point at right now.
-            COUNTRY_IR -> null
-            // AliDNS (Chinese public resolver); https://223.5.5.5/dns-query is a published
-            // endpoint and its certificate covers the IP literal.
-            COUNTRY_CN -> DirectResolver("223.5.5.5", "dns.alidns.com")
-            else -> throw IllegalArgumentException("unsupported split-tunnel country: $country")
-        }
     }
 }
 
+/**
+ * Platform input assembly for the shared sing-box config builder: gathers the Android-side inputs
+ * (relay identity, TUN addresses, an optional punch/WSS loopback bridge, validated split-tunnel
+ * rules) and hands them to the libbox binding's `OpenRungBuildSingBoxConfig`, whose emission comes
+ * from the one Go builder every OpenRung client runs (`connectcore/client` in the sibling
+ * `openrung` repo — the generator this file used to hand-copy). This file no longer emits any
+ * config JSON; the DNS failover chains, probe pins, split-tunnel rules, route exclusions, and
+ * their ordering all live in the shared builder, and the frozen bound outputs under
+ * `testdata/singbox-binding/` are what this platform's structural tests assert against.
+ *
+ * The assembly ([bindingInputJson]) is pure JVM so the test suite can pin it without the native
+ * library; the input→config half runs in `android/punchbridge`'s Go tests against the same
+ * checked-in inputs.
+ */
 data class SingBoxConfiguration(
     val relay: RelayDescriptor,
     /** Loopback TCP adapter exposed by a native transport. Empty means use the relay endpoint. */
@@ -84,348 +56,73 @@ data class SingBoxConfiguration(
     val mtu: Int = 1400,
     val splitTunnel: SplitTunnelRules? = null,
 ) {
+    /**
+     * The emitted config JSON from the shared builder. Throws [IllegalArgumentException] when the
+     * binding rejects the input (an invalid relay, a partial bridge, an unsupported split-tunnel
+     * country, …) — the same failures the deleted generator used to reject locally.
+     */
     fun encodedJsonString(): String {
-        validateRelay()
-        return prettyJson.encodeToString(makeJsonObject())
-    }
-
-    fun makeJsonObject(): JsonObject {
-        require(mtu > 0) { "mtu must be positive" }
-        validateRelay()
-        val useLoopbackAdapter = bridgeHost.isNotBlank() || bridgePort != 0
-        if (useLoopbackAdapter) {
-            require(bridgeHost.isNotBlank() && bridgePort in 1..65535) {
-                "loopback adapter requires a host and valid port"
-            }
+        val result = Libbox.openRungBuildSingBoxConfig(bindingInputJson())
+        require(result.succeeded()) {
+            result.errorText().ifBlank { "sing-box config build failed" }
         }
-        val outboundHost = if (useLoopbackAdapter) bridgeHost else relay.publicHost
-        val outboundPort = if (useLoopbackAdapter) bridgePort else relay.publicPort
-        val bypassCountries = splitTunnel?.bypassCountries.orEmpty()
-        val excludedPackages = splitTunnel?.excludedPackages.orEmpty()
-        val dnsServers = DEFAULT_DOH_RESOLVERS
-
-        val tunInbound = mutableMapOf<String, JsonElement>(
-            "type" to JsonPrimitive("tun"),
-            "tag" to JsonPrimitive("tun-in"),
-            "address" to JsonArray(listOf(JsonPrimitive(tunnelIPv4Address), JsonPrimitive(tunnelIPv6Address))),
-            "mtu" to JsonPrimitive(mtu),
-            "auto_route" to JsonPrimitive(true),
-            "strict_route" to JsonPrimitive(true),
-            "stack" to JsonPrimitive("system"),
-            "dns_mode" to JsonPrimitive("hijack"),
-            "endpoint_independent_nat" to JsonPrimitive(true),
-        )
-        if (excludedPackages.isNotEmpty()) {
-            // Excluded apps leave the VPN at the OS level. NEVER emit include_package alongside
-            // this: Android forbids mixing the two, and we only ever exclude.
-            tunInbound["exclude_package"] = JsonArray(excludedPackages.map(::JsonPrimitive))
-        }
-        if (!useLoopbackAdapter) {
-            relayRouteExcludeAddress(relay.publicHost)?.let {
-                tunInbound["route_exclude_address"] = JsonArray(listOf(JsonPrimitive(it)))
-            }
-        }
-
-        return buildJsonObject {
-            put("log", buildJsonObject {
-                // "info" logs every flow and DNS query inside the Go engine; release builds
-                // keep only warnings to stay off the per-connection hot path.
-                put("level", if (BuildConfig.DEBUG) "info" else "warn")
-                put("timestamp", true)
-            })
-            put("dns", buildJsonObject {
-                put("servers", buildJsonArray {
-                    dnsServers.forEachIndexed { index, server ->
-                        add(buildJsonObject {
-                            put("tag", "dns-$index")
-                            // DoH over 443 via the proxy: relays answer 443 on every transport,
-                            // while TCP/53 gets no replies under WSS. IP-literal servers need no
-                            // bootstrap resolver (defaults: port 443, path /dns-query).
-                            put("type", "https")
-                            put("server", server)
-                            put("detour", "proxy")
-                            // TLS authenticates the provider hostname while the dial stays on
-                            // the IP literal, so a provider dropping IP SANs from its
-                            // certificate cannot break resolution.
-                            DOH_TLS_SERVER_NAMES[server]?.let { serverName ->
-                                put("tls", buildJsonObject {
-                                    put("enabled", true)
-                                    put("server_name", serverName)
-                                })
-                            }
-                        })
-                    }
-                    bypassCountries.forEach { country ->
-                        val resolver = SplitTunnelRules.directResolver(country) ?: return@forEach
-                        add(buildJsonObject {
-                            put("tag", "dns-direct-$country")
-                            // DoH over 443 on the direct path: encrypted, and 443 survives the
-                            // middleboxes that a bare 853 often does not.
-                            put("type", "https")
-                            put("server", resolver.server)
-                            put("tls", buildJsonObject {
-                                put("enabled", true)
-                                put("server_name", resolver.tlsServerName)
-                            })
-                            // A DNS server with no detour builds its own direct dialer, which is
-                            // exactly what a bypass resolver needs. Detouring to our otherwise-empty
-                            // tagged direct outbound is rejected during sing-box's Start stage
-                            // ("detour to an empty direct outbound").
-                        })
-                    }
-                })
-                put("rules", buildJsonArray {
-                    // Highest priority: probe lookups must reach the proxied DoH resolvers even
-                    // when a country rule would divert them (geosite-cn contains gstatic-class
-                    // hosts), and must never be answered from any cache — a cached answer
-                    // proves nothing about the tunnel right now. The chain is terminal for
-                    // probe domains (its trailing route rule always fires), so a future geosite
-                    // refresh can never capture a probe lookup.
-                    dnsFailoverRules(
-                        domainSuffixes = ProbeTargets.RULE_DOMAIN_SUFFIXES,
-                        disableCache = true,
-                    ).forEach(::add)
-                    bypassCountries.forEach { country ->
-                        countryDnsRules(country).forEach(::add)
-                    }
-                    // Real failover for everything else: a static `final` would never consult a
-                    // second resolver. `evaluate` is non-terminal on a transport error, timeout,
-                    // SERVFAIL or REFUSED in the pinned engine — a usable answer (NOERROR, or an
-                    // authoritative NXDOMAIN) is returned by `respond`, anything else falls
-                    // through to the next resolver's terminal route rule.
-                    dnsFailoverRules(domainSuffixes = null, disableCache = false).forEach(::add)
-                })
-                put("final", "dns-${dnsServers.lastIndex}")
-                put("timeout", DNS_FALLBACK_TIMEOUT)
-            })
-            put("inbounds", JsonArray(listOf(JsonObject(tunInbound))))
-            put("outbounds", buildJsonArray {
-                add(buildJsonObject {
-                    put("type", "vless")
-                    put("tag", "proxy")
-                    put("server", outboundHost)
-                    put("server_port", outboundPort)
-                    put("uuid", relay.clientId)
-                    put("flow", relay.flow)
-                    put("network", "tcp")
-                    put("packet_encoding", "xudp")
-                    put("tls", buildJsonObject {
-                        put("enabled", true)
-                        put("server_name", relay.serverName)
-                        put("utls", buildJsonObject {
-                            put("enabled", true)
-                            put("fingerprint", "chrome")
-                        })
-                        put("reality", buildJsonObject {
-                            put("enabled", true)
-                            put("public_key", relay.realityPublicKey)
-                            put("short_id", relay.shortId)
-                        })
-                    })
-                })
-                add(buildJsonObject {
-                    put("type", "direct")
-                    put("tag", "direct")
-                })
-                add(buildJsonObject {
-                    put("type", "block")
-                    put("tag", "block")
-                })
-            })
-            put("route", buildJsonObject {
-                put("auto_detect_interface", true)
-                put("find_process", true)
-                put("default_domain_resolver", "dns-0")
-                if (bypassCountries.isNotEmpty()) {
-                    put("rule_set", buildJsonArray {
-                        bypassCountries.forEach { country ->
-                            add(localRuleSet("geosite-$country"))
-                            add(localRuleSet("geoip-$country"))
-                        }
-                    })
-                }
-                put("rules", buildJsonArray {
-                    add(buildJsonObject {
-                        put("protocol", "dns")
-                        put("action", "hijack-dns")
-                    })
-                    if (bypassCountries.isNotEmpty()) {
-                        // Route rules need a sniffed domain before geosite matching can work.
-                        add(buildJsonObject {
-                            put("action", "sniff")
-                        })
-                        // Probe traffic must reach the proxy even when a bypass rule would send
-                        // it direct; a probe that escapes onto the direct path can report
-                        // CONNECTED over a dead tunnel. Must precede every bypass rule.
-                        add(buildJsonObject {
-                            put(
-                                "domain_suffix",
-                                JsonArray(ProbeTargets.RULE_DOMAIN_SUFFIXES.map(::JsonPrimitive)),
-                            )
-                            put("outbound", "proxy")
-                        })
-                    }
-                    if (splitTunnel?.bypassLan == true) {
-                        add(buildJsonObject {
-                            put("ip_is_private", true)
-                            put("outbound", "direct")
-                        })
-                    }
-                    bypassCountries.forEach { country ->
-                        add(buildJsonObject {
-                            put(
-                                "rule_set",
-                                JsonArray(
-                                    listOf(
-                                        JsonPrimitive("geosite-$country"),
-                                        JsonPrimitive("geoip-$country"),
-                                    ),
-                                ),
-                            )
-                            put("outbound", "direct")
-                        })
-                    }
-                })
-                put("final", "proxy")
-            })
-            put("experimental", buildJsonObject {
-                // No external_controller is set, so nothing listens; an empty clash_api
-                // block just turns on sing-box's traffic accounting, which feeds the
-                // cumulative bytes_sent/bytes_received counters reported with session
-                // telemetry (see TelemetryManager.updateTrafficCounters).
-                put("clash_api", buildJsonObject { })
-            })
-        }
+        return result.configJSON()
     }
 
     /**
-     * Emits an ordered primary-to-fallback resolver chain from sing-box 1.14 DNS rule actions:
-     * for every resolver but the last, `evaluate` exchanges the query (non-terminal on error)
-     * and `respond` returns its answer when the RCODE is NOERROR or NXDOMAIN — both are real
-     * answers, and probe nonce queries are expected to draw NXDOMAIN. Everything else (timeout,
-     * transport error, SERVFAIL, REFUSED) falls through until the last resolver's terminal
-     * route rule. With [domainSuffixes] the whole chain applies only to those domains and is
-     * guaranteed terminal for them; with null it applies to every remaining query.
+     * The binding input for this configuration: one JSON object of the platform-assembled fields.
+     * The relay object carries the broker's canonical wire names, the probe suffixes come from
+     * [ProbeTargets] so the builder's probe pins can never diverge from the endpoints this
+     * platform actually probes, and [debug] selects the log level ("info" logs every flow and DNS
+     * query inside the Go engine; release builds keep only warnings to stay off the
+     * per-connection hot path). Values are forwarded faithfully — a partial bridge is the
+     * binding's to reject, not this assembly's to repair.
      */
-    private fun dnsFailoverRules(
-        domainSuffixes: List<String>?,
-        disableCache: Boolean,
-    ): List<JsonObject> = buildList {
-        val dnsServers = DEFAULT_DOH_RESOLVERS
-        fun JsonObjectBuilder.putScopeAndCache() {
-            domainSuffixes?.let {
-                put("domain_suffix", JsonArray(it.map(::JsonPrimitive)))
-            }
-            if (disableCache) {
-                put("disable_cache", true)
-                put("disable_optimistic_cache", true)
-            }
+    internal fun bindingInputJson(debug: Boolean = BuildConfig.DEBUG): String = buildJsonObject {
+        putJsonObject("relay") {
+            put("public_host", relay.publicHost)
+            put("public_port", relay.publicPort)
+            put("protocol", relay.relayProtocol)
+            put("client_id", relay.clientId)
+            put("reality_public_key", relay.realityPublicKey)
+            put("short_id", relay.shortId)
+            put("server_name", relay.serverName)
+            put("flow", relay.flow)
+            put("exit_mode", relay.exitMode)
         }
-        dnsServers.dropLast(1).forEachIndexed { index, _ ->
-            add(buildJsonObject {
-                putScopeAndCache()
-                put("action", "evaluate")
-                put("server", "dns-$index")
-                put("timeout", DNS_PRIMARY_TIMEOUT)
-            })
-            listOf("NOERROR", "NXDOMAIN").forEach { rcode ->
-                add(buildJsonObject {
-                    domainSuffixes?.let {
-                        put("domain_suffix", JsonArray(it.map(::JsonPrimitive)))
-                    }
-                    put("match_response", true)
-                    put("response_rcode", rcode)
-                    put("action", "respond")
-                })
+        put("tunnel_ipv4_address", tunnelIPv4Address)
+        put("tunnel_ipv6_address", tunnelIPv6Address)
+        put("mtu", mtu)
+        if (bridgeHost.isNotBlank()) put("bridge_host", bridgeHost)
+        if (bridgePort != 0) put("bridge_port", bridgePort)
+        put("log_level", if (debug) "info" else "warn")
+        put("route_find_process", true)
+        putJsonArray("probe_domain_suffixes") {
+            ProbeTargets.RULE_DOMAIN_SUFFIXES.forEach { add(it) }
+        }
+        splitTunnel?.let { rules ->
+            putJsonObject("split_tunnel") {
+                put("bypass_lan", rules.bypassLan)
+                putJsonArray("bypass_countries") { rules.bypassCountries.forEach { add(it) } }
+                putJsonArray("excluded_packages") { rules.excludedPackages.forEach { add(it) } }
+                put("rule_set_directory", rules.ruleSetDirectory)
             }
         }
-        add(buildJsonObject {
-            putScopeAndCache()
-            put("server", "dns-${dnsServers.lastIndex}")
-            put("timeout", DNS_FALLBACK_TIMEOUT)
-        })
-    }
-
-    /**
-     * Per-country lookup chain for the domains that country bypasses: ask the in-country DoH
-     * resolver, and return its answer when it is a real one (NOERROR, or an authoritative
-     * NXDOMAIN). Nothing else is terminal, so a resolver that is unreachable, times out, or has
-     * let its certificate lapse falls through to the proxied global chain below instead of
-     * failing the lookup outright — the same fail-open posture as the rest of the feature
-     * (CONTRACT §1), and the reason moving off plaintext UDP cannot cost anyone reachability.
-     *
-     * `rule_set` matches against the queried domain in both the query and the response pass, so
-     * the response rules stay scoped to this country's domains.
-     *
-     * Empty for a country with no usable in-country resolver: with nothing to evaluate, its
-     * lookups simply reach the global chain, which is where they would end up anyway.
-     */
-    private fun countryDnsRules(country: String): List<JsonObject> = buildList {
-        if (SplitTunnelRules.directResolver(country) == null) return@buildList
-        val ruleSet = JsonArray(listOf(JsonPrimitive("geosite-$country")))
-        add(buildJsonObject {
-            put("rule_set", ruleSet)
-            put("action", "evaluate")
-            put("server", "dns-direct-$country")
-            put("timeout", DNS_PRIMARY_TIMEOUT)
-        })
-        listOf("NOERROR", "NXDOMAIN").forEach { rcode ->
-            add(buildJsonObject {
-                put("rule_set", ruleSet)
-                put("match_response", true)
-                put("response_rcode", rcode)
-                put("action", "respond")
-            })
-        }
-    }
-
-    private fun localRuleSet(tag: String): JsonObject = buildJsonObject {
-        put("type", "local")
-        put("tag", tag)
-        put("format", "binary")
-        put("path", "${checkNotNull(splitTunnel).ruleSetDirectory}/$tag.srs")
-    }
-
-    private fun validateRelay() {
-        require(relay.relayProtocol == RelayConstants.PROTOCOL_VLESS_REALITY_VISION) {
-            "relay protocol is not vless-reality-vision"
-        }
-        require(relay.flow == RelayConstants.FLOW_VISION) {
-            "relay flow is not xtls-rprx-vision"
-        }
-        require(relay.exitMode == RelayConstants.EXIT_MODE_DIRECT) {
-            "relay exit mode is not direct"
-        }
-        require(relay.publicHost.isNotBlank() && relay.publicPort > 0) {
-            "relay is missing required connection fields"
-        }
-        require(relay.clientId.isNotBlank() && relay.realityPublicKey.isNotBlank()) {
-            "relay is missing required Reality fields"
-        }
-        require(relay.shortId.isNotBlank() && relay.serverName.isNotBlank()) {
-            "relay is missing required TLS fields"
-        }
-    }
+    }.toString()
 
     companion object {
-        private val prettyJson = Json {
-            prettyPrint = true
-        }
-
-        /** DoH-capable public resolvers reached as IP literals: no bootstrap resolution needed. */
+        /**
+         * The proxied DoH resolvers the shared builder emits by default (its defaults are the
+         * same IP literals). Kept here because the probe budgets below are derived from the
+         * chain's length and timeouts; the bound goldens pin the emitted list, so a builder-side
+         * change cannot drift past this constant unnoticed.
+         */
         val DEFAULT_DOH_RESOLVERS = listOf("1.1.1.1", "8.8.8.8")
 
-        /** Hostnames the DoH TLS handshakes authenticate while dialing the IP literals above. */
-        private val DOH_TLS_SERVER_NAMES = mapOf(
-            "1.1.1.1" to "cloudflare-dns.com",
-            "8.8.8.8" to "dns.google",
-        )
-
-        // Per-evaluate budget before the next resolver runs, and the terminal/global budget.
+        // Per-evaluate budget before the next resolver runs, and the terminal/global budget —
+        // the shared builder's dnsPrimaryTimeout/dnsFallbackTimeout, in milliseconds.
         const val DNS_PRIMARY_TIMEOUT_MS = 2_000L
         const val DNS_FALLBACK_TIMEOUT_MS = 3_000L
-        private val DNS_PRIMARY_TIMEOUT = "${DNS_PRIMARY_TIMEOUT_MS / 1_000}s"
-        private val DNS_FALLBACK_TIMEOUT = "${DNS_FALLBACK_TIMEOUT_MS / 1_000}s"
 
         /**
          * Engine-side worst case for one lookup through the default chain: every non-terminal
@@ -441,12 +138,12 @@ data class SingBoxConfiguration(
 
         /**
          * The ONLY in-TUN address whose port-53 traffic sing-box hijacks. When the tun inbound
-         * carries no explicit `dns_address` (we emit none), sing-tun derives the hijack address
-         * as the next address after the TUN's own IPv4 address, and the tun inbound tags a
-         * packet `Protocol=DNS` only when its destination equals that address — after which the
-         * router hijacks it into the DNS module ahead of any route rule. A datagram addressed
-         * to a public resolver (1.1.1.1) is NOT tagged, matches no rule, and dies on the
-         * TCP-only proxy outbound, so the fresh-DNS probe must target this address.
+         * carries no explicit `dns_address` (the shared builder emits none), sing-tun derives the
+         * hijack address as the next address after the TUN's own IPv4 address, and the tun
+         * inbound tags a packet `Protocol=DNS` only when its destination equals that address —
+         * after which the router hijacks it into the DNS module ahead of any route rule. A
+         * datagram addressed to a public resolver (1.1.1.1) is NOT tagged, matches no rule, and
+         * dies on the TCP-only proxy outbound, so the fresh-DNS probe must target this address.
          */
         val DEFAULT_TUNNEL_DNS_ADDRESS = tunnelDnsAddress(DEFAULT_TUNNEL_IPV4_ADDRESS)
 
@@ -481,23 +178,6 @@ data class SingBoxConfiguration(
                 "tunnel address $tunnelIPv4Address has no successor inside its prefix for sing-tun to hijack"
             }
             return (24 downTo 0 step 8).joinToString(".") { shift -> ((next shr shift) and 0xFF).toString() }
-        }
-
-        fun relayRouteExcludeAddress(host: String): String? {
-            val cleanHost = host.removePrefix("[").removeSuffix("]")
-            return when {
-                cleanHost.isIPv4Literal() -> "$cleanHost/32"
-                cleanHost.contains(":") -> "$cleanHost/128"
-                else -> null
-            }
-        }
-
-        private fun String.isIPv4Literal(): Boolean {
-            val octets = split(".")
-            return octets.size == 4 && octets.all { octet ->
-                val value = octet.toIntOrNull()
-                value != null && value in 0..255 && value.toString() == octet
-            }
         }
     }
 }

--- a/android/app/src/test/java/com/openrung/net/SingBoxBindingFixtures.kt
+++ b/android/app/src/test/java/com/openrung/net/SingBoxBindingFixtures.kt
@@ -1,0 +1,71 @@
+package com.openrung.net
+
+import com.openrung.model.RelayDescriptor
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import java.io.File
+
+/**
+ * The sing-box binding fixtures shared by the three platform suites and `android/punchbridge`'s
+ * Go tests: one `<scenario>.input.json` per platform scenario (the binding input the assembly
+ * must produce), and one frozen `<scenario>.golden.json` holding the bound builder's output.
+ * The Go suite is the only writer of the goldens and pins input→config through the real binding;
+ * the suites here pin platform state→input and re-run this platform's structural emission
+ * assertions against the goldens — so the existing expectations hold against the bound output
+ * without the JVM loading the gomobile engine.
+ */
+object SingBoxBindingFixtures {
+    private val directory: File = File(
+        requireNotNull(System.getProperty("openrung.contractVectors")) {
+            "openrung.contractVectors is unset; the Gradle unit-test task should supply it"
+        },
+    ).parentFile.resolve("singbox-binding")
+
+    fun input(scenario: String): JsonObject = parse("$scenario.input.json")
+
+    fun golden(scenario: String): JsonObject = parse(goldenText(scenario))
+
+    fun goldenText(scenario: String): String =
+        directory.resolve("$scenario.golden.json").readText()
+
+    /** Scenario names for this platform, derived from the checked-in input files. */
+    fun scenarios(platform: String): List<String> =
+        requireNotNull(directory.list()) { "missing fixture directory $directory" }
+            .filter { it.startsWith("$platform-") && it.endsWith(".input.json") }
+            .map { it.removeSuffix(".input.json") }
+            .sorted()
+
+    private fun parse(nameOrText: String): JsonObject {
+        val text = if (nameOrText.endsWith(".json")) directory.resolve(nameOrText).readText() else nameOrText
+        return Json.parseToJsonElement(text).jsonObject
+    }
+
+    /**
+     * The relay every scenario input carries. The connection identity fields must match the
+     * fixtures' `relay` object byte-for-byte; the remaining fields exist only to satisfy the
+     * model and are never assembled into the binding input.
+     */
+    fun relay(): RelayDescriptor = RelayDescriptor(
+        id = "relay-1",
+        label = "test-relay",
+        publicHost = "203.0.113.10",
+        publicPort = 443,
+        relayProtocol = "vless-reality-vision",
+        clientId = "e6b1a1de-9f0f-4c1a-8bb1-1f2b3c4d5e6f",
+        realityPublicKey = "reality-key",
+        shortId = "abcd1234",
+        serverName = "www.example.com",
+        flow = "xtls-rprx-vision",
+        exitMode = "direct",
+        maxSessions = 8,
+        maxMbps = 100,
+        relayVersion = "1.0.0",
+        transport = "tunnel",
+        punchCapable = true,
+        punchEndpoint = "https://203.0.113.10:9444",
+        registeredAt = "2026-01-01T00:00:00Z",
+        lastHeartbeatAt = "2026-01-01T00:00:00Z",
+        expiresAt = "2026-01-01T01:00:00Z",
+    )
+}

--- a/android/app/src/test/java/com/openrung/net/SingBoxConfigurationBindingInputTest.kt
+++ b/android/app/src/test/java/com/openrung/net/SingBoxConfigurationBindingInputTest.kt
@@ -1,0 +1,106 @@
+package com.openrung.net
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The assembly half of the sing-box builder contract: the configuration each Android scenario
+ * constructs must produce exactly the checked-in binding input for that scenario. The other half
+ * — those inputs building to the frozen goldens through the real binding — runs in
+ * `android/punchbridge`'s Go tests, and the structural suites here assert against the goldens.
+ */
+class SingBoxConfigurationBindingInputTest {
+
+    /** The configuration whose assembly must reproduce each scenario's input file. */
+    private fun configurationFor(scenario: String): SingBoxConfiguration {
+        val relay = SingBoxBindingFixtures.relay()
+        val directory = "/data/user/0/rulesets"
+        return when (scenario) {
+            "android-tun" -> SingBoxConfiguration(relay)
+            "android-bridge" -> SingBoxConfiguration(relay, bridgeHost = "127.0.0.1", bridgePort = 54321)
+            "android-split-empty" -> SingBoxConfiguration(
+                relay,
+                splitTunnel = SplitTunnelRules(false, emptyList(), emptyList(), ""),
+            )
+            "android-split-lan" -> SingBoxConfiguration(
+                relay,
+                splitTunnel = SplitTunnelRules(true, emptyList(), emptyList(), directory),
+            )
+            "android-split-ir" -> SingBoxConfiguration(
+                relay,
+                splitTunnel = SplitTunnelRules(false, listOf("ir"), emptyList(), directory),
+            )
+            "android-split-cn" -> SingBoxConfiguration(
+                relay,
+                splitTunnel = SplitTunnelRules(false, listOf("cn"), emptyList(), directory),
+            )
+            "android-split-ir-cn-lan" -> SingBoxConfiguration(
+                relay,
+                splitTunnel = SplitTunnelRules(true, listOf("ir", "cn"), emptyList(), directory),
+            )
+            "android-split-ir-cn-lan-bridge" -> SingBoxConfiguration(
+                relay,
+                bridgeHost = "127.0.0.1",
+                bridgePort = 54321,
+                splitTunnel = SplitTunnelRules(true, listOf("ir", "cn"), emptyList(), directory),
+            )
+            "android-split-packages" -> SingBoxConfiguration(
+                relay,
+                splitTunnel = SplitTunnelRules(
+                    false,
+                    emptyList(),
+                    listOf("com.tencent.mm", "org.telegram.messenger"),
+                    "",
+                ),
+            )
+            else -> throw AssertionError(
+                "no construction for scenario $scenario; add it here when adding a fixture",
+            )
+        }
+    }
+
+    @Test
+    fun `every android scenario assembles to its checked-in binding input`() {
+        val scenarios = SingBoxBindingFixtures.scenarios("android")
+        assertTrue("no android scenarios found; the fixture directory changed shape", scenarios.size >= 5)
+        scenarios.forEach { scenario ->
+            assertEquals(
+                scenario,
+                SingBoxBindingFixtures.input(scenario),
+                Json.parseToJsonElement(configurationFor(scenario).bindingInputJson(debug = false)).jsonObject,
+            )
+        }
+    }
+
+    @Test
+    fun `debug builds request the info log level`() {
+        val assembled = Json.parseToJsonElement(
+            SingBoxConfiguration(SingBoxBindingFixtures.relay()).bindingInputJson(debug = true),
+        ).jsonObject
+        assertEquals("info", assembled["log_level"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `a partial bridge is forwarded faithfully for the binding to reject`() {
+        // The old generator rejected a partial bridge locally; that validation is the binding's
+        // now (see the Go suite), so the assembly must not repair or drop the partial values.
+        val hostOnly = Json.parseToJsonElement(
+            SingBoxConfiguration(SingBoxBindingFixtures.relay(), bridgeHost = "127.0.0.1")
+                .bindingInputJson(debug = false),
+        ).jsonObject
+        assertEquals("127.0.0.1", hostOnly["bridge_host"]!!.jsonPrimitive.content)
+        assertFalse(hostOnly.containsKey("bridge_port"))
+
+        val portOnly = Json.parseToJsonElement(
+            SingBoxConfiguration(SingBoxBindingFixtures.relay(), bridgePort = 1234)
+                .bindingInputJson(debug = false),
+        ).jsonObject
+        assertEquals(1234, portOnly["bridge_port"]!!.jsonPrimitive.content.toInt())
+        assertFalse(portOnly.containsKey("bridge_host"))
+    }
+}

--- a/android/app/src/test/java/com/openrung/net/SingBoxConfigurationDnsTest.kt
+++ b/android/app/src/test/java/com/openrung/net/SingBoxConfigurationDnsTest.kt
@@ -1,7 +1,5 @@
 package com.openrung.net
 
-import com.openrung.model.RelayDescriptor
-import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
@@ -15,16 +13,20 @@ import org.junit.Test
 import java.net.URI
 
 /**
- * Regression tests for the DoH emission and the probe-priority pins. TCP/53 through the proxy
- * receives no replies under WSS relays, and geosite-cn contains probe-class hostnames
+ * Regression tests for the DoH emission and the probe-priority pins, asserted against the frozen
+ * bound outputs under testdata/singbox-binding (see [SingBoxBindingFixtures]). TCP/53 through the
+ * proxy receives no replies under WSS relays, and geosite-cn contains probe-class hostnames
  * (www.gstatic.com), so both properties below are load-bearing for startup truthfulness.
  */
 class SingBoxConfigurationDnsTest {
     @Test
     fun `resolvers are emitted as DoH servers detoured through the proxy`() {
-        val servers = SingBoxConfiguration(relay()).makeJsonObject().dnsServers()
+        val servers = SingBoxBindingFixtures.golden("android-tun").dnsServers()
         assertEquals(listOf("dns-0", "dns-1"), servers.map { it.tag() })
-        assertEquals(listOf("1.1.1.1", "8.8.8.8"), servers.map { it["server"]!!.jsonPrimitive.content })
+        assertEquals(
+            SingBoxConfiguration.DEFAULT_DOH_RESOLVERS,
+            servers.map { it["server"]!!.jsonPrimitive.content },
+        )
         servers.forEach { server ->
             assertEquals("https", server["type"]!!.jsonPrimitive.content)
             assertEquals("proxy", server["detour"]!!.jsonPrimitive.content)
@@ -44,18 +46,15 @@ class SingBoxConfigurationDnsTest {
 
     @Test
     fun `no dns server anywhere speaks plaintext dns`() {
-        val config = SingBoxConfiguration(
-            relay(),
-            splitTunnel = rules(bypassCountries = listOf("ir", "cn")),
-        ).makeJsonObject()
-        config.dnsServers().forEach { server ->
+        val config = SingBoxBindingFixtures.golden("android-split-ir-cn-lan")
+        config.dnsServers(includeDirect = true).forEach { server ->
             // Proxied resolvers need DoH because relays answer 443 on every transport while
             // TCP/53 gets no replies under WSS. The bypass-country resolvers need it for a
             // different reason: they are dialed DIRECTLY, so an unencrypted query would leave
             // the device on the user's real IP — in cleartext, and forgeable — while the tunnel
             // is up. Neither may ever regress to udp/tcp.
             assertEquals(
-                "every dns server must be encrypted: ${server["tag"]!!.jsonPrimitive.content}",
+                "every dns server must be encrypted: ${server.tag()}",
                 "https",
                 server["type"]!!.jsonPrimitive.content,
             )
@@ -68,7 +67,7 @@ class SingBoxConfigurationDnsTest {
 
     @Test
     fun `default domain resolver stays on the primary and final on the terminal fallback`() {
-        val config = SingBoxConfiguration(relay()).makeJsonObject()
+        val config = SingBoxBindingFixtures.golden("android-tun")
         // The global chain's trailing route rule is the real terminus; `final` names the same
         // fallback resolver for coherence.
         assertEquals("dns-1", config["dns"]!!.jsonObject["final"]!!.jsonPrimitive.content)
@@ -84,8 +83,7 @@ class SingBoxConfigurationDnsTest {
         // sing-box has no upstream failover of its own: `evaluate` is non-terminal on a
         // transport error/timeout/SERVFAIL/REFUSED, `respond` returns a usable answer (NOERROR,
         // or an authoritative NXDOMAIN), and the trailing route rule is the terminal fallback.
-        val rules = SingBoxConfiguration(relay()).makeJsonObject()
-            .dnsRules().takeLast(4)
+        val rules = SingBoxBindingFixtures.golden("android-tun").dnsRules().takeLast(4)
         assertEquals("evaluate", rules[0]["action"]!!.jsonPrimitive.content)
         assertEquals("dns-0", rules[0]["server"]!!.jsonPrimitive.content)
         assertEquals("2s", rules[0]["timeout"]!!.jsonPrimitive.content)
@@ -101,31 +99,20 @@ class SingBoxConfigurationDnsTest {
 
     @Test
     fun `probe dns chain is always first uncached and terminal for probe domains`() {
-        val baseline = SingBoxConfiguration(relay()).makeJsonObject()
-        val china = SingBoxConfiguration(
-            relay(),
-            splitTunnel = rules(bypassCountries = listOf("cn")),
-        ).makeJsonObject()
-
-        listOf(baseline, china).forEach { config ->
-            val probeChain = config.dnsRules().take(4)
+        listOf("android-tun", "android-split-cn").forEach { scenario ->
+            val probeChain = SingBoxBindingFixtures.golden(scenario).dnsRules().take(4)
             // Every probe rule is scoped to the probe domains; the chain ends in a terminal
             // route rule, so a probe lookup can never leak past it into a country rule.
             probeChain.forEach { rule ->
+                assertEquals(
+                    ProbeTargets.RULE_DOMAIN_SUFFIXES,
+                    rule["domain_suffix"]!!.jsonArray.map { it.jsonPrimitive.content },
+                )
                 if (rule["match_response"]?.jsonPrimitive?.content?.toBoolean() != true) {
-                    assertEquals(
-                        ProbeTargets.RULE_DOMAIN_SUFFIXES,
-                        rule["domain_suffix"]!!.jsonArray.map { it.jsonPrimitive.content },
-                    )
                     assertEquals(true, rule["disable_cache"]!!.jsonPrimitive.content.toBoolean())
                     assertEquals(
                         true,
                         rule["disable_optimistic_cache"]!!.jsonPrimitive.content.toBoolean(),
-                    )
-                } else {
-                    assertEquals(
-                        ProbeTargets.RULE_DOMAIN_SUFFIXES,
-                        rule["domain_suffix"]!!.jsonArray.map { it.jsonPrimitive.content },
                     )
                 }
             }
@@ -143,10 +130,7 @@ class SingBoxConfigurationDnsTest {
         // The confirmed regression: geosite-cn contains www.gstatic.com, so before these pins a
         // dead proxy still produced a passing probe over the direct path and the app published
         // CONNECTED. Probe DNS and probe routing must both win before any country rule.
-        val config = SingBoxConfiguration(
-            relay(),
-            splitTunnel = rules(bypassCountries = listOf("cn")),
-        ).makeJsonObject()
+        val config = SingBoxBindingFixtures.golden("android-split-cn")
 
         val dnsRules = config.dnsRules()
         assertTrue(dnsRules[0].containsKey("domain_suffix"))
@@ -189,15 +173,15 @@ class SingBoxConfigurationDnsTest {
     fun `probe queries target the only address sing-box hijacks`() {
         // sing-box tags a packet as DNS — and hijacks it into the DNS module ahead of every
         // route rule — ONLY when its destination equals the TUN's derived DNS address (the next
-        // address after the TUN's own IPv4 address, since we emit no dns_address). A probe sent
-        // to a public resolver instead would match no rule and die on the TCP-only proxy
+        // address after the TUN's own IPv4 address, since no dns_address is emitted). A probe
+        // sent to a public resolver instead would match no rule and die on the TCP-only proxy
         // outbound, failing on every healthy tunnel.
         assertEquals("172.19.0.1/30", SingBoxConfiguration.DEFAULT_TUNNEL_IPV4_ADDRESS)
         assertEquals("172.19.0.2", SingBoxConfiguration.DEFAULT_TUNNEL_DNS_ADDRESS)
         assertEquals(
             SingBoxConfiguration.DEFAULT_TUNNEL_DNS_ADDRESS,
             SingBoxConfiguration.tunnelDnsAddress(
-                SingBoxConfiguration(relay()).tunnelIPv4Address,
+                SingBoxConfiguration(SingBoxBindingFixtures.relay()).tunnelIPv4Address,
             ),
         )
         // Octet carry, so a future tunnel address change cannot silently derive a wrong hijack
@@ -231,61 +215,25 @@ class SingBoxConfigurationDnsTest {
     fun `tun inbound never pins its own dns_address away from the derived one`() {
         // An explicit dns_address on the tun inbound would replace the derived hijack address
         // and silently invalidate the probe target above.
-        val tunInbound = SingBoxConfiguration(relay()).makeJsonObject()["inbounds"]!!
+        val tunInbound = SingBoxBindingFixtures.golden("android-tun")["inbounds"]!!
             .jsonArray[0].jsonObject
         assertFalse(tunInbound.containsKey("dns_address"))
     }
 
     @Test
     fun `dns block is identical across direct and bridged shapes`() {
-        val direct = SingBoxConfiguration(relay()).makeJsonObject()
-        val bridged = SingBoxConfiguration(
-            relay(),
-            bridgeHost = "127.0.0.1",
-            bridgePort = 54321,
-        ).makeJsonObject()
-        assertEquals(direct["dns"], bridged["dns"])
+        assertEquals(
+            SingBoxBindingFixtures.golden("android-tun")["dns"],
+            SingBoxBindingFixtures.golden("android-bridge")["dns"],
+        )
     }
 
-    private fun JsonObject.dnsServers(): List<JsonObject> =
+    private fun JsonObject.dnsServers(includeDirect: Boolean = false): List<JsonObject> =
         this["dns"]!!.jsonObject["servers"]!!.jsonArray.map { it.jsonObject }
-            .filter { it.tag().startsWith("dns-") && !it.tag().startsWith("dns-direct-") }
+            .filter { includeDirect || !it.tag().startsWith("dns-direct-") }
 
     private fun JsonObject.dnsRules(): List<JsonObject> =
         this["dns"]!!.jsonObject["rules"]!!.jsonArray.map { it.jsonObject }
 
     private fun JsonObject.tag(): String = this["tag"]!!.jsonPrimitive.content
-
-    private fun rules(
-        bypassLan: Boolean = false,
-        bypassCountries: List<String> = emptyList(),
-    ): SplitTunnelRules = SplitTunnelRules(
-        bypassLan = bypassLan,
-        bypassCountries = bypassCountries,
-        excludedPackages = emptyList(),
-        ruleSetDirectory = "/data/user/0/rulesets",
-    )
-
-    private fun relay(): RelayDescriptor = RelayDescriptor(
-        id = "relay-1",
-        label = "test-relay",
-        publicHost = "203.0.113.10",
-        publicPort = 443,
-        relayProtocol = "vless-reality-vision",
-        clientId = "e6b1a1de-9f0f-4c1a-8bb1-1f2b3c4d5e6f",
-        realityPublicKey = "reality-key",
-        shortId = "abcd1234",
-        serverName = "www.example.com",
-        flow = "xtls-rprx-vision",
-        exitMode = "direct",
-        maxSessions = 8,
-        maxMbps = 100,
-        relayVersion = "1.0.0",
-        transport = "tunnel",
-        punchCapable = true,
-        punchEndpoint = "https://203.0.113.10:9444",
-        registeredAt = "2026-01-01T00:00:00Z",
-        lastHeartbeatAt = "2026-01-01T00:00:00Z",
-        expiresAt = "2026-01-01T01:00:00Z",
-    )
 }

--- a/android/app/src/test/java/com/openrung/net/SingBoxConfigurationPunchTest.kt
+++ b/android/app/src/test/java/com/openrung/net/SingBoxConfigurationPunchTest.kt
@@ -1,26 +1,26 @@
 package com.openrung.net
 
-import com.openrung.model.RelayDescriptor
 import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
+/**
+ * Punched/bridged emission expectations, asserted against the frozen bound outputs under
+ * testdata/singbox-binding (see [SingBoxBindingFixtures]). The partial-bridge rejection the old
+ * generator enforced locally lives in the binding now, pinned by android/punchbridge's Go
+ * validation tests; [SingBoxConfigurationBindingInputTest] pins that a partial bridge is
+ * forwarded faithfully for it to reject.
+ */
 class SingBoxConfigurationPunchTest {
     @Test
     fun `punch bridge changes only the transport endpoint`() {
-        val relay = relay()
-        val config = SingBoxConfiguration(
-            relay = relay,
-            bridgeHost = "127.0.0.1",
-            bridgePort = 54321,
-        ).makeJsonObject()
+        val relay = SingBoxBindingFixtures.relay()
+        val config = SingBoxBindingFixtures.golden("android-bridge")
 
         val outbound = config["outbounds"]!!.jsonArray[0].jsonObject
         assertEquals("127.0.0.1", outbound["server"]!!.jsonPrimitive.content)
@@ -42,7 +42,7 @@ class SingBoxConfigurationPunchTest {
 
     @Test
     fun `ordinary relay path keeps its endpoint route exclusion`() {
-        val config = SingBoxConfiguration(relay()).makeJsonObject()
+        val config = SingBoxBindingFixtures.golden("android-tun")
         val outbound = config["outbounds"]!!.jsonArray[0].jsonObject
         assertEquals("203.0.113.10", outbound["server"]!!.jsonPrimitive.content)
         assertEquals(443, outbound["server_port"]!!.jsonPrimitive.content.toInt())
@@ -51,37 +51,4 @@ class SingBoxConfigurationPunchTest {
         val excluded = tunInbound["route_exclude_address"] as JsonArray
         assertTrue(excluded.any { it.jsonPrimitive.content == "203.0.113.10/32" })
     }
-
-    @Test
-    fun `rejects a partial punch bridge`() {
-        assertThrows(IllegalArgumentException::class.java) {
-            SingBoxConfiguration(relay(), bridgeHost = "127.0.0.1").encodedJsonString()
-        }
-        assertThrows(IllegalArgumentException::class.java) {
-            SingBoxConfiguration(relay(), bridgePort = 1234).encodedJsonString()
-        }
-    }
-
-    private fun relay(): RelayDescriptor = RelayDescriptor(
-        id = "relay-1",
-        label = "test-relay",
-        publicHost = "203.0.113.10",
-        publicPort = 443,
-        relayProtocol = "vless-reality-vision",
-        clientId = "e6b1a1de-9f0f-4c1a-8bb1-1f2b3c4d5e6f",
-        realityPublicKey = "reality-key",
-        shortId = "abcd1234",
-        serverName = "www.example.com",
-        flow = "xtls-rprx-vision",
-        exitMode = "direct",
-        maxSessions = 8,
-        maxMbps = 100,
-        relayVersion = "1.0.0",
-        transport = "tunnel",
-        punchCapable = true,
-        punchEndpoint = "https://203.0.113.10:9444",
-        registeredAt = "2026-01-01T00:00:00Z",
-        lastHeartbeatAt = "2026-01-01T00:00:00Z",
-        expiresAt = "2026-01-01T01:00:00Z",
-    )
 }

--- a/android/app/src/test/java/com/openrung/net/SingBoxConfigurationSplitTunnelTest.kt
+++ b/android/app/src/test/java/com/openrung/net/SingBoxConfigurationSplitTunnelTest.kt
@@ -1,6 +1,5 @@
 package com.openrung.net
 
-import com.openrung.model.RelayDescriptor
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonArray
@@ -11,27 +10,24 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
+/**
+ * Split-tunnel emission expectations, asserted against the frozen bound outputs under
+ * testdata/singbox-binding (see [SingBoxBindingFixtures]). The scenario inputs these goldens are
+ * built from are pinned by [SingBoxConfigurationBindingInputTest].
+ */
 class SingBoxConfigurationSplitTunnelTest {
     @Test
-    fun `null split tunnel emits the exact no-split configuration`() {
-        val baseline = SingBoxConfiguration(relay()).makeJsonObject()
-        assertEquals(baseline, SingBoxConfiguration(relay(), splitTunnel = null).makeJsonObject())
-    }
-
-    @Test
     fun `all-empty split rules emit the exact no-split configuration`() {
-        val baseline = SingBoxConfiguration(relay()).makeJsonObject()
-        val noop = SingBoxConfiguration(relay(), splitTunnel = rules()).makeJsonObject()
-        assertEquals(baseline, noop)
+        assertEquals(
+            SingBoxBindingFixtures.goldenText("android-tun"),
+            SingBoxBindingFixtures.goldenText("android-split-empty"),
+        )
     }
 
     @Test
     fun `lan-only bypass adds exactly one route rule and nothing else`() {
-        val baseline = SingBoxConfiguration(relay()).makeJsonObject()
-        val config = SingBoxConfiguration(
-            relay(),
-            splitTunnel = rules(bypassLan = true),
-        ).makeJsonObject()
+        val baseline = SingBoxBindingFixtures.golden("android-tun")
+        val config = SingBoxBindingFixtures.golden("android-split-lan")
 
         val routeRules = config.routeRules()
         assertEquals(baseline.routeRules().size + 1, routeRules.size)
@@ -41,20 +37,14 @@ class SingBoxConfigurationSplitTunnelTest {
         assertFalse(routeRules.any { "sniff" == it.jsonObject["action"]?.jsonPrimitive?.content })
 
         // Only the always-on probe/global failover chains; no country rules without countries.
-        assertEquals(
-            SingBoxConfiguration(relay()).makeJsonObject()["dns"],
-            config["dns"],
-        )
+        assertEquals(baseline["dns"], config["dns"])
         assertFalse(config["route"]!!.jsonObject.containsKey("rule_set"))
         assertFalse(config.tunInbound().containsKey("exclude_package"))
     }
 
     @Test
     fun `single country bypass wires dns and route rule sets`() {
-        val config = SingBoxConfiguration(
-            relay(),
-            splitTunnel = rules(bypassCountries = listOf("ir")),
-        ).makeJsonObject()
+        val config = SingBoxBindingFixtures.golden("android-split-ir")
 
         val routeRules = config.routeRules()
         assertEquals("hijack-dns", routeRules[0].jsonObject["action"]!!.jsonPrimitive.content)
@@ -79,10 +69,7 @@ class SingBoxConfigurationSplitTunnelTest {
         // no dns server and no dns rules at all — its ROUTE bypass above is untouched, and its
         // lookups just reach the proxied global chain. A dead primary would be strictly worse:
         // every bypassed lookup would burn the full evaluate timeout on a doomed TLS handshake.
-        assertEquals(
-            SingBoxConfiguration(relay()).makeJsonObject()["dns"],
-            config["dns"],
-        )
+        assertEquals(SingBoxBindingFixtures.golden("android-tun")["dns"], config["dns"])
         assertTrue(
             dns["servers"]!!.jsonArray.none {
                 it.jsonObject["tag"]!!.jsonPrimitive.content.startsWith("dns-direct-")
@@ -101,10 +88,7 @@ class SingBoxConfigurationSplitTunnelTest {
 
     @Test
     fun `both countries plus lan keep the full canonical rule order`() {
-        val config = SingBoxConfiguration(
-            relay(),
-            splitTunnel = rules(bypassLan = true, bypassCountries = listOf("ir", "cn")),
-        ).makeJsonObject()
+        val config = SingBoxBindingFixtures.golden("android-split-ir-cn-lan")
 
         val routeRules = config.routeRules().map { it.jsonObject }
         assertEquals(6, routeRules.size)
@@ -122,8 +106,8 @@ class SingBoxConfigurationSplitTunnelTest {
         )
 
         val dns = config["dns"]!!.jsonObject
-        // Only China contributes a resolver today (see SplitTunnelRules.directResolver), but the
-        // ROUTE rules above still cover both countries.
+        // Only China contributes a resolver today (see connectcore's split-tunnel resolver
+        // table), but the ROUTE rules above still cover both countries.
         val directServers = dns["servers"]!!.jsonArray.map { it.jsonObject }
             .filter { it["tag"]!!.jsonPrimitive.content.startsWith("dns-direct-") }
         assertEquals(
@@ -154,12 +138,7 @@ class SingBoxConfigurationSplitTunnelTest {
 
     @Test
     fun `excluded packages land on the tun inbound and never as include_package`() {
-        val config = SingBoxConfiguration(
-            relay(),
-            splitTunnel = rules(excludedPackages = listOf("com.tencent.mm", "org.telegram.messenger")),
-        ).makeJsonObject()
-
-        val tunInbound = config.tunInbound()
+        val tunInbound = SingBoxBindingFixtures.golden("android-split-packages").tunInbound()
         assertEquals(
             listOf("com.tencent.mm", "org.telegram.messenger"),
             tunInbound["exclude_package"]!!.jsonArray.map { it.jsonPrimitive.content },
@@ -169,14 +148,8 @@ class SingBoxConfigurationSplitTunnelTest {
 
     @Test
     fun `bridge mode keeps split rules and still omits the endpoint route exclusion`() {
-        val splitTunnel = rules(bypassLan = true, bypassCountries = listOf("ir", "cn"))
-        val direct = SingBoxConfiguration(relay(), splitTunnel = splitTunnel).makeJsonObject()
-        val bridged = SingBoxConfiguration(
-            relay(),
-            bridgeHost = "127.0.0.1",
-            bridgePort = 54321,
-            splitTunnel = splitTunnel,
-        ).makeJsonObject()
+        val direct = SingBoxBindingFixtures.golden("android-split-ir-cn-lan")
+        val bridged = SingBoxBindingFixtures.golden("android-split-ir-cn-lan-bridge")
 
         assertEquals(direct["dns"], bridged["dns"])
         assertEquals(direct["route"], bridged["route"])
@@ -186,44 +159,9 @@ class SingBoxConfigurationSplitTunnelTest {
         assertTrue(direct.tunInbound().containsKey("route_exclude_address"))
     }
 
-    private fun rules(
-        bypassLan: Boolean = false,
-        bypassCountries: List<String> = emptyList(),
-        excludedPackages: List<String> = emptyList(),
-        ruleSetDirectory: String = "/data/user/0/rulesets",
-    ): SplitTunnelRules = SplitTunnelRules(
-        bypassLan = bypassLan,
-        bypassCountries = bypassCountries,
-        excludedPackages = excludedPackages,
-        ruleSetDirectory = ruleSetDirectory,
-    )
-
     private fun JsonObject.routeRules(): JsonArray =
         this["route"]!!.jsonObject["rules"]!!.jsonArray
 
     private fun JsonObject.tunInbound(): JsonObject =
         this["inbounds"]!!.jsonArray[0].jsonObject
-
-    private fun relay(): RelayDescriptor = RelayDescriptor(
-        id = "relay-1",
-        label = "test-relay",
-        publicHost = "203.0.113.10",
-        publicPort = 443,
-        relayProtocol = "vless-reality-vision",
-        clientId = "e6b1a1de-9f0f-4c1a-8bb1-1f2b3c4d5e6f",
-        realityPublicKey = "reality-key",
-        shortId = "abcd1234",
-        serverName = "www.example.com",
-        flow = "xtls-rprx-vision",
-        exitMode = "direct",
-        maxSessions = 8,
-        maxMbps = 100,
-        relayVersion = "1.0.0",
-        transport = "tunnel",
-        punchCapable = true,
-        punchEndpoint = "https://203.0.113.10:9444",
-        registeredAt = "2026-01-01T00:00:00Z",
-        lastHeartbeatAt = "2026-01-01T00:00:00Z",
-        expiresAt = "2026-01-01T01:00:00Z",
-    )
 }

--- a/android/app/src/test/java/com/openrung/vpn/StartupProbeChinaBypassTest.kt
+++ b/android/app/src/test/java/com/openrung/vpn/StartupProbeChinaBypassTest.kt
@@ -6,8 +6,7 @@ import com.openrung.model.WssFrontDescriptor
 import com.openrung.net.DnsProbe
 import com.openrung.net.InternetProbeResult
 import com.openrung.net.ProbeTargets
-import com.openrung.net.SingBoxConfiguration
-import com.openrung.net.SplitTunnelRules
+import com.openrung.net.SingBoxBindingFixtures
 import com.openrung.net.TunnelDnsTransport
 import com.openrung.net.TunnelHttpProbe
 import com.openrung.net.TunnelPathProbe
@@ -86,15 +85,9 @@ class StartupProbeChinaBypassTest {
     fun `china bypass config keeps every probe flow on the proxy`() {
         // The premise the socket-boundary fakes rest on: with cn bypass enabled, probe DNS is
         // answered only via the proxied DoH resolver and probe HTTPS routes only to the proxy.
-        val config = SingBoxConfiguration(
-            relay(),
-            splitTunnel = SplitTunnelRules(
-                bypassLan = false,
-                bypassCountries = listOf("cn"),
-                excludedPackages = emptyList(),
-                ruleSetDirectory = "/data/user/0/rulesets",
-            ),
-        ).makeJsonObject()
+        // The config is the frozen bound output for exactly this shape (see
+        // SingBoxBindingFixtures and SingBoxConfigurationBindingInputTest).
+        val config = SingBoxBindingFixtures.golden("android-split-cn")
 
         val dns = config["dns"]!!.jsonObject
         val probeDnsRule = dns["rules"]!!.jsonArray.first().jsonObject

--- a/android/build-libbox-release.sh
+++ b/android/build-libbox-release.sh
@@ -259,6 +259,7 @@ cp "$punch_source/binding.go" "$work_dir/source/experimental/libbox/openrung_pun
 cp "$punch_source/wss_binding.go" "$work_dir/source/experimental/libbox/openrung_wss.go"
 cp "$punch_source/broker_binding.go" "$work_dir/source/experimental/libbox/openrung_broker.go"
 cp "$punch_source/failure_binding.go" "$work_dir/source/experimental/libbox/openrung_failure.go"
+cp "$punch_source/singbox_binding.go" "$work_dir/source/experimental/libbox/openrung_singbox.go"
 mkdir -p "$work_dir/source/experimental/libbox/internal/openrungpunch"
 for source_file in "$punch_source/internal/openrungpunch/"*.go; do
   case "$source_file" in
@@ -350,6 +351,7 @@ required_classes = [
     "io/nekohasekai/libbox/OpenRungBrokerSpeedTestResult.class",
     "io/nekohasekai/libbox/OpenRungBrokerManifestResult.class",
     "io/nekohasekai/libbox/OpenRungBrokerWSSTicketResult.class",
+    "io/nekohasekai/libbox/OpenRungSingBoxConfigResult.class",
 ]
 required_native_libraries = [
     "jni/armeabi-v7a/libbox.so",
@@ -382,7 +384,8 @@ javap_output="$(
     io.nekohasekai.libbox.OpenRungBrokerRelayResult \
     io.nekohasekai.libbox.OpenRungBrokerSpeedTestResult \
     io.nekohasekai.libbox.OpenRungBrokerManifestResult \
-    io.nekohasekai.libbox.OpenRungBrokerWSSTicketResult
+    io.nekohasekai.libbox.OpenRungBrokerWSSTicketResult \
+    io.nekohasekai.libbox.OpenRungSingBoxConfigResult
 )"
 # Every entry below must be a symbol a Kotlin/Swift/React Native call site actually links. Pinning
 # an unconsumed binding method here gates releases on surface nothing uses — `downloadSpeedTest`
@@ -412,7 +415,9 @@ for generated_symbol in \
   'httpStatus();' \
   'retryAfterMillis();' \
   'openRungClassifyFailure(java.lang.String);' \
-  'openRungFailureDetail(java.lang.String);'; do
+  'openRungFailureDetail(java.lang.String);' \
+  'openRungBuildSingBoxConfig(java.lang.String);' \
+  'configJSON();'; do
   if ! grep -Fq "$generated_symbol" <<< "$javap_output"; then
     echo "error: libbox AAR is missing generated broker symbol: $generated_symbol" >&2
     exit 1

--- a/android/punchbridge/singbox_binding.go
+++ b/android/punchbridge/singbox_binding.go
@@ -1,0 +1,195 @@
+package libbox
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/openrung/openrung/brokerapi"
+	"github.com/openrung/openrung/connectcore/client"
+)
+
+// openRungSingBoxInput is one platform-described sing-box build request: the
+// inputs SingBoxConfiguration.kt / SingBoxConfiguration.swift assemble, with
+// every emission decision left to connectcore's shared builder
+// (client.BuildSingBoxConfig — the superset that reproduces the mobile
+// generators' output shape). The relay object uses the broker's canonical
+// wire names, so it decodes straight into brokerapi.RelayDescriptor.
+type openRungSingBoxInput struct {
+	// Relay carries the connection identity fields of the selected relay
+	// (public_host, public_port, protocol, flow, exit_mode, client_id,
+	// reality_public_key, short_id, server_name).
+	Relay json.RawMessage `json:"relay"`
+	// TunnelIPv4Address / TunnelIPv6Address are the TUN addresses; empty keeps
+	// connectcore's defaults, which equal the mobile constants.
+	TunnelIPv4Address string `json:"tunnel_ipv4_address"`
+	TunnelIPv6Address string `json:"tunnel_ipv6_address"`
+	// MTU is required and must be positive: connectcore would default a zero
+	// MTU to 1500, silently replacing mobile's deliberate 1400.
+	MTU int `json:"mtu"`
+	// BridgeHost and BridgePort redirect the VLESS outbound to a local punch or
+	// WSS loopback adapter. Mobile bridges always own a platform-protected
+	// outer socket (VpnService.protect / the provider's tunnel-exempt socket),
+	// so an active bridge also suppresses every TUN route exclusion — a peer
+	// /32 on a protected transport would leak unrelated apps' traffic.
+	BridgeHost string `json:"bridge_host"`
+	BridgePort int    `json:"bridge_port"`
+	// LogLevel is required: "info" for debug builds, "warn" for release, and
+	// an empty value is an assembly bug rather than a request for a default.
+	LogLevel string `json:"log_level"`
+	// RouteFindProcess emits route.find_process (Android; iOS leaves it off).
+	RouteFindProcess bool `json:"route_find_process"`
+	// ProbeDomainSuffixes are the platform's ProbeTargets, required so the
+	// probe-priority DNS and route pins can never silently diverge from the
+	// endpoints the platform actually probes.
+	ProbeDomainSuffixes []string `json:"probe_domain_suffixes"`
+	// SplitTunnel enables split tunneling when non-nil; connectcore validates
+	// its countries and rule-set directory and emits a byte-identical no-split
+	// config for all-empty rules.
+	SplitTunnel *openRungSplitTunnelInput `json:"split_tunnel"`
+}
+
+type openRungSplitTunnelInput struct {
+	BypassLAN        bool     `json:"bypass_lan"`
+	BypassCountries  []string `json:"bypass_countries"`
+	ExcludedPackages []string `json:"excluded_packages"`
+	RuleSetDirectory string   `json:"rule_set_directory"`
+}
+
+// OpenRungSingBoxConfigResult is one build outcome: the emitted config JSON,
+// or the validation/build error that rejected the input. The error text names
+// input fields only — relay secrets are never interpolated into it.
+type OpenRungSingBoxConfigResult struct {
+	configJSON string
+	errorText  string
+}
+
+func (r *OpenRungSingBoxConfigResult) Succeeded() bool {
+	return r != nil && r.errorText == "" && r.configJSON != ""
+}
+
+func (r *OpenRungSingBoxConfigResult) ConfigJSON() string {
+	if r == nil {
+		return ""
+	}
+	return r.configJSON
+}
+
+func (r *OpenRungSingBoxConfigResult) ErrorText() string {
+	if r == nil {
+		return ""
+	}
+	return r.errorText
+}
+
+// OpenRungBuildSingBoxConfig builds the sing-box configuration for one
+// platform-assembled input (openRungSingBoxInput as JSON) through
+// connectcore's shared builder, so both mobile platforms and the desktop/CLI
+// clients emit the same shape from one implementation. The platforms keep
+// only input assembly; validation of the assembled input happens here (the
+// mobile-specific contract) and in connectcore (relay identity, split-tunnel
+// countries).
+func OpenRungBuildSingBoxConfig(inputJSON string) *OpenRungSingBoxConfigResult {
+	input, err := decodeOpenRungSingBoxInput(inputJSON)
+	if err != nil {
+		return failedOpenRungSingBoxConfigResult(err)
+	}
+	builderInput, err := openRungSingBoxBuilderInput(input)
+	if err != nil {
+		return failedOpenRungSingBoxConfigResult(err)
+	}
+	configJSON, err := client.BuildSingBoxConfig(builderInput)
+	if err != nil {
+		return failedOpenRungSingBoxConfigResult(err)
+	}
+	return &OpenRungSingBoxConfigResult{configJSON: string(configJSON)}
+}
+
+func decodeOpenRungSingBoxInput(inputJSON string) (openRungSingBoxInput, error) {
+	var input openRungSingBoxInput
+	decoder := json.NewDecoder(strings.NewReader(inputJSON))
+	// The adapters ship in the same bundle as this binding, so an unknown
+	// field is drift, not forward compatibility. The relay sub-object is
+	// decoded against brokerapi's canonical descriptor below instead.
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&input); err != nil {
+		return openRungSingBoxInput{}, fmt.Errorf("invalid sing-box build input: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return openRungSingBoxInput{}, errors.New("trailing data after sing-box build input")
+	}
+	return input, nil
+}
+
+// openRungSingBoxBuilderInput validates the mobile input contract and maps it
+// onto connectcore's builder input. The constants of the mobile shape — TUN
+// inbound, DoH failover DNS, traffic accounting — are fixed here rather than
+// assembled per call: no mobile build has ever varied them, and a platform
+// that could would be re-deciding policy this binding exists to centralize.
+func openRungSingBoxBuilderInput(input openRungSingBoxInput) (client.SingBoxConfigInput, error) {
+	if len(input.Relay) == 0 {
+		return client.SingBoxConfigInput{}, errors.New("sing-box build input has no relay")
+	}
+	var relay brokerapi.RelayDescriptor
+	if err := json.Unmarshal(input.Relay, &relay); err != nil {
+		return client.SingBoxConfigInput{}, fmt.Errorf("invalid relay in sing-box build input: %w", err)
+	}
+	if input.MTU <= 0 {
+		// connectcore would default a zero MTU to 1500; mobile's 1400 is
+		// deliberate, so an absent MTU is an assembly bug.
+		return client.SingBoxConfigInput{}, errors.New("mtu must be positive")
+	}
+	hasBridgeHost := input.BridgeHost != ""
+	hasBridgePort := input.BridgePort != 0
+	if hasBridgeHost != hasBridgePort || (hasBridgePort && (input.BridgePort < 1 || input.BridgePort > 65535)) {
+		// connectcore quietly ignores a partial bridge and dials the relay's
+		// public endpoint; for mobile that would mask a broken punch/WSS
+		// adapter as a direct connection.
+		return client.SingBoxConfigInput{}, errors.New("loopback adapter requires a host and valid port")
+	}
+	if strings.TrimSpace(input.LogLevel) == "" {
+		return client.SingBoxConfigInput{}, errors.New("sing-box build input has no log level")
+	}
+	if len(input.ProbeDomainSuffixes) == 0 {
+		// connectcore would fall back to its own copy of the probe suffixes;
+		// requiring the platform's keeps the DNS/route probe pins provably
+		// aligned with the endpoints the platform actually probes.
+		return client.SingBoxConfigInput{}, errors.New("sing-box build input has no probe domain suffixes")
+	}
+
+	builderInput := client.SingBoxConfigInput{
+		Relay:               relay,
+		TunnelIPv4Address:   input.TunnelIPv4Address,
+		TunnelIPv6Address:   input.TunnelIPv6Address,
+		MTU:                 input.MTU,
+		BridgeHost:          input.BridgeHost,
+		BridgePort:          input.BridgePort,
+		LogLevel:            input.LogLevel,
+		RouteFindProcess:    input.RouteFindProcess,
+		ProbeDomainSuffixes: input.ProbeDomainSuffixes,
+		// The mobile shape: full-device TUN, DoH failover DNS (TCP/53 gets no
+		// replies under WSS relays), and clash_api traffic accounting feeding
+		// the session byte counters.
+		DNSShape: client.DNSShapeDoHFailover,
+		ClashAPI: true,
+		// Every mobile bridge owns a platform-protected outer socket; see
+		// openRungSingBoxInput.BridgeHost.
+		BridgeOwnsOuterSocket: hasBridgeHost,
+	}
+	if input.SplitTunnel != nil {
+		builderInput.SplitTunnel = &client.SplitTunnelRules{
+			BypassLAN:        input.SplitTunnel.BypassLAN,
+			BypassCountries:  input.SplitTunnel.BypassCountries,
+			ExcludedPackages: input.SplitTunnel.ExcludedPackages,
+			RuleSetDirectory: input.SplitTunnel.RuleSetDirectory,
+		}
+	}
+	return builderInput, nil
+}
+
+func failedOpenRungSingBoxConfigResult(err error) *OpenRungSingBoxConfigResult {
+	return &OpenRungSingBoxConfigResult{errorText: err.Error()}
+}

--- a/android/punchbridge/singbox_binding_test.go
+++ b/android/punchbridge/singbox_binding_test.go
@@ -1,0 +1,167 @@
+package libbox
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The sing-box binding fixtures: one .input.json per platform scenario (the
+// binding input the Kotlin/Swift assembly must produce, pinned by the platform
+// suites), and one frozen .golden.json holding the bound output. This test is
+// the only writer of the goldens; regenerate deliberately with:
+//
+//	UPDATE_SINGBOX_BINDING_GOLDEN=1 go test -run TestOpenRungBuildSingBoxConfigGolden .
+const singBoxBindingFixtureDir = "../../testdata/singbox-binding"
+
+func singBoxScenarioNames(t *testing.T) []string {
+	t.Helper()
+	entries, err := os.ReadDir(singBoxBindingFixtureDir)
+	if err != nil {
+		t.Fatalf("reading fixture directory: %v", err)
+	}
+	var names []string
+	for _, entry := range entries {
+		if name, ok := strings.CutSuffix(entry.Name(), ".input.json"); ok {
+			names = append(names, name)
+		}
+	}
+	if len(names) < 10 {
+		t.Fatalf("only %d scenarios found; the fixture directory changed shape", len(names))
+	}
+	return names
+}
+
+func readSingBoxFixture(t *testing.T, name string) string {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(singBoxBindingFixtureDir, name))
+	if err != nil {
+		t.Fatalf("reading %s: %v", name, err)
+	}
+	return string(raw)
+}
+
+// TestOpenRungBuildSingBoxConfigGolden composes with the Kotlin and Swift
+// suites: they pin platform state → fixture input, this pins fixture input →
+// emitted config through the real binding entry point, and the platform
+// structural suites re-run their emission assertions against the frozen
+// goldens — so the existing platform expectations hold against the bound
+// output without the JVM or a pod-free XCTest bundle loading the engine.
+func TestOpenRungBuildSingBoxConfigGolden(t *testing.T) {
+	for _, name := range singBoxScenarioNames(t) {
+		t.Run(name, func(t *testing.T) {
+			result := OpenRungBuildSingBoxConfig(readSingBoxFixture(t, name+".input.json"))
+			if !result.Succeeded() {
+				t.Fatalf("build failed: %s", result.ErrorText())
+			}
+			got := []byte(result.ConfigJSON())
+			goldenPath := filepath.Join(singBoxBindingFixtureDir, name+".golden.json")
+			if os.Getenv("UPDATE_SINGBOX_BINDING_GOLDEN") != "" {
+				if err := os.WriteFile(goldenPath, got, 0o644); err != nil {
+					t.Fatalf("update golden: %v", err)
+				}
+			}
+			want, err := os.ReadFile(goldenPath)
+			if err != nil {
+				t.Fatalf("read golden (run with UPDATE_SINGBOX_BINDING_GOLDEN=1 to create): %v", err)
+			}
+			if !bytes.Equal(got, want) {
+				t.Fatalf("config drifted from %s:\n--- want\n%s\n--- got\n%s", goldenPath, want, got)
+			}
+		})
+	}
+}
+
+// TestOpenRungBuildSingBoxConfigEmptySplitRulesEmitTheNoSplitConfig pins the
+// identity the platform suites rely on: all-empty split rules and no split
+// rules at all emit byte-identical configs, on both platform shapes.
+func TestOpenRungBuildSingBoxConfigEmptySplitRulesEmitTheNoSplitConfig(t *testing.T) {
+	for _, platform := range []string{"android", "ios"} {
+		baseline := readSingBoxFixture(t, platform+"-tun.golden.json")
+		emptied := readSingBoxFixture(t, platform+"-split-empty.golden.json")
+		if baseline != emptied {
+			t.Fatalf("%s: all-empty split rules must emit the exact no-split configuration", platform)
+		}
+	}
+}
+
+// TestOpenRungBuildSingBoxConfigValidation: the mobile input contract this
+// binding enforces on top of connectcore's own relay and split-tunnel
+// validation. Every rejection carries an error and no config.
+func TestOpenRungBuildSingBoxConfigValidation(t *testing.T) {
+	valid := readSingBoxFixture(t, "android-tun.input.json")
+	mutate := func(t *testing.T, change func(input map[string]any)) string {
+		t.Helper()
+		var input map[string]any
+		if err := json.Unmarshal([]byte(valid), &input); err != nil {
+			t.Fatalf("decode valid fixture: %v", err)
+		}
+		change(input)
+		encoded, err := json.Marshal(input)
+		if err != nil {
+			t.Fatalf("encode mutated input: %v", err)
+		}
+		return string(encoded)
+	}
+
+	cases := map[string]string{
+		"not JSON":      `not json`,
+		"empty string":  ``,
+		"trailing data": valid + " {}",
+		"unknown field": mutate(t, func(input map[string]any) { input["dns_servers"] = []string{"9.9.9.9"} }),
+		"missing relay": mutate(t, func(input map[string]any) { delete(input, "relay") }),
+		"invalid relay protocol": mutate(t, func(input map[string]any) {
+			input["relay"].(map[string]any)["protocol"] = "wireguard"
+		}),
+		"relay missing connection fields": mutate(t, func(input map[string]any) {
+			delete(input["relay"].(map[string]any), "reality_public_key")
+		}),
+		"missing mtu":  mutate(t, func(input map[string]any) { delete(input, "mtu") }),
+		"negative mtu": mutate(t, func(input map[string]any) { input["mtu"] = -1 }),
+		"bridge host without port": mutate(t, func(input map[string]any) {
+			input["bridge_host"] = "127.0.0.1"
+		}),
+		"bridge port without host": mutate(t, func(input map[string]any) {
+			input["bridge_port"] = 54321
+		}),
+		"bridge port out of range": mutate(t, func(input map[string]any) {
+			input["bridge_host"] = "127.0.0.1"
+			input["bridge_port"] = 65536
+		}),
+		"missing log level": mutate(t, func(input map[string]any) { delete(input, "log_level") }),
+		"missing probe suffixes": mutate(t, func(input map[string]any) {
+			delete(input, "probe_domain_suffixes")
+		}),
+		"unknown split-tunnel country": mutate(t, func(input map[string]any) {
+			input["split_tunnel"] = map[string]any{
+				"bypass_countries":   []string{"us"},
+				"rule_set_directory": "/rulesets",
+			}
+		}),
+		"duplicate split-tunnel country": mutate(t, func(input map[string]any) {
+			input["split_tunnel"] = map[string]any{
+				"bypass_countries":   []string{"cn", "cn"},
+				"rule_set_directory": "/rulesets",
+			}
+		}),
+		"bypass country without a rule-set directory": mutate(t, func(input map[string]any) {
+			input["split_tunnel"] = map[string]any{"bypass_countries": []string{"cn"}}
+		}),
+	}
+	for name, input := range cases {
+		result := OpenRungBuildSingBoxConfig(input)
+		if result.Succeeded() {
+			t.Errorf("%s: expected the build to be rejected", name)
+			continue
+		}
+		if result.ErrorText() == "" {
+			t.Errorf("%s: a rejection must carry an error text", name)
+		}
+		if result.ConfigJSON() != "" {
+			t.Errorf("%s: a rejection must carry no config", name)
+		}
+	}
+}

--- a/ios/OpenRungTests/DnsConfigurationTests.swift
+++ b/ios/OpenRungTests/DnsConfigurationTests.swift
@@ -1,17 +1,19 @@
 import Foundation
 import XCTest
 
-/// Regression tests for the DoH emission and the probe-priority pins. TCP/53 through the proxy
-/// receives no replies under WSS relays, and geosite-cn contains probe-class hostnames
+/// Regression tests for the DoH emission and the probe-priority pins, asserted against the frozen
+/// bound outputs under testdata/singbox-binding (see `SingBoxBindingFixtures`). TCP/53 through
+/// the proxy receives no replies under WSS relays, and geosite-cn contains probe-class hostnames
 /// (www.gstatic.com), so both properties below are load-bearing for startup truthfulness.
 /// Mirror of Android `SingBoxConfigurationDnsTest`.
 final class DnsConfigurationTests: XCTestCase {
-    private let ruleSetDirectory = "/var/rulesets"
-
     func testResolversAreEmittedAsDoHServersDetouredThroughTheProxy() throws {
-        let servers = try proxiedDnsServers(SingBoxConfiguration(relay: makeWssTestRelay()).makeJSONObject())
+        let servers = try proxiedDnsServers(SingBoxBindingFixtures.golden("ios-tun"))
         XCTAssertEqual(servers.map { $0["tag"] as? String }, ["dns-0", "dns-1"])
-        XCTAssertEqual(servers.map { $0["server"] as? String }, ["1.1.1.1", "8.8.8.8"])
+        XCTAssertEqual(
+            servers.map { $0["server"] as? String },
+            SingBoxConfiguration.defaultDoHResolvers
+        )
         for server in servers {
             XCTAssertEqual(server["type"] as? String, "https")
             XCTAssertEqual(server["detour"] as? String, "proxy")
@@ -30,14 +32,7 @@ final class DnsConfigurationTests: XCTestCase {
     }
 
     func testNoDnsServerAnywhereSpeaksPlaintextDns() throws {
-        let object = SingBoxConfiguration(
-            relay: makeWssTestRelay(),
-            splitTunnel: SplitTunnelRules(
-                bypassLan: false,
-                bypassCountries: ["ir", "cn"],
-                ruleSetDirectory: ruleSetDirectory
-            )
-        ).makeJSONObject()
+        let object = try SingBoxBindingFixtures.golden("ios-split-ir-cn-lan")
         let dns = try XCTUnwrap(object["dns"] as? [String: Any])
         for server in try XCTUnwrap(dns["servers"] as? [[String: Any]]) {
             // Proxied resolvers need DoH because relays answer 443 on every transport while
@@ -55,7 +50,7 @@ final class DnsConfigurationTests: XCTestCase {
     }
 
     func testDefaultDomainResolverStaysOnPrimaryAndFinalOnTerminalFallback() throws {
-        let object = SingBoxConfiguration(relay: makeWssTestRelay()).makeJSONObject()
+        let object = try SingBoxBindingFixtures.golden("ios-tun")
         let dns = try XCTUnwrap(object["dns"] as? [String: Any])
         // The global chain's trailing route rule is the real terminus; `final` names the same
         // fallback resolver for coherence.
@@ -69,7 +64,7 @@ final class DnsConfigurationTests: XCTestCase {
         // sing-box has no upstream failover of its own: `evaluate` is non-terminal on a
         // transport error/timeout/SERVFAIL/REFUSED, `respond` returns a usable answer (NOERROR,
         // or an authoritative NXDOMAIN), and the trailing route rule is the terminal fallback.
-        let object = SingBoxConfiguration(relay: makeWssTestRelay()).makeJSONObject()
+        let object = try SingBoxBindingFixtures.golden("ios-tun")
         let dns = try XCTUnwrap(object["dns"] as? [String: Any])
         let rules = try XCTUnwrap(dns["rules"] as? [[String: Any]]).suffix(4).map { $0 }
         XCTAssertEqual(rules[0]["action"] as? String, "evaluate")
@@ -89,17 +84,8 @@ final class DnsConfigurationTests: XCTestCase {
     }
 
     func testProbeDnsPinIsAlwaysFirstProxiedAndUncached() throws {
-        let baseline = SingBoxConfiguration(relay: makeWssTestRelay()).makeJSONObject()
-        let china = SingBoxConfiguration(
-            relay: makeWssTestRelay(),
-            splitTunnel: SplitTunnelRules(
-                bypassLan: false,
-                bypassCountries: ["cn"],
-                ruleSetDirectory: ruleSetDirectory
-            )
-        ).makeJSONObject()
-
-        for object in [baseline, china] {
+        for scenario in ["ios-tun", "ios-split-cn"] {
+            let object = try SingBoxBindingFixtures.golden(scenario)
             let dns = try XCTUnwrap(object["dns"] as? [String: Any])
             let probeChain = try XCTUnwrap(dns["rules"] as? [[String: Any]]).prefix(4).map { $0 }
             // Every probe rule is scoped to the probe domains; the chain ends in a terminal
@@ -133,8 +119,8 @@ final class DnsConfigurationTests: XCTestCase {
     func testProbeQueriesTargetTheOnlyAddressSingBoxHijacks() throws {
         // sing-box tags a packet as DNS — and hijacks it into the DNS module ahead of every
         // route rule — ONLY when its destination equals the TUN's derived DNS address (the next
-        // address after the TUN's own IPv4 address, since we emit no dns_address). A probe sent
-        // to a public resolver instead would match no rule and die on the TCP-only proxy
+        // address after the TUN's own IPv4 address, since no dns_address is emitted). A probe
+        // sent to a public resolver instead would match no rule and die on the TCP-only proxy
         // outbound, failing on every healthy tunnel.
         XCTAssertEqual(SingBoxConfiguration.defaultTunnelIPv4Address, "172.19.0.1/30")
         XCTAssertEqual(SingBoxConfiguration.defaultTunnelDnsAddress, "172.19.0.2")
@@ -162,19 +148,14 @@ final class DnsConfigurationTests: XCTestCase {
 
         // An explicit dns_address on the tun inbound would replace the derived hijack address
         // and silently invalidate the probe target above.
-        let object = SingBoxConfiguration(relay: makeWssTestRelay()).makeJSONObject()
+        let object = try SingBoxBindingFixtures.golden("ios-tun")
         let inbounds = try XCTUnwrap(object["inbounds"] as? [[String: Any]])
         XCTAssertNil(try XCTUnwrap(inbounds.first)["dns_address"])
     }
 
     func testDnsBlockIsIdenticalAcrossDirectAndBridgedShapes() throws {
-        let relay = makeWssTestRelay()
-        let direct = SingBoxConfiguration(relay: relay).makeJSONObject()
-        let bridged = SingBoxConfiguration(
-            relay: relay,
-            bridgeHost: "127.0.0.1",
-            bridgePort: 54_321
-        ).makeJSONObject()
+        let direct = try SingBoxBindingFixtures.golden("ios-tun")
+        let bridged = try SingBoxBindingFixtures.golden("ios-bridge")
         XCTAssertEqual(
             try JSONSerialization.data(withJSONObject: XCTUnwrap(direct["dns"]), options: [.sortedKeys]),
             try JSONSerialization.data(withJSONObject: XCTUnwrap(bridged["dns"]), options: [.sortedKeys])
@@ -185,14 +166,7 @@ final class DnsConfigurationTests: XCTestCase {
         // The confirmed regression: geosite-cn contains www.gstatic.com, so before these pins a
         // dead proxy still produced a passing probe over the direct path and the app published
         // CONNECTED. Probe DNS and probe routing must both win before any country rule.
-        let object = SingBoxConfiguration(
-            relay: makeWssTestRelay(),
-            splitTunnel: SplitTunnelRules(
-                bypassLan: false,
-                bypassCountries: ["cn"],
-                ruleSetDirectory: ruleSetDirectory
-            )
-        ).makeJSONObject()
+        let object = try SingBoxBindingFixtures.golden("ios-split-cn")
 
         let dns = try XCTUnwrap(object["dns"] as? [String: Any])
         let dnsRules = try XCTUnwrap(dns["rules"] as? [[String: Any]])

--- a/ios/OpenRungTests/SplitTunnelConfigurationTests.swift
+++ b/ios/OpenRungTests/SplitTunnelConfigurationTests.swift
@@ -3,39 +3,24 @@ import XCTest
 
 final class SplitTunnelConfigurationTests: XCTestCase {
     private static let testDefaultsSuite = "com.openrung.tests.split-tunnel"
-    private let ruleSetDirectory = "/var/rulesets"
+    private let ruleSetDirectory = "/var/mobile/rulesets"
 
-    // MARK: - sing-box emission (spec §2; byte-parallel with the Kotlin generator)
+    // MARK: - sing-box emission (spec §2), asserted against the frozen bound outputs under
+    // testdata/singbox-binding (see SingBoxBindingFixtures); the scenario inputs those goldens
+    // are built from are pinned by SingBoxConfigurationBindingInputTests below.
 
     func testNilAndInertRulesEmitBaselineConfig() throws {
-        let relay = makeWssTestRelay()
-        let baseline = SingBoxConfiguration(relay: relay).makeJSONObject()
-        let explicitNil = SingBoxConfiguration(relay: relay, splitTunnel: nil).makeJSONObject()
-        // Callers pass nil when disabled, but rules contributing nothing must also be a no-op.
-        let inert = SingBoxConfiguration(
-            relay: relay,
-            splitTunnel: SplitTunnelRules(
-                bypassLan: false,
-                bypassCountries: [],
-                ruleSetDirectory: ruleSetDirectory
-            )
-        ).makeJSONObject()
-
-        XCTAssertEqual(try canonicalJSON(baseline), try canonicalJSON(explicitNil))
-        XCTAssertEqual(try canonicalJSON(baseline), try canonicalJSON(inert))
+        // Rules contributing nothing must be a no-op (nil-vs-absent is assembly-level: both
+        // produce the ios-tun input, pinned by the binding-input suite).
+        XCTAssertEqual(
+            try SingBoxBindingFixtures.goldenText("ios-tun"),
+            try SingBoxBindingFixtures.goldenText("ios-split-empty")
+        )
     }
 
     func testLanOnlyRulesAddExactlyOnePrivateBypassRouteRule() throws {
-        let relay = makeWssTestRelay()
-        var baseline = SingBoxConfiguration(relay: relay).makeJSONObject()
-        var split = SingBoxConfiguration(
-            relay: relay,
-            splitTunnel: SplitTunnelRules(
-                bypassLan: true,
-                bypassCountries: [],
-                ruleSetDirectory: ruleSetDirectory
-            )
-        ).makeJSONObject()
+        var baseline = try SingBoxBindingFixtures.golden("ios-tun")
+        var split = try SingBoxBindingFixtures.golden("ios-split-lan")
 
         let route = try XCTUnwrap(split["route"] as? [String: Any])
         XCTAssertNil(route["rule_set"])
@@ -52,20 +37,14 @@ final class SplitTunnelConfigurationTests: XCTestCase {
     }
 
     func testIranOnlyRulesEmitDnsAndRouteDeltasInOrder() throws {
-        let object = SingBoxConfiguration(
-            relay: makeWssTestRelay(),
-            splitTunnel: SplitTunnelRules(
-                bypassLan: false,
-                bypassCountries: ["ir"],
-                ruleSetDirectory: ruleSetDirectory
-            )
-        ).makeJSONObject()
+        let object = try SingBoxBindingFixtures.golden("ios-split-ir")
 
-        // Iran has no encrypted public resolver we can currently stand behind, so it contributes
-        // no dns server and no dns rules at all — its ROUTE bypass below is untouched, and its
-        // lookups just reach the proxied global chain. A dead primary would be strictly worse:
-        // every bypassed lookup would burn the full evaluate timeout on a doomed TLS handshake.
-        let baselineDns = SingBoxConfiguration(relay: makeWssTestRelay()).makeJSONObject()["dns"]
+        // Iran has no encrypted public resolver the shared builder can currently stand behind,
+        // so it contributes no dns server and no dns rules at all — its ROUTE bypass below is
+        // untouched, and its lookups just reach the proxied global chain. A dead primary would
+        // be strictly worse: every bypassed lookup would burn the full evaluate timeout on a
+        // doomed TLS handshake.
+        let baselineDns = try SingBoxBindingFixtures.golden("ios-tun")["dns"]
         XCTAssertEqual(try canonicalJSON(object["dns"]), try canonicalJSON(baselineDns))
 
         let route = try XCTUnwrap(object["route"] as? [String: Any])
@@ -76,20 +55,19 @@ final class SplitTunnelConfigurationTests: XCTestCase {
             ["rule_set": ["geosite-ir", "geoip-ir"], "outbound": "direct"],
         ] as [[String: Any]]))
         XCTAssertEqual(try canonicalJSON(route["rule_set"]), try canonicalJSON([
-            ["type": "local", "tag": "geosite-ir", "format": "binary", "path": "/var/rulesets/geosite-ir.srs"],
-            ["type": "local", "tag": "geoip-ir", "format": "binary", "path": "/var/rulesets/geoip-ir.srs"],
+            ["type": "local", "tag": "geosite-ir", "format": "binary", "path": "\(ruleSetDirectory)/geosite-ir.srs"],
+            ["type": "local", "tag": "geoip-ir", "format": "binary", "path": "\(ruleSetDirectory)/geoip-ir.srs"],
         ] as [[String: Any]]))
     }
 
     func testFullRulesEmitIranBeforeChinaAndLeaveTheRestUntouched() throws {
-        let relay = makeWssTestRelay()
-        var baseline = SingBoxConfiguration(relay: relay).makeJSONObject()
-        var split = SingBoxConfiguration(relay: relay, splitTunnel: fullRules).makeJSONObject()
+        var baseline = try SingBoxBindingFixtures.golden("ios-tun")
+        var split = try SingBoxBindingFixtures.golden("ios-split-ir-cn-lan")
 
         let dns = try XCTUnwrap(split["dns"] as? [String: Any])
         let servers = try XCTUnwrap(dns["servers"] as? [[String: Any]])
-        // Only China contributes a resolver today (see SplitTunnelCountry.directResolver), but the
-        // ROUTE rules below still cover both countries.
+        // Only China contributes a resolver today (see connectcore's split-tunnel resolver
+        // table), but the ROUTE rules below still cover both countries.
         XCTAssertEqual(servers.map { $0["tag"] as? String }, ["dns-0", "dns-1", "dns-direct-cn"])
         XCTAssertEqual(servers[2]["server"] as? String, "223.5.5.5")
         XCTAssertEqual(
@@ -134,14 +112,8 @@ final class SplitTunnelConfigurationTests: XCTestCase {
     }
 
     func testBridgeModeKeepsSplitRulesAndStillOmitsRouteExcludeAddress() throws {
-        let relay = makeWssTestRelay()
-        let direct = SingBoxConfiguration(relay: relay, splitTunnel: fullRules).makeJSONObject()
-        let bridged = SingBoxConfiguration(
-            relay: relay,
-            bridgeHost: "127.0.0.1",
-            bridgePort: 24_680,
-            splitTunnel: fullRules
-        ).makeJSONObject()
+        let direct = try SingBoxBindingFixtures.golden("ios-split-ir-cn-lan")
+        let bridged = try SingBoxBindingFixtures.golden("ios-split-ir-cn-lan-bridge")
 
         XCTAssertEqual(try canonicalJSON(direct["dns"]), try canonicalJSON(bridged["dns"]))
         XCTAssertEqual(try canonicalJSON(direct["route"]), try canonicalJSON(bridged["route"]))
@@ -151,18 +123,13 @@ final class SplitTunnelConfigurationTests: XCTestCase {
     }
 
     func testCountryConstantsMatchSpec() {
+        // The per-country direct resolvers (and Iran's documented absence) are the shared
+        // builder's now; the bound goldens pin them (see the full-rules test above).
         XCTAssertEqual(SplitTunnelCountry.supported.map(\.code), ["ir", "cn"])
         XCTAssertEqual(SplitTunnelCountry.forCode("ir")?.geositeTag, "geosite-ir")
         XCTAssertEqual(SplitTunnelCountry.forCode("ir")?.geoipTag, "geoip-ir")
-        // Iran ships no resolver while Shecan's certificate is expired; see the type's docs
-        // before restoring one, and verify the live endpoint rather than its documentation.
-        XCTAssertNil(SplitTunnelCountry.forCode("ir")?.directResolver)
         XCTAssertEqual(SplitTunnelCountry.forCode("cn")?.geositeTag, "geosite-cn")
         XCTAssertEqual(SplitTunnelCountry.forCode("cn")?.geoipTag, "geoip-cn")
-        XCTAssertEqual(
-            SplitTunnelCountry.forCode("cn")?.directResolver,
-            SplitTunnelDirectResolver(server: "223.5.5.5", tlsServerName: "dns.alidns.com")
-        )
         XCTAssertNil(SplitTunnelCountry.forCode("us"))
     }
 
@@ -431,14 +398,6 @@ final class SplitTunnelConfigurationTests: XCTestCase {
         ]
     }
 
-    private var fullRules: SplitTunnelRules {
-        SplitTunnelRules(
-            bypassLan: true,
-            bypassCountries: ["ir", "cn"],
-            ruleSetDirectory: ruleSetDirectory
-        )
-    }
-
     private func firstInbound(_ object: [String: Any]) throws -> [String: Any] {
         let inbounds = try XCTUnwrap(object["inbounds"] as? [[String: Any]])
         return try XCTUnwrap(inbounds.first)
@@ -446,5 +405,116 @@ final class SplitTunnelConfigurationTests: XCTestCase {
 
     private func canonicalJSON(_ object: Any?) throws -> Data {
         try JSONSerialization.data(withJSONObject: XCTUnwrap(object), options: [.sortedKeys])
+    }
+}
+
+/// The assembly half of the sing-box builder contract: the configuration each iOS scenario
+/// constructs must produce exactly the checked-in binding input for that scenario. The other half
+/// — those inputs building to the frozen goldens through the real binding — runs in
+/// `android/punchbridge`'s Go tests, and the structural suites above assert against the goldens.
+/// Lives in this file because the OpenRungTests target lists files explicitly (xcodegen); adding
+/// a file means regenerating the project.
+final class SingBoxConfigurationBindingInputTests: XCTestCase {
+    private let ruleSetDirectory = "/var/mobile/rulesets"
+
+    /// The configuration whose assembly must reproduce each scenario's input file.
+    private func configuration(for scenario: String) throws -> SingBoxConfiguration {
+        let relay = SingBoxBindingFixtures.relay()
+        switch scenario {
+        case "ios-tun":
+            return SingBoxConfiguration(relay: relay)
+        case "ios-bridge":
+            return SingBoxConfiguration(relay: relay, bridgeHost: "127.0.0.1", bridgePort: 54_321)
+        case "ios-split-empty":
+            return SingBoxConfiguration(
+                relay: relay,
+                splitTunnel: SplitTunnelRules(bypassLan: false, bypassCountries: [], ruleSetDirectory: "")
+            )
+        case "ios-split-lan":
+            return SingBoxConfiguration(
+                relay: relay,
+                splitTunnel: SplitTunnelRules(
+                    bypassLan: true,
+                    bypassCountries: [],
+                    ruleSetDirectory: ruleSetDirectory
+                )
+            )
+        case "ios-split-ir":
+            return SingBoxConfiguration(
+                relay: relay,
+                splitTunnel: SplitTunnelRules(
+                    bypassLan: false,
+                    bypassCountries: ["ir"],
+                    ruleSetDirectory: ruleSetDirectory
+                )
+            )
+        case "ios-split-cn":
+            return SingBoxConfiguration(
+                relay: relay,
+                splitTunnel: SplitTunnelRules(
+                    bypassLan: false,
+                    bypassCountries: ["cn"],
+                    ruleSetDirectory: ruleSetDirectory
+                )
+            )
+        case "ios-split-ir-cn-lan":
+            return SingBoxConfiguration(
+                relay: relay,
+                splitTunnel: SplitTunnelRules(
+                    bypassLan: true,
+                    bypassCountries: ["ir", "cn"],
+                    ruleSetDirectory: ruleSetDirectory
+                )
+            )
+        case "ios-split-ir-cn-lan-bridge":
+            return SingBoxConfiguration(
+                relay: relay,
+                bridgeHost: "127.0.0.1",
+                bridgePort: 54_321,
+                splitTunnel: SplitTunnelRules(
+                    bypassLan: true,
+                    bypassCountries: ["ir", "cn"],
+                    ruleSetDirectory: ruleSetDirectory
+                )
+            )
+        default:
+            throw XCTSkip("no construction for scenario \(scenario); add it here when adding a fixture")
+        }
+    }
+
+    func testEveryIOSScenarioAssemblesToItsCheckedInBindingInput() throws {
+        let scenarios = try SingBoxBindingFixtures.scenarios(platform: "ios")
+        XCTAssertGreaterThanOrEqual(
+            scenarios.count, 5,
+            "no ios scenarios found; the fixture directory changed shape"
+        )
+        for scenario in scenarios {
+            let assembled = try configuration(for: scenario).bindingInput(debug: false)
+            XCTAssertEqual(
+                assembled as NSDictionary,
+                try SingBoxBindingFixtures.input(scenario) as NSDictionary,
+                "scenario \(scenario)"
+            )
+        }
+    }
+
+    func testDebugBuildsRequestTheInfoLogLevel() {
+        let assembled = SingBoxConfiguration(relay: SingBoxBindingFixtures.relay())
+            .bindingInput(debug: true)
+        XCTAssertEqual(assembled["log_level"] as? String, "info")
+    }
+
+    func testPartialBridgeIsForwardedFaithfullyForTheBindingToReject() {
+        // The old generator quietly kept a partial bridge off the outbound; rejection is the
+        // binding's now (see the Go suite), so the assembly must not repair or drop the values.
+        let hostOnly = SingBoxConfiguration(relay: SingBoxBindingFixtures.relay(), bridgeHost: "127.0.0.1")
+            .bindingInput(debug: false)
+        XCTAssertEqual(hostOnly["bridge_host"] as? String, "127.0.0.1")
+        XCTAssertNil(hostOnly["bridge_port"])
+
+        let portOnly = SingBoxConfiguration(relay: SingBoxBindingFixtures.relay(), bridgePort: 1_234)
+            .bindingInput(debug: false)
+        XCTAssertEqual(portOnly["bridge_port"] as? Int, 1_234)
+        XCTAssertNil(portOnly["bridge_host"])
     }
 }

--- a/ios/OpenRungTests/WssLifecycleAndConfigurationTests.swift
+++ b/ios/OpenRungTests/WssLifecycleAndConfigurationTests.swift
@@ -55,20 +55,17 @@ final class WssLifecycleAndConfigurationTests: XCTestCase {
     }
 
     func testBridgeChangesOnlyRealityTransportEndpointAndKeepsLoopbackInsideTun() throws {
-        let relay = makeWssTestRelay()
-        let direct = SingBoxConfiguration(relay: relay).makeJSONObject()
-        let bridged = SingBoxConfiguration(
-            relay: relay,
-            bridgeHost: "127.0.0.1",
-            bridgePort: 24_680
-        ).makeJSONObject()
+        // The frozen bound outputs for the direct and bridged shapes (see SingBoxBindingFixtures).
+        let relay = SingBoxBindingFixtures.relay()
+        let direct = try SingBoxBindingFixtures.golden("ios-tun")
+        let bridged = try SingBoxBindingFixtures.golden("ios-bridge")
 
         var directOutbound = try firstOutbound(direct)
         var bridgedOutbound = try firstOutbound(bridged)
         XCTAssertEqual(directOutbound["server"] as? String, relay.publicHost)
         XCTAssertEqual(directOutbound["server_port"] as? Int, relay.publicPort)
         XCTAssertEqual(bridgedOutbound["server"] as? String, "127.0.0.1")
-        XCTAssertEqual(bridgedOutbound["server_port"] as? Int, 24_680)
+        XCTAssertEqual(bridgedOutbound["server_port"] as? Int, 54_321)
         directOutbound.removeValue(forKey: "server")
         directOutbound.removeValue(forKey: "server_port")
         bridgedOutbound.removeValue(forKey: "server")

--- a/ios/OpenRungTests/WssTestFixtures.swift
+++ b/ios/OpenRungTests/WssTestFixtures.swift
@@ -49,3 +49,82 @@ actor WssTestEventLog {
 
     func snapshot() -> [String] { values }
 }
+
+/// The sing-box binding fixtures shared by the platform suites and `android/punchbridge`'s Go
+/// tests: one `<scenario>.input.json` per platform scenario (the binding input the assembly must
+/// produce), and one frozen `<scenario>.golden.json` holding the bound builder's output. The Go
+/// suite is the only writer of the goldens and pins input→config through the real binding; the
+/// suites here pin platform state→input and re-run this platform's structural emission assertions
+/// against the goldens — so the existing expectations hold against the bound output without this
+/// pod-free test bundle loading the engine. Lives in this file because the OpenRungTests target
+/// lists files explicitly (xcodegen); adding a file means regenerating the project.
+enum SingBoxBindingFixtures {
+    /// Resolved from this file's own path, like the contract-vector suites, so the fixtures stay
+    /// plain checked-in files and the Xcode target needs no resource wiring.
+    private static let directory = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()  // OpenRungTests
+        .deletingLastPathComponent()  // ios
+        .deletingLastPathComponent()  // repository root
+        .appendingPathComponent("testdata/singbox-binding", isDirectory: true)
+
+    static func input(_ scenario: String) throws -> [String: Any] {
+        try object(file: "\(scenario).input.json")
+    }
+
+    static func golden(_ scenario: String) throws -> [String: Any] {
+        try object(file: "\(scenario).golden.json")
+    }
+
+    static func goldenText(_ scenario: String) throws -> String {
+        try String(contentsOf: directory.appendingPathComponent("\(scenario).golden.json"), encoding: .utf8)
+    }
+
+    /// Scenario names for this platform, derived from the checked-in input files.
+    static func scenarios(platform: String) throws -> [String] {
+        try FileManager.default.contentsOfDirectory(atPath: directory.path)
+            .filter { $0.hasPrefix("\(platform)-") && $0.hasSuffix(".input.json") }
+            .map { String($0.dropLast(".input.json".count)) }
+            .sorted()
+    }
+
+    /// The relay every scenario input carries. The connection identity fields must match the
+    /// fixtures' `relay` object byte-for-byte; the remaining fields exist only to satisfy the
+    /// model and are never assembled into the binding input.
+    static func relay() -> RelayDescriptor {
+        RelayDescriptor(
+            id: "relay-1",
+            publicHost: "203.0.113.10",
+            publicPort: 443,
+            relayProtocol: "vless-reality-vision",
+            clientID: "e6b1a1de-9f0f-4c1a-8bb1-1f2b3c4d5e6f",
+            realityPublicKey: "reality-key",
+            shortID: "abcd1234",
+            serverName: "www.example.com",
+            flow: "xtls-rprx-vision",
+            exitMode: "direct",
+            maxSessions: 8,
+            maxMbps: 100,
+            relayVersion: "1.0.0",
+            nodeClass: RelayConstants.nodeClassFoundation,
+            transport: "tunnel",
+            wssFronts: [],
+            punchCapable: true,
+            punchEndpoint: "https://203.0.113.10:9444",
+            registeredAt: Date(timeIntervalSince1970: 1_767_225_600),
+            lastHeartbeatAt: Date(timeIntervalSince1970: 1_767_225_600),
+            expiresAt: Date(timeIntervalSince1970: 1_798_761_600)
+        )
+    }
+
+    private static func object(file: String) throws -> [String: Any] {
+        let data = try Data(contentsOf: directory.appendingPathComponent(file))
+        guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw NSError(
+                domain: "SingBoxBindingFixtures",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "\(file) is not a JSON object"]
+            )
+        }
+        return object
+    }
+}

--- a/ios/Shared/SingBoxConfiguration.swift
+++ b/ios/Shared/SingBoxConfiguration.swift
@@ -1,20 +1,32 @@
 import Foundation
+#if canImport(Libbox)
+import Libbox
+#endif
 
+/// Platform input assembly for the shared sing-box config builder: gathers the iOS-side inputs
+/// (relay identity, TUN addresses, an optional punch/WSS loopback bridge, validated split-tunnel
+/// rules) and hands them to the libbox binding's `OpenRungBuildSingBoxConfig`, whose emission
+/// comes from the one Go builder every OpenRung client runs (`connectcore/client` in the sibling
+/// `openrung` repo — the generator this file used to hand-copy). This file no longer emits any
+/// config JSON; the DNS failover chains, probe pins, split-tunnel rules, route exclusions, and
+/// their ordering all live in the shared builder, and the frozen bound outputs under
+/// `testdata/singbox-binding/` are what this platform's structural tests assert against.
+///
+/// The assembly (`bindingInput(debug:)`) is engine-free so the pod-free test bundle can pin it;
+/// the input→config half runs in `android/punchbridge`'s Go tests against the same checked-in
+/// inputs. Unlike the Kotlin twin, the assembly never sends `excluded_packages` or
+/// `route_find_process`: iOS has no OS-level per-app exclusion and never emits `find_process`.
 public struct SingBoxConfiguration: Equatable, Sendable {
-    /// DoH-capable public resolvers reached as IP literals: no bootstrap resolution needed.
+    /// The proxied DoH resolvers the shared builder emits by default (its defaults are the same
+    /// IP literals). Kept here because the probe budgets below are derived from the chain's
+    /// length and timeouts; the bound goldens pin the emitted list, so a builder-side change
+    /// cannot drift past this constant unnoticed.
     public static let defaultDoHResolvers = ["1.1.1.1", "8.8.8.8"]
 
-    /// Hostnames the DoH TLS handshakes authenticate while dialing the IP literals above.
-    private static let dohTLSServerNames = [
-        "1.1.1.1": "cloudflare-dns.com",
-        "8.8.8.8": "dns.google",
-    ]
-
-    // Per-evaluate budget before the next resolver runs, and the terminal/global budget.
+    // Per-evaluate budget before the next resolver runs, and the terminal/global budget — the
+    // shared builder's dnsPrimaryTimeout/dnsFallbackTimeout, in milliseconds.
     public static let dnsPrimaryTimeoutMilliseconds: UInt64 = 2_000
     public static let dnsFallbackTimeoutMilliseconds: UInt64 = 3_000
-    private static let dnsPrimaryTimeout = "\(dnsPrimaryTimeoutMilliseconds / 1_000)s"
-    private static let dnsFallbackTimeout = "\(dnsFallbackTimeoutMilliseconds / 1_000)s"
 
     /// Engine-side worst case for one lookup through the default chain: every non-terminal
     /// resolver may consume its full evaluate timeout before the terminal fallback gets its
@@ -29,11 +41,11 @@ public struct SingBoxConfiguration: Equatable, Sendable {
     public static let defaultTunnelIPv4Address = "172.19.0.1/30"
 
     /// The ONLY in-TUN address whose port-53 traffic sing-box hijacks. When the tun inbound
-    /// carries no explicit `dns_address` (we emit none), sing-tun derives the hijack address as
-    /// the next address after the TUN's own IPv4 address, and the tun inbound tags a packet
-    /// `Protocol=DNS` only when its destination equals that address — after which the router
-    /// hijacks it into the DNS module ahead of any route rule. A datagram addressed to a public
-    /// resolver (1.1.1.1) is NOT tagged, matches no rule, and dies on the TCP-only proxy
+    /// carries no explicit `dns_address` (the shared builder emits none), sing-tun derives the
+    /// hijack address as the next address after the TUN's own IPv4 address, and the tun inbound
+    /// tags a packet `Protocol=DNS` only when its destination equals that address — after which
+    /// the router hijacks it into the DNS module ahead of any route rule. A datagram addressed to
+    /// a public resolver (1.1.1.1) is NOT tagged, matches no rule, and dies on the TCP-only proxy
     /// outbound, so the fresh-DNS probe must target this address. It is also what libbox reports
     /// to `NEDNSSettings`, so it is exactly where system lookups already go.
     public static let defaultTunnelDnsAddress: String = {
@@ -81,8 +93,7 @@ public struct SingBoxConfiguration: Equatable, Sendable {
     public let bridgeHost: String?
     public let bridgePort: Int?
     /// Validated split-tunnel rules, or nil for full-tunnel behavior (byte-identical output to a
-    /// build without split tunneling). Mirrors the Kotlin generator, except iOS NEVER emits
-    /// `exclude_package` — per-app exclusion is Android-only.
+    /// build without split tunneling).
     public let splitTunnel: SplitTunnelRules?
 
     public init(
@@ -103,326 +114,94 @@ public struct SingBoxConfiguration: Equatable, Sendable {
         self.splitTunnel = splitTunnel
     }
 
+    /// The emitted config from the shared builder. Throws
+    /// `SingBoxConfigurationError.rejected` when the binding rejects the input (an invalid
+    /// relay, a partial bridge, an unsupported split-tunnel country, …) — the same failures the
+    /// deleted generator used to reject locally.
     public func encodedJSON() throws -> Data {
-        try JSONSerialization.data(
-            withJSONObject: makeJSONObject(),
-            options: [.prettyPrinted, .sortedKeys]
-        )
+        Data(try encodedJSONString().utf8)
     }
 
     public func encodedJSONString() throws -> String {
-        String(decoding: try encodedJSON(), as: UTF8.self)
-    }
-
-    public func makeJSONObject() -> [String: Any] {
-        var tunInbound: [String: Any] = [
-            "type": "tun",
-            "tag": "tun-in",
-            "address": [
-                tunnelIPv4Address,
-                tunnelIPv6Address
-            ],
-            "mtu": mtu,
-            "auto_route": true,
-            "strict_route": true,
-            "stack": "system",
-            "dns_mode": "hijack",
-            "endpoint_independent_nat": true
-        ]
-        // A native bridge owns its outer socket. Only a direct Reality socket needs the raw relay
-        // address excluded from the TUN route; the inner bridge endpoint must stay on loopback.
-        if bridgeHost == nil, let excludeAddress = Self.relayRouteExcludeAddress(for: relay.publicHost) {
-            tunInbound["route_exclude_address"] = [excludeAddress]
+        #if canImport(Libbox)
+        let result = LibboxOpenRungBuildSingBoxConfig(try serializedBindingInput())
+        guard let result, result.succeeded() else {
+            let reason = result?.errorText() ?? ""
+            throw SingBoxConfigurationError.rejected(
+                reason.isEmpty ? "sing-box config build failed" : reason
+            )
         }
-
-        let outboundHost = bridgeHost ?? relay.publicHost
-        let outboundPort = bridgePort ?? relay.publicPort
-
-        // Split-tunnel emission (spec §2): countries were already validated (files on disk) and
-        // normalized to ir,cn order by the caller; unknown codes are dropped here as a last resort.
-        let bypassCountries = (splitTunnel?.bypassCountries ?? []).compactMap(SplitTunnelCountry.forCode)
-        let bypassLan = splitTunnel?.bypassLan == true
-
-        let dnsServers = Self.defaultDoHResolvers
-        var dnsServerObjects: [[String: Any]] = dnsServers.enumerated().map { index, server in
-            var object: [String: Any] = [
-                "tag": "dns-\(index)",
-                // DoH over 443 via the proxy: relays answer 443 on every transport, while
-                // TCP/53 gets no replies under WSS. IP-literal servers need no bootstrap
-                // resolver (defaults: port 443, path /dns-query).
-                "type": "https",
-                "server": server,
-                "detour": "proxy"
-            ]
-            // TLS authenticates the provider hostname while the dial stays on the IP literal,
-            // so a provider dropping IP SANs from its certificate cannot break resolution.
-            if let serverName = Self.dohTLSServerNames[server] {
-                object["tls"] = ["enabled": true, "server_name": serverName] as [String: Any]
-            }
-            return object
-        }
-        for country in bypassCountries {
-            // A DNS server with no detour builds its own direct dialer, which is exactly what a
-            // bypass resolver needs. Detouring to our otherwise-empty tagged direct outbound is
-            // rejected during sing-box's Start stage. DoH over 443 keeps the query encrypted on
-            // that direct path, and 443 survives the middleboxes that a bare 853 often does not.
-            guard let resolver = country.directResolver else { continue }
-            dnsServerObjects.append([
-                "tag": "dns-direct-\(country.code)",
-                "type": "https",
-                "server": resolver.server,
-                "tls": ["enabled": true, "server_name": resolver.tlsServerName] as [String: Any]
-            ])
-        }
-        // Highest priority: probe lookups must reach the proxied DoH resolvers even when a
-        // country rule would divert them (geosite-cn contains gstatic-class hosts), and must
-        // never be answered from any cache — a cached answer proves nothing about the tunnel
-        // right now. The chain is terminal for probe domains (its trailing route rule always
-        // fires), so a future geosite refresh can never capture a probe lookup.
-        var dnsRules = dnsFailoverRules(
-            domainSuffixes: ProbeTargets.ruleDomainSuffixes,
-            disableCache: true
-        )
-        dnsRules.append(contentsOf: bypassCountries.flatMap { Self.countryDnsRules(for: $0) })
-        // Real failover for everything else: a static `final` would never consult a second
-        // resolver. `evaluate` is non-terminal on a transport error, timeout, SERVFAIL or
-        // REFUSED in the pinned engine — a usable answer (NOERROR, or an authoritative
-        // NXDOMAIN) is returned by `respond`, anything else falls through to the next
-        // resolver's terminal route rule.
-        dnsRules.append(contentsOf: dnsFailoverRules(domainSuffixes: nil, disableCache: false))
-        let dns: [String: Any] = [
-            "servers": dnsServerObjects,
-            "rules": dnsRules,
-            "final": "dns-\(dnsServers.count - 1)",
-            "timeout": Self.dnsFallbackTimeout
-        ]
-
-        var routeRules: [[String: Any]] = [
-            [
-                "protocol": "dns",
-                "action": "hijack-dns"
-            ]
-        ]
-        if bypassCountries.isEmpty == false {
-            // Domain rule sets need the sniffed hostname on raw connections.
-            routeRules.append(["action": "sniff"])
-            // Probe traffic must reach the proxy even when a bypass rule would send it direct;
-            // a probe that escapes onto the direct path can report CONNECTED over a dead
-            // tunnel. Must precede every bypass rule.
-            routeRules.append([
-                "domain_suffix": ProbeTargets.ruleDomainSuffixes,
-                "outbound": "proxy"
-            ])
-        }
-        if bypassLan {
-            routeRules.append([
-                "ip_is_private": true,
-                "outbound": "direct"
-            ])
-        }
-        for country in bypassCountries {
-            routeRules.append([
-                "rule_set": [country.geositeTag, country.geoipTag],
-                "outbound": "direct"
-            ])
-        }
-        var route: [String: Any] = [
-            "auto_detect_interface": true,
-            "default_domain_resolver": "dns-0",
-            "rules": routeRules,
-            "final": "proxy"
-        ]
-        if bypassCountries.isEmpty == false, let ruleSetDirectory = splitTunnel?.ruleSetDirectory {
-            route["rule_set"] = bypassCountries.flatMap { country in
-                [
-                    [
-                        "type": "local",
-                        "tag": country.geositeTag,
-                        "format": "binary",
-                        "path": "\(ruleSetDirectory)/\(country.geositeTag).srs"
-                    ],
-                    [
-                        "type": "local",
-                        "tag": country.geoipTag,
-                        "format": "binary",
-                        "path": "\(ruleSetDirectory)/\(country.geoipTag).srs"
-                    ]
-                ] as [[String: Any]]
-            }
-        }
-
-        // "info" logs every flow and DNS query — each line crosses the gomobile boundary and
-        // costs CPU inside the 50 MB extension, so release builds keep only warnings.
-        #if DEBUG
-        let logLevel = "info"
+        return result.configJSON()
         #else
-        let logLevel = "warn"
+        // Only the engine-free test bundle compiles this branch (see project.yml); it pins the
+        // assembly below and asserts against the frozen bound outputs instead of building live.
+        throw SingBoxConfigurationError.engineUnavailable
         #endif
-
-        return [
-            "log": [
-                "level": logLevel,
-                "timestamp": true
-            ],
-            "dns": dns,
-            "inbounds": [
-                tunInbound
-            ],
-            "outbounds": [
-                [
-                    "type": "vless",
-                    "tag": "proxy",
-                    "server": outboundHost,
-                    "server_port": outboundPort,
-                    "uuid": relay.clientID,
-                    "flow": relay.flow,
-                    "network": "tcp",
-                    "packet_encoding": "xudp",
-                    "tls": [
-                        "enabled": true,
-                        "server_name": relay.serverName,
-                        "utls": [
-                            "enabled": true,
-                            "fingerprint": "chrome"
-                        ],
-                        "reality": [
-                            "enabled": true,
-                            "public_key": relay.realityPublicKey,
-                            "short_id": relay.shortID
-                        ]
-                    ] as [String: Any]
-                ] as [String: Any],
-                [
-                    "type": "direct",
-                    "tag": "direct"
-                ],
-                [
-                    "type": "block",
-                    "tag": "block"
-                ]
-            ],
-            "route": route,
-            "experimental": [
-                // No external_controller is set, so nothing listens; an empty clash_api
-                // block just turns on sing-box's traffic accounting, which feeds the
-                // cumulative bytes_sent/bytes_received counters reported with session
-                // telemetry (see TelemetryManager.updateTrafficCounters).
-                "clash_api": [String: Any]()
-            ]
-        ]
     }
 
-    /// Per-country lookup chain for the domains that country bypasses: ask the in-country DoH
-    /// resolver, and return its answer when it is a real one (NOERROR, or an authoritative
-    /// NXDOMAIN). Nothing else is terminal, so a resolver that is unreachable, times out, or has
-    /// let its certificate lapse falls through to the proxied global chain below instead of
-    /// failing the lookup outright — the same fail-open posture as the rest of the feature
-    /// (CONTRACT §1), and the reason moving off plaintext UDP cannot cost anyone reachability.
-    ///
-    /// `rule_set` matches against the queried domain in both the query and the response pass, so
-    /// the response rules stay scoped to this country's domains.
-    ///
-    /// Empty for a country with no usable in-country resolver: with nothing to evaluate, its
-    /// lookups simply reach the global chain, which is where they would end up anyway.
-    private static func countryDnsRules(for country: SplitTunnelCountry) -> [[String: Any]] {
-        guard country.directResolver != nil else { return [] }
-        var rules: [[String: Any]] = [
-            [
-                "rule_set": [country.geositeTag],
-                "action": "evaluate",
-                "server": "dns-direct-\(country.code)",
-                "timeout": dnsPrimaryTimeout
-            ]
+    /// The binding input for this configuration: one JSON object of the platform-assembled
+    /// fields. The relay object carries the broker's canonical wire names, the probe suffixes
+    /// come from `ProbeTargets` so the builder's probe pins can never diverge from the endpoints
+    /// this platform actually probes, and `debug` selects the log level ("info" logs every flow
+    /// and DNS query — each line crosses the gomobile boundary and costs CPU inside the 50 MB
+    /// extension, so release builds keep only warnings). Values are forwarded faithfully — a
+    /// partial bridge is the binding's to reject, not this assembly's to repair.
+    func bindingInput(debug: Bool) -> [String: Any] {
+        var input: [String: Any] = [
+            "relay": [
+                "public_host": relay.publicHost,
+                "public_port": relay.publicPort,
+                "protocol": relay.relayProtocol,
+                "client_id": relay.clientID,
+                "reality_public_key": relay.realityPublicKey,
+                "short_id": relay.shortID,
+                "server_name": relay.serverName,
+                "flow": relay.flow,
+                "exit_mode": relay.exitMode,
+            ] as [String: Any],
+            "tunnel_ipv4_address": tunnelIPv4Address,
+            "tunnel_ipv6_address": tunnelIPv6Address,
+            "mtu": mtu,
+            "log_level": debug ? "info" : "warn",
+            "probe_domain_suffixes": ProbeTargets.ruleDomainSuffixes,
         ]
-        for rcode in ["NOERROR", "NXDOMAIN"] {
-            rules.append([
-                "rule_set": [country.geositeTag],
-                "match_response": true,
-                "response_rcode": rcode,
-                "action": "respond"
-            ])
+        if let bridgeHost { input["bridge_host"] = bridgeHost }
+        if let bridgePort { input["bridge_port"] = bridgePort }
+        if let splitTunnel {
+            input["split_tunnel"] = [
+                "bypass_lan": splitTunnel.bypassLan,
+                "bypass_countries": splitTunnel.bypassCountries,
+                "excluded_packages": [String](),
+                "rule_set_directory": splitTunnel.ruleSetDirectory,
+            ] as [String: Any]
         }
-        return rules
+        return input
     }
 
-    /// Emits an ordered primary-to-fallback resolver chain from sing-box 1.14 DNS rule actions:
-    /// for every resolver but the last, `evaluate` exchanges the query (non-terminal on error)
-    /// and `respond` returns its answer when the RCODE is NOERROR or NXDOMAIN — both are real
-    /// answers, and probe nonce queries are expected to draw NXDOMAIN. Everything else (timeout,
-    /// transport error, SERVFAIL, REFUSED) falls through until the last resolver's terminal
-    /// route rule. With `domainSuffixes` the whole chain applies only to those domains and is
-    /// guaranteed terminal for them; with nil it applies to every remaining query.
-    private func dnsFailoverRules(
-        domainSuffixes: [String]?,
-        disableCache: Bool
-    ) -> [[String: Any]] {
-        let dnsServers = Self.defaultDoHResolvers
-        var rules: [[String: Any]] = []
-        for index in 0..<(dnsServers.count - 1) {
-            var evaluate: [String: Any] = [
-                "action": "evaluate",
-                "server": "dns-\(index)",
-                "timeout": Self.dnsPrimaryTimeout
-            ]
-            if let domainSuffixes { evaluate["domain_suffix"] = domainSuffixes }
-            if disableCache {
-                evaluate["disable_cache"] = true
-                evaluate["disable_optimistic_cache"] = true
-            }
-            rules.append(evaluate)
-            for rcode in ["NOERROR", "NXDOMAIN"] {
-                var respond: [String: Any] = [
-                    "match_response": true,
-                    "response_rcode": rcode,
-                    "action": "respond"
-                ]
-                if let domainSuffixes { respond["domain_suffix"] = domainSuffixes }
-                rules.append(respond)
-            }
-        }
-        var route: [String: Any] = [
-            "server": "dns-\(dnsServers.count - 1)",
-            "timeout": Self.dnsFallbackTimeout
-        ]
-        if let domainSuffixes { route["domain_suffix"] = domainSuffixes }
-        if disableCache {
-            route["disable_cache"] = true
-            route["disable_optimistic_cache"] = true
-        }
-        rules.append(route)
-        return rules
-    }
-
-    private static func relayRouteExcludeAddress(for host: String) -> String? {
-        let cleanHost = host.removingIPv6Brackets()
-        if cleanHost.isIPv4Literal {
-            return "\(cleanHost)/32"
-        }
-        if cleanHost.contains(":") {
-            return "\(cleanHost)/128"
-        }
-        return nil
+    private func serializedBindingInput() throws -> String {
+        #if DEBUG
+        let debug = true
+        #else
+        let debug = false
+        #endif
+        let data = try JSONSerialization.data(withJSONObject: bindingInput(debug: debug))
+        return String(decoding: data, as: UTF8.self)
     }
 }
 
-private extension String {
-    func removingIPv6Brackets() -> String {
-        guard hasPrefix("["), hasSuffix("]") else {
-            return self
-        }
-        return String(dropFirst().dropLast())
-    }
+/// Failures of the bound sing-box builder, surfaced where the deleted generator used to throw.
+public enum SingBoxConfigurationError: LocalizedError, Equatable {
+    /// The binding rejected the assembled input; the message names the offending field.
+    case rejected(String)
+    /// Only the engine-free test bundle can see this: every shipping target links Libbox.
+    case engineUnavailable
 
-    var isIPv4Literal: Bool {
-        let octets = split(separator: ".", omittingEmptySubsequences: false)
-        guard octets.count == 4 else {
-            return false
-        }
-        return octets.allSatisfy { octet in
-            guard let value = Int(octet), (0...255).contains(value) else {
-                return false
-            }
-            return String(value) == String(octet)
+    public var errorDescription: String? {
+        switch self {
+        case .rejected(let reason):
+            return "The sing-box configuration was rejected: \(reason)"
+        case .engineUnavailable:
+            return "The sing-box config builder is unavailable without the engine."
         }
     }
 }

--- a/ios/Shared/SplitTunnelConfig.swift
+++ b/ios/Shared/SplitTunnelConfig.swift
@@ -208,66 +208,27 @@ public struct SplitTunnelRules: Equatable, Sendable {
     }
 }
 
-/// An in-country public resolver reached over the DIRECT path, so bypassed domains resolve to
-/// in-country CDN nodes instead of the relay exit's view of them.
-///
-/// DoH over 443, never plaintext UDP/53: these queries leave the device on the user's real IP
-/// while the tunnel is up, so the local network, the ISP and anything else on the path must not
-/// get a cleartext list of the domains being bypassed (nor the chance to forge the answers).
-/// `server` stays an IP literal so no bootstrap lookup is needed, and TLS authenticates
-/// `tlsServerName` — the same shape the proxied DoH resolvers use.
-public struct SplitTunnelDirectResolver: Equatable, Sendable {
-    public let server: String
-    public let tlsServerName: String
-
-    public init(server: String, tlsServerName: String) {
-        self.server = server
-        self.tlsServerName = tlsServerName
-    }
-}
-
-/// The v1 bypass-country presets, pairing the bundled sing-box rule-set tags with that country's
-/// direct-path resolver.
+/// The v1 bypass-country presets: the bundled sing-box rule-set tags per country. Each country's
+/// direct-path resolver (or its documented absence) is the shared builder's now — see
+/// `connectcore/client/singbox_split_tunnel.go` in the sibling `openrung` repo, whose emitted
+/// shape the frozen goldens under `testdata/singbox-binding/` pin.
 public struct SplitTunnelCountry: Equatable, Sendable {
     public let code: String
     public let geositeTag: String
     public let geoipTag: String
-    /// Nil when the country has no encrypted public resolver we can currently stand behind. Its
-    /// bypass then keeps its ROUTE rules — the traffic still takes the direct path — and only its
-    /// lookups fall to the proxied DoH chain, resolving through the relay exit's view. That costs
-    /// in-country CDN affinity and nothing else.
-    ///
-    /// A resolver goes in here only while its certificate actually validates. Anything else is
-    /// worse than omitting it: sing-box would spend the full evaluate timeout failing the TLS
-    /// handshake on EVERY bypassed lookup before the fallback runs, so users would pay latency for
-    /// an in-country answer they can never receive. Never restore one on the strength of its
-    /// documentation — verify the live endpoint first.
-    public let directResolver: SplitTunnelDirectResolver?
 
     /// Recognized countries in the normalized emission order: ir first, then cn. Unknown codes
     /// in a persisted config are ignored (forward compat).
     public static let supported: [SplitTunnelCountry] = [
-        // Shecan is Iran's usual public resolver, but every endpoint it publishes
-        // (178.22.122.100, 185.51.200.2, dns.shecan.ir) served an expired Let's Encrypt
-        // certificate as of 2026-08-12 (notAfter Jul 10 2026), on both 443 and 853. Electro
-        // (78.157.42.100) refuses both ports and Begzar's DoH host no longer resolves, so Iran
-        // has no verifiable encrypted resolver to point at right now.
         SplitTunnelCountry(
             code: "ir",
             geositeTag: "geosite-ir",
-            geoipTag: "geoip-ir",
-            directResolver: nil
+            geoipTag: "geoip-ir"
         ),
-        // AliDNS (Chinese public resolver); https://223.5.5.5/dns-query is a published endpoint
-        // and its certificate covers the IP literal.
         SplitTunnelCountry(
             code: "cn",
             geositeTag: "geosite-cn",
-            geoipTag: "geoip-cn",
-            directResolver: SplitTunnelDirectResolver(
-                server: "223.5.5.5",
-                tlsServerName: "dns.alidns.com"
-            )
+            geoipTag: "geoip-cn"
         ),
     ]
 

--- a/ios/build-libbox-release.sh
+++ b/ios/build-libbox-release.sh
@@ -271,6 +271,8 @@ cp "$binding_source/broker_binding.go" \
   "$work_dir/source/experimental/libbox/openrung_broker.go"
 cp "$binding_source/failure_binding.go" \
   "$work_dir/source/experimental/libbox/openrung_failure.go"
+cp "$binding_source/singbox_binding.go" \
+  "$work_dir/source/experimental/libbox/openrung_singbox.go"
 mkdir -p "$work_dir/source/experimental/libbox/internal/openrungpunch"
 for source_file in "$binding_source/internal/openrungpunch/"*.go; do
   case "$source_file" in
@@ -385,6 +387,15 @@ for slice in ios-arm64 ios-arm64_x86_64-simulator; do
     'LibboxOpenRungFailureDetail'; do
     if ! grep -Fq "$classifier_symbol" "$header"; then
       echo "error: Apple build is missing the OpenRung failure classifier API in $slice: $classifier_symbol" >&2
+      exit 1
+    fi
+  done
+  for singbox_symbol in \
+    'LibboxOpenRungBuildSingBoxConfig' \
+    'LibboxOpenRungSingBoxConfigResult' \
+    ')configJSON;'; do
+    if ! grep -Fq "$singbox_symbol" "$header"; then
+      echo "error: Apple build is missing the OpenRung sing-box builder API in $slice: $singbox_symbol" >&2
       exit 1
     fi
   done

--- a/testdata/singbox-binding/README.md
+++ b/testdata/singbox-binding/README.md
@@ -1,0 +1,25 @@
+# sing-box binding fixtures
+
+One `<scenario>.input.json` per platform scenario — the `OpenRungBuildSingBoxConfig` binding
+input the Kotlin/Swift assembly must produce for that scenario — and one frozen
+`<scenario>.golden.json` holding the bound builder's output for it.
+
+The three suites compose into the platform emission expectations running end-to-end against
+the shared Go builder (`connectcore/client`, pinned in `android/punchbridge/go.mod`), without
+the JVM or the pod-free XCTest bundle loading the gomobile engine:
+
+- `android/punchbridge/singbox_binding_test.go` is the only writer of the goldens and pins
+  input → config through the real binding entry point. Regenerate deliberately with
+  `UPDATE_SINGBOX_BINDING_GOLDEN=1 go test -run TestOpenRungBuildSingBoxConfigGolden .`
+  from `android/punchbridge`.
+- `SingBoxConfigurationBindingInputTest(.kt)` / `SingBoxConfigurationBindingInputTests` (Swift)
+  pin platform construction → input.
+- The platform structural suites (`SingBoxConfigurationDnsTest`, `SingBoxConfigurationSplitTunnelTest`,
+  `SingBoxConfigurationPunchTest`, `DnsConfigurationTests`, `SplitTunnelConfigurationTests`, …)
+  assert their emission expectations against the goldens.
+
+The `relay` object in every input carries the broker's canonical wire names and one shared
+test identity; scenario axes are the platform (`route_find_process` and `excluded_packages`
+are Android-only), an optional loopback bridge, and the split-tunnel variants. All inputs use
+the release log level ("warn"); the debug→"info" mapping is pinned separately by the
+assembly suites.

--- a/testdata/singbox-binding/android-bridge.golden.json
+++ b/testdata/singbox-binding/android-bridge.golden.json
@@ -1,0 +1,156 @@
+{
+  "dns": {
+    "final": "dns-1",
+    "rules": [
+      {
+        "action": "evaluate",
+        "disable_cache": true,
+        "disable_optimistic_cache": true,
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "server": "dns-0",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "match_response": true,
+        "response_rcode": "NOERROR"
+      },
+      {
+        "action": "respond",
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "match_response": true,
+        "response_rcode": "NXDOMAIN"
+      },
+      {
+        "disable_cache": true,
+        "disable_optimistic_cache": true,
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "server": "dns-1",
+        "timeout": "3s"
+      },
+      {
+        "action": "evaluate",
+        "server": "dns-0",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NOERROR"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NXDOMAIN"
+      },
+      {
+        "server": "dns-1",
+        "timeout": "3s"
+      }
+    ],
+    "servers": [
+      {
+        "detour": "proxy",
+        "server": "1.1.1.1",
+        "tag": "dns-0",
+        "tls": {
+          "enabled": true,
+          "server_name": "cloudflare-dns.com"
+        },
+        "type": "https"
+      },
+      {
+        "detour": "proxy",
+        "server": "8.8.8.8",
+        "tag": "dns-1",
+        "tls": {
+          "enabled": true,
+          "server_name": "dns.google"
+        },
+        "type": "https"
+      }
+    ],
+    "timeout": "3s"
+  },
+  "experimental": {
+    "clash_api": {}
+  },
+  "inbounds": [
+    {
+      "address": [
+        "172.19.0.1/30",
+        "fdfe:dcba:9876::1/126"
+      ],
+      "auto_route": true,
+      "dns_mode": "hijack",
+      "endpoint_independent_nat": true,
+      "mtu": 1400,
+      "stack": "system",
+      "strict_route": true,
+      "tag": "tun-in",
+      "type": "tun"
+    }
+  ],
+  "log": {
+    "level": "warn",
+    "timestamp": true
+  },
+  "outbounds": [
+    {
+      "flow": "xtls-rprx-vision",
+      "network": "tcp",
+      "packet_encoding": "xudp",
+      "server": "127.0.0.1",
+      "server_port": 54321,
+      "tag": "proxy",
+      "tls": {
+        "enabled": true,
+        "reality": {
+          "enabled": true,
+          "public_key": "reality-key",
+          "short_id": "abcd1234"
+        },
+        "server_name": "www.example.com",
+        "utls": {
+          "enabled": true,
+          "fingerprint": "chrome"
+        }
+      },
+      "type": "vless",
+      "uuid": "e6b1a1de-9f0f-4c1a-8bb1-1f2b3c4d5e6f"
+    },
+    {
+      "tag": "direct",
+      "type": "direct"
+    },
+    {
+      "tag": "block",
+      "type": "block"
+    }
+  ],
+  "route": {
+    "auto_detect_interface": true,
+    "default_domain_resolver": "dns-0",
+    "final": "proxy",
+    "find_process": true,
+    "rules": [
+      {
+        "action": "hijack-dns",
+        "protocol": "dns"
+      }
+    ]
+  }
+}

--- a/testdata/singbox-binding/android-bridge.input.json
+++ b/testdata/singbox-binding/android-bridge.input.json
@@ -1,0 +1,24 @@
+{
+  "bridge_host": "127.0.0.1",
+  "bridge_port": 54321,
+  "log_level": "warn",
+  "mtu": 1400,
+  "probe_domain_suffixes": [
+    "probe.openrung.org",
+    "cp.cloudflare.com"
+  ],
+  "relay": {
+    "client_id": "e6b1a1de-9f0f-4c1a-8bb1-1f2b3c4d5e6f",
+    "exit_mode": "direct",
+    "flow": "xtls-rprx-vision",
+    "protocol": "vless-reality-vision",
+    "public_host": "203.0.113.10",
+    "public_port": 443,
+    "reality_public_key": "reality-key",
+    "server_name": "www.example.com",
+    "short_id": "abcd1234"
+  },
+  "route_find_process": true,
+  "tunnel_ipv4_address": "172.19.0.1/30",
+  "tunnel_ipv6_address": "fdfe:dcba:9876::1/126"
+}

--- a/testdata/singbox-binding/android-split-cn.golden.json
+++ b/testdata/singbox-binding/android-split-cn.golden.json
@@ -1,0 +1,223 @@
+{
+  "dns": {
+    "final": "dns-1",
+    "rules": [
+      {
+        "action": "evaluate",
+        "disable_cache": true,
+        "disable_optimistic_cache": true,
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "server": "dns-0",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "match_response": true,
+        "response_rcode": "NOERROR"
+      },
+      {
+        "action": "respond",
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "match_response": true,
+        "response_rcode": "NXDOMAIN"
+      },
+      {
+        "disable_cache": true,
+        "disable_optimistic_cache": true,
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "server": "dns-1",
+        "timeout": "3s"
+      },
+      {
+        "action": "evaluate",
+        "rule_set": [
+          "geosite-cn"
+        ],
+        "server": "dns-direct-cn",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NOERROR",
+        "rule_set": [
+          "geosite-cn"
+        ]
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NXDOMAIN",
+        "rule_set": [
+          "geosite-cn"
+        ]
+      },
+      {
+        "action": "evaluate",
+        "server": "dns-0",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NOERROR"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NXDOMAIN"
+      },
+      {
+        "server": "dns-1",
+        "timeout": "3s"
+      }
+    ],
+    "servers": [
+      {
+        "detour": "proxy",
+        "server": "1.1.1.1",
+        "tag": "dns-0",
+        "tls": {
+          "enabled": true,
+          "server_name": "cloudflare-dns.com"
+        },
+        "type": "https"
+      },
+      {
+        "detour": "proxy",
+        "server": "8.8.8.8",
+        "tag": "dns-1",
+        "tls": {
+          "enabled": true,
+          "server_name": "dns.google"
+        },
+        "type": "https"
+      },
+      {
+        "server": "223.5.5.5",
+        "tag": "dns-direct-cn",
+        "tls": {
+          "enabled": true,
+          "server_name": "dns.alidns.com"
+        },
+        "type": "https"
+      }
+    ],
+    "timeout": "3s"
+  },
+  "experimental": {
+    "clash_api": {}
+  },
+  "inbounds": [
+    {
+      "address": [
+        "172.19.0.1/30",
+        "fdfe:dcba:9876::1/126"
+      ],
+      "auto_route": true,
+      "dns_mode": "hijack",
+      "endpoint_independent_nat": true,
+      "mtu": 1400,
+      "route_exclude_address": [
+        "203.0.113.10/32"
+      ],
+      "stack": "system",
+      "strict_route": true,
+      "tag": "tun-in",
+      "type": "tun"
+    }
+  ],
+  "log": {
+    "level": "warn",
+    "timestamp": true
+  },
+  "outbounds": [
+    {
+      "flow": "xtls-rprx-vision",
+      "network": "tcp",
+      "packet_encoding": "xudp",
+      "server": "203.0.113.10",
+      "server_port": 443,
+      "tag": "proxy",
+      "tls": {
+        "enabled": true,
+        "reality": {
+          "enabled": true,
+          "public_key": "reality-key",
+          "short_id": "abcd1234"
+        },
+        "server_name": "www.example.com",
+        "utls": {
+          "enabled": true,
+          "fingerprint": "chrome"
+        }
+      },
+      "type": "vless",
+      "uuid": "e6b1a1de-9f0f-4c1a-8bb1-1f2b3c4d5e6f"
+    },
+    {
+      "tag": "direct",
+      "type": "direct"
+    },
+    {
+      "tag": "block",
+      "type": "block"
+    }
+  ],
+  "route": {
+    "auto_detect_interface": true,
+    "default_domain_resolver": "dns-0",
+    "final": "proxy",
+    "find_process": true,
+    "rule_set": [
+      {
+        "format": "binary",
+        "path": "/data/user/0/rulesets/geosite-cn.srs",
+        "tag": "geosite-cn",
+        "type": "local"
+      },
+      {
+        "format": "binary",
+        "path": "/data/user/0/rulesets/geoip-cn.srs",
+        "tag": "geoip-cn",
+        "type": "local"
+      }
+    ],
+    "rules": [
+      {
+        "action": "hijack-dns",
+        "protocol": "dns"
+      },
+      {
+        "action": "sniff"
+      },
+      {
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "outbound": "proxy"
+      },
+      {
+        "outbound": "direct",
+        "rule_set": [
+          "geosite-cn",
+          "geoip-cn"
+        ]
+      }
+    ]
+  }
+}

--- a/testdata/singbox-binding/android-split-cn.input.json
+++ b/testdata/singbox-binding/android-split-cn.input.json
@@ -1,0 +1,30 @@
+{
+  "log_level": "warn",
+  "mtu": 1400,
+  "probe_domain_suffixes": [
+    "probe.openrung.org",
+    "cp.cloudflare.com"
+  ],
+  "relay": {
+    "client_id": "e6b1a1de-9f0f-4c1a-8bb1-1f2b3c4d5e6f",
+    "exit_mode": "direct",
+    "flow": "xtls-rprx-vision",
+    "protocol": "vless-reality-vision",
+    "public_host": "203.0.113.10",
+    "public_port": 443,
+    "reality_public_key": "reality-key",
+    "server_name": "www.example.com",
+    "short_id": "abcd1234"
+  },
+  "route_find_process": true,
+  "split_tunnel": {
+    "bypass_countries": [
+      "cn"
+    ],
+    "bypass_lan": false,
+    "excluded_packages": [],
+    "rule_set_directory": "/data/user/0/rulesets"
+  },
+  "tunnel_ipv4_address": "172.19.0.1/30",
+  "tunnel_ipv6_address": "fdfe:dcba:9876::1/126"
+}

--- a/testdata/singbox-binding/android-split-empty.golden.json
+++ b/testdata/singbox-binding/android-split-empty.golden.json
@@ -1,0 +1,159 @@
+{
+  "dns": {
+    "final": "dns-1",
+    "rules": [
+      {
+        "action": "evaluate",
+        "disable_cache": true,
+        "disable_optimistic_cache": true,
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "server": "dns-0",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "match_response": true,
+        "response_rcode": "NOERROR"
+      },
+      {
+        "action": "respond",
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "match_response": true,
+        "response_rcode": "NXDOMAIN"
+      },
+      {
+        "disable_cache": true,
+        "disable_optimistic_cache": true,
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "server": "dns-1",
+        "timeout": "3s"
+      },
+      {
+        "action": "evaluate",
+        "server": "dns-0",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NOERROR"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NXDOMAIN"
+      },
+      {
+        "server": "dns-1",
+        "timeout": "3s"
+      }
+    ],
+    "servers": [
+      {
+        "detour": "proxy",
+        "server": "1.1.1.1",
+        "tag": "dns-0",
+        "tls": {
+          "enabled": true,
+          "server_name": "cloudflare-dns.com"
+        },
+        "type": "https"
+      },
+      {
+        "detour": "proxy",
+        "server": "8.8.8.8",
+        "tag": "dns-1",
+        "tls": {
+          "enabled": true,
+          "server_name": "dns.google"
+        },
+        "type": "https"
+      }
+    ],
+    "timeout": "3s"
+  },
+  "experimental": {
+    "clash_api": {}
+  },
+  "inbounds": [
+    {
+      "address": [
+        "172.19.0.1/30",
+        "fdfe:dcba:9876::1/126"
+      ],
+      "auto_route": true,
+      "dns_mode": "hijack",
+      "endpoint_independent_nat": true,
+      "mtu": 1400,
+      "route_exclude_address": [
+        "203.0.113.10/32"
+      ],
+      "stack": "system",
+      "strict_route": true,
+      "tag": "tun-in",
+      "type": "tun"
+    }
+  ],
+  "log": {
+    "level": "warn",
+    "timestamp": true
+  },
+  "outbounds": [
+    {
+      "flow": "xtls-rprx-vision",
+      "network": "tcp",
+      "packet_encoding": "xudp",
+      "server": "203.0.113.10",
+      "server_port": 443,
+      "tag": "proxy",
+      "tls": {
+        "enabled": true,
+        "reality": {
+          "enabled": true,
+          "public_key": "reality-key",
+          "short_id": "abcd1234"
+        },
+        "server_name": "www.example.com",
+        "utls": {
+          "enabled": true,
+          "fingerprint": "chrome"
+        }
+      },
+      "type": "vless",
+      "uuid": "e6b1a1de-9f0f-4c1a-8bb1-1f2b3c4d5e6f"
+    },
+    {
+      "tag": "direct",
+      "type": "direct"
+    },
+    {
+      "tag": "block",
+      "type": "block"
+    }
+  ],
+  "route": {
+    "auto_detect_interface": true,
+    "default_domain_resolver": "dns-0",
+    "final": "proxy",
+    "find_process": true,
+    "rules": [
+      {
+        "action": "hijack-dns",
+        "protocol": "dns"
+      }
+    ]
+  }
+}

--- a/testdata/singbox-binding/android-split-empty.input.json
+++ b/testdata/singbox-binding/android-split-empty.input.json
@@ -1,0 +1,28 @@
+{
+  "log_level": "warn",
+  "mtu": 1400,
+  "probe_domain_suffixes": [
+    "probe.openrung.org",
+    "cp.cloudflare.com"
+  ],
+  "relay": {
+    "client_id": "e6b1a1de-9f0f-4c1a-8bb1-1f2b3c4d5e6f",
+    "exit_mode": "direct",
+    "flow": "xtls-rprx-vision",
+    "protocol": "vless-reality-vision",
+    "public_host": "203.0.113.10",
+    "public_port": 443,
+    "reality_public_key": "reality-key",
+    "server_name": "www.example.com",
+    "short_id": "abcd1234"
+  },
+  "route_find_process": true,
+  "split_tunnel": {
+    "bypass_countries": [],
+    "bypass_lan": false,
+    "excluded_packages": [],
+    "rule_set_directory": ""
+  },
+  "tunnel_ipv4_address": "172.19.0.1/30",
+  "tunnel_ipv6_address": "fdfe:dcba:9876::1/126"
+}

--- a/testdata/singbox-binding/android-split-ir-cn-lan-bridge.golden.json
+++ b/testdata/singbox-binding/android-split-ir-cn-lan-bridge.golden.json
@@ -1,0 +1,243 @@
+{
+  "dns": {
+    "final": "dns-1",
+    "rules": [
+      {
+        "action": "evaluate",
+        "disable_cache": true,
+        "disable_optimistic_cache": true,
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "server": "dns-0",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "match_response": true,
+        "response_rcode": "NOERROR"
+      },
+      {
+        "action": "respond",
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "match_response": true,
+        "response_rcode": "NXDOMAIN"
+      },
+      {
+        "disable_cache": true,
+        "disable_optimistic_cache": true,
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "server": "dns-1",
+        "timeout": "3s"
+      },
+      {
+        "action": "evaluate",
+        "rule_set": [
+          "geosite-cn"
+        ],
+        "server": "dns-direct-cn",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NOERROR",
+        "rule_set": [
+          "geosite-cn"
+        ]
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NXDOMAIN",
+        "rule_set": [
+          "geosite-cn"
+        ]
+      },
+      {
+        "action": "evaluate",
+        "server": "dns-0",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NOERROR"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NXDOMAIN"
+      },
+      {
+        "server": "dns-1",
+        "timeout": "3s"
+      }
+    ],
+    "servers": [
+      {
+        "detour": "proxy",
+        "server": "1.1.1.1",
+        "tag": "dns-0",
+        "tls": {
+          "enabled": true,
+          "server_name": "cloudflare-dns.com"
+        },
+        "type": "https"
+      },
+      {
+        "detour": "proxy",
+        "server": "8.8.8.8",
+        "tag": "dns-1",
+        "tls": {
+          "enabled": true,
+          "server_name": "dns.google"
+        },
+        "type": "https"
+      },
+      {
+        "server": "223.5.5.5",
+        "tag": "dns-direct-cn",
+        "tls": {
+          "enabled": true,
+          "server_name": "dns.alidns.com"
+        },
+        "type": "https"
+      }
+    ],
+    "timeout": "3s"
+  },
+  "experimental": {
+    "clash_api": {}
+  },
+  "inbounds": [
+    {
+      "address": [
+        "172.19.0.1/30",
+        "fdfe:dcba:9876::1/126"
+      ],
+      "auto_route": true,
+      "dns_mode": "hijack",
+      "endpoint_independent_nat": true,
+      "mtu": 1400,
+      "stack": "system",
+      "strict_route": true,
+      "tag": "tun-in",
+      "type": "tun"
+    }
+  ],
+  "log": {
+    "level": "warn",
+    "timestamp": true
+  },
+  "outbounds": [
+    {
+      "flow": "xtls-rprx-vision",
+      "network": "tcp",
+      "packet_encoding": "xudp",
+      "server": "127.0.0.1",
+      "server_port": 54321,
+      "tag": "proxy",
+      "tls": {
+        "enabled": true,
+        "reality": {
+          "enabled": true,
+          "public_key": "reality-key",
+          "short_id": "abcd1234"
+        },
+        "server_name": "www.example.com",
+        "utls": {
+          "enabled": true,
+          "fingerprint": "chrome"
+        }
+      },
+      "type": "vless",
+      "uuid": "e6b1a1de-9f0f-4c1a-8bb1-1f2b3c4d5e6f"
+    },
+    {
+      "tag": "direct",
+      "type": "direct"
+    },
+    {
+      "tag": "block",
+      "type": "block"
+    }
+  ],
+  "route": {
+    "auto_detect_interface": true,
+    "default_domain_resolver": "dns-0",
+    "final": "proxy",
+    "find_process": true,
+    "rule_set": [
+      {
+        "format": "binary",
+        "path": "/data/user/0/rulesets/geosite-ir.srs",
+        "tag": "geosite-ir",
+        "type": "local"
+      },
+      {
+        "format": "binary",
+        "path": "/data/user/0/rulesets/geoip-ir.srs",
+        "tag": "geoip-ir",
+        "type": "local"
+      },
+      {
+        "format": "binary",
+        "path": "/data/user/0/rulesets/geosite-cn.srs",
+        "tag": "geosite-cn",
+        "type": "local"
+      },
+      {
+        "format": "binary",
+        "path": "/data/user/0/rulesets/geoip-cn.srs",
+        "tag": "geoip-cn",
+        "type": "local"
+      }
+    ],
+    "rules": [
+      {
+        "action": "hijack-dns",
+        "protocol": "dns"
+      },
+      {
+        "action": "sniff"
+      },
+      {
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "outbound": "proxy"
+      },
+      {
+        "ip_is_private": true,
+        "outbound": "direct"
+      },
+      {
+        "outbound": "direct",
+        "rule_set": [
+          "geosite-ir",
+          "geoip-ir"
+        ]
+      },
+      {
+        "outbound": "direct",
+        "rule_set": [
+          "geosite-cn",
+          "geoip-cn"
+        ]
+      }
+    ]
+  }
+}

--- a/testdata/singbox-binding/android-split-ir-cn-lan-bridge.input.json
+++ b/testdata/singbox-binding/android-split-ir-cn-lan-bridge.input.json
@@ -1,0 +1,33 @@
+{
+  "bridge_host": "127.0.0.1",
+  "bridge_port": 54321,
+  "log_level": "warn",
+  "mtu": 1400,
+  "probe_domain_suffixes": [
+    "probe.openrung.org",
+    "cp.cloudflare.com"
+  ],
+  "relay": {
+    "client_id": "e6b1a1de-9f0f-4c1a-8bb1-1f2b3c4d5e6f",
+    "exit_mode": "direct",
+    "flow": "xtls-rprx-vision",
+    "protocol": "vless-reality-vision",
+    "public_host": "203.0.113.10",
+    "public_port": 443,
+    "reality_public_key": "reality-key",
+    "server_name": "www.example.com",
+    "short_id": "abcd1234"
+  },
+  "route_find_process": true,
+  "split_tunnel": {
+    "bypass_countries": [
+      "ir",
+      "cn"
+    ],
+    "bypass_lan": true,
+    "excluded_packages": [],
+    "rule_set_directory": "/data/user/0/rulesets"
+  },
+  "tunnel_ipv4_address": "172.19.0.1/30",
+  "tunnel_ipv6_address": "fdfe:dcba:9876::1/126"
+}

--- a/testdata/singbox-binding/android-split-ir-cn-lan.golden.json
+++ b/testdata/singbox-binding/android-split-ir-cn-lan.golden.json
@@ -1,0 +1,246 @@
+{
+  "dns": {
+    "final": "dns-1",
+    "rules": [
+      {
+        "action": "evaluate",
+        "disable_cache": true,
+        "disable_optimistic_cache": true,
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "server": "dns-0",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "match_response": true,
+        "response_rcode": "NOERROR"
+      },
+      {
+        "action": "respond",
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "match_response": true,
+        "response_rcode": "NXDOMAIN"
+      },
+      {
+        "disable_cache": true,
+        "disable_optimistic_cache": true,
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "server": "dns-1",
+        "timeout": "3s"
+      },
+      {
+        "action": "evaluate",
+        "rule_set": [
+          "geosite-cn"
+        ],
+        "server": "dns-direct-cn",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NOERROR",
+        "rule_set": [
+          "geosite-cn"
+        ]
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NXDOMAIN",
+        "rule_set": [
+          "geosite-cn"
+        ]
+      },
+      {
+        "action": "evaluate",
+        "server": "dns-0",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NOERROR"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NXDOMAIN"
+      },
+      {
+        "server": "dns-1",
+        "timeout": "3s"
+      }
+    ],
+    "servers": [
+      {
+        "detour": "proxy",
+        "server": "1.1.1.1",
+        "tag": "dns-0",
+        "tls": {
+          "enabled": true,
+          "server_name": "cloudflare-dns.com"
+        },
+        "type": "https"
+      },
+      {
+        "detour": "proxy",
+        "server": "8.8.8.8",
+        "tag": "dns-1",
+        "tls": {
+          "enabled": true,
+          "server_name": "dns.google"
+        },
+        "type": "https"
+      },
+      {
+        "server": "223.5.5.5",
+        "tag": "dns-direct-cn",
+        "tls": {
+          "enabled": true,
+          "server_name": "dns.alidns.com"
+        },
+        "type": "https"
+      }
+    ],
+    "timeout": "3s"
+  },
+  "experimental": {
+    "clash_api": {}
+  },
+  "inbounds": [
+    {
+      "address": [
+        "172.19.0.1/30",
+        "fdfe:dcba:9876::1/126"
+      ],
+      "auto_route": true,
+      "dns_mode": "hijack",
+      "endpoint_independent_nat": true,
+      "mtu": 1400,
+      "route_exclude_address": [
+        "203.0.113.10/32"
+      ],
+      "stack": "system",
+      "strict_route": true,
+      "tag": "tun-in",
+      "type": "tun"
+    }
+  ],
+  "log": {
+    "level": "warn",
+    "timestamp": true
+  },
+  "outbounds": [
+    {
+      "flow": "xtls-rprx-vision",
+      "network": "tcp",
+      "packet_encoding": "xudp",
+      "server": "203.0.113.10",
+      "server_port": 443,
+      "tag": "proxy",
+      "tls": {
+        "enabled": true,
+        "reality": {
+          "enabled": true,
+          "public_key": "reality-key",
+          "short_id": "abcd1234"
+        },
+        "server_name": "www.example.com",
+        "utls": {
+          "enabled": true,
+          "fingerprint": "chrome"
+        }
+      },
+      "type": "vless",
+      "uuid": "e6b1a1de-9f0f-4c1a-8bb1-1f2b3c4d5e6f"
+    },
+    {
+      "tag": "direct",
+      "type": "direct"
+    },
+    {
+      "tag": "block",
+      "type": "block"
+    }
+  ],
+  "route": {
+    "auto_detect_interface": true,
+    "default_domain_resolver": "dns-0",
+    "final": "proxy",
+    "find_process": true,
+    "rule_set": [
+      {
+        "format": "binary",
+        "path": "/data/user/0/rulesets/geosite-ir.srs",
+        "tag": "geosite-ir",
+        "type": "local"
+      },
+      {
+        "format": "binary",
+        "path": "/data/user/0/rulesets/geoip-ir.srs",
+        "tag": "geoip-ir",
+        "type": "local"
+      },
+      {
+        "format": "binary",
+        "path": "/data/user/0/rulesets/geosite-cn.srs",
+        "tag": "geosite-cn",
+        "type": "local"
+      },
+      {
+        "format": "binary",
+        "path": "/data/user/0/rulesets/geoip-cn.srs",
+        "tag": "geoip-cn",
+        "type": "local"
+      }
+    ],
+    "rules": [
+      {
+        "action": "hijack-dns",
+        "protocol": "dns"
+      },
+      {
+        "action": "sniff"
+      },
+      {
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "outbound": "proxy"
+      },
+      {
+        "ip_is_private": true,
+        "outbound": "direct"
+      },
+      {
+        "outbound": "direct",
+        "rule_set": [
+          "geosite-ir",
+          "geoip-ir"
+        ]
+      },
+      {
+        "outbound": "direct",
+        "rule_set": [
+          "geosite-cn",
+          "geoip-cn"
+        ]
+      }
+    ]
+  }
+}

--- a/testdata/singbox-binding/android-split-ir-cn-lan.input.json
+++ b/testdata/singbox-binding/android-split-ir-cn-lan.input.json
@@ -1,0 +1,31 @@
+{
+  "log_level": "warn",
+  "mtu": 1400,
+  "probe_domain_suffixes": [
+    "probe.openrung.org",
+    "cp.cloudflare.com"
+  ],
+  "relay": {
+    "client_id": "e6b1a1de-9f0f-4c1a-8bb1-1f2b3c4d5e6f",
+    "exit_mode": "direct",
+    "flow": "xtls-rprx-vision",
+    "protocol": "vless-reality-vision",
+    "public_host": "203.0.113.10",
+    "public_port": 443,
+    "reality_public_key": "reality-key",
+    "server_name": "www.example.com",
+    "short_id": "abcd1234"
+  },
+  "route_find_process": true,
+  "split_tunnel": {
+    "bypass_countries": [
+      "ir",
+      "cn"
+    ],
+    "bypass_lan": true,
+    "excluded_packages": [],
+    "rule_set_directory": "/data/user/0/rulesets"
+  },
+  "tunnel_ipv4_address": "172.19.0.1/30",
+  "tunnel_ipv6_address": "fdfe:dcba:9876::1/126"
+}

--- a/testdata/singbox-binding/android-split-ir.golden.json
+++ b/testdata/singbox-binding/android-split-ir.golden.json
@@ -1,0 +1,190 @@
+{
+  "dns": {
+    "final": "dns-1",
+    "rules": [
+      {
+        "action": "evaluate",
+        "disable_cache": true,
+        "disable_optimistic_cache": true,
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "server": "dns-0",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "match_response": true,
+        "response_rcode": "NOERROR"
+      },
+      {
+        "action": "respond",
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "match_response": true,
+        "response_rcode": "NXDOMAIN"
+      },
+      {
+        "disable_cache": true,
+        "disable_optimistic_cache": true,
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "server": "dns-1",
+        "timeout": "3s"
+      },
+      {
+        "action": "evaluate",
+        "server": "dns-0",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NOERROR"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NXDOMAIN"
+      },
+      {
+        "server": "dns-1",
+        "timeout": "3s"
+      }
+    ],
+    "servers": [
+      {
+        "detour": "proxy",
+        "server": "1.1.1.1",
+        "tag": "dns-0",
+        "tls": {
+          "enabled": true,
+          "server_name": "cloudflare-dns.com"
+        },
+        "type": "https"
+      },
+      {
+        "detour": "proxy",
+        "server": "8.8.8.8",
+        "tag": "dns-1",
+        "tls": {
+          "enabled": true,
+          "server_name": "dns.google"
+        },
+        "type": "https"
+      }
+    ],
+    "timeout": "3s"
+  },
+  "experimental": {
+    "clash_api": {}
+  },
+  "inbounds": [
+    {
+      "address": [
+        "172.19.0.1/30",
+        "fdfe:dcba:9876::1/126"
+      ],
+      "auto_route": true,
+      "dns_mode": "hijack",
+      "endpoint_independent_nat": true,
+      "mtu": 1400,
+      "route_exclude_address": [
+        "203.0.113.10/32"
+      ],
+      "stack": "system",
+      "strict_route": true,
+      "tag": "tun-in",
+      "type": "tun"
+    }
+  ],
+  "log": {
+    "level": "warn",
+    "timestamp": true
+  },
+  "outbounds": [
+    {
+      "flow": "xtls-rprx-vision",
+      "network": "tcp",
+      "packet_encoding": "xudp",
+      "server": "203.0.113.10",
+      "server_port": 443,
+      "tag": "proxy",
+      "tls": {
+        "enabled": true,
+        "reality": {
+          "enabled": true,
+          "public_key": "reality-key",
+          "short_id": "abcd1234"
+        },
+        "server_name": "www.example.com",
+        "utls": {
+          "enabled": true,
+          "fingerprint": "chrome"
+        }
+      },
+      "type": "vless",
+      "uuid": "e6b1a1de-9f0f-4c1a-8bb1-1f2b3c4d5e6f"
+    },
+    {
+      "tag": "direct",
+      "type": "direct"
+    },
+    {
+      "tag": "block",
+      "type": "block"
+    }
+  ],
+  "route": {
+    "auto_detect_interface": true,
+    "default_domain_resolver": "dns-0",
+    "final": "proxy",
+    "find_process": true,
+    "rule_set": [
+      {
+        "format": "binary",
+        "path": "/data/user/0/rulesets/geosite-ir.srs",
+        "tag": "geosite-ir",
+        "type": "local"
+      },
+      {
+        "format": "binary",
+        "path": "/data/user/0/rulesets/geoip-ir.srs",
+        "tag": "geoip-ir",
+        "type": "local"
+      }
+    ],
+    "rules": [
+      {
+        "action": "hijack-dns",
+        "protocol": "dns"
+      },
+      {
+        "action": "sniff"
+      },
+      {
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "outbound": "proxy"
+      },
+      {
+        "outbound": "direct",
+        "rule_set": [
+          "geosite-ir",
+          "geoip-ir"
+        ]
+      }
+    ]
+  }
+}

--- a/testdata/singbox-binding/android-split-ir.input.json
+++ b/testdata/singbox-binding/android-split-ir.input.json
@@ -1,0 +1,30 @@
+{
+  "log_level": "warn",
+  "mtu": 1400,
+  "probe_domain_suffixes": [
+    "probe.openrung.org",
+    "cp.cloudflare.com"
+  ],
+  "relay": {
+    "client_id": "e6b1a1de-9f0f-4c1a-8bb1-1f2b3c4d5e6f",
+    "exit_mode": "direct",
+    "flow": "xtls-rprx-vision",
+    "protocol": "vless-reality-vision",
+    "public_host": "203.0.113.10",
+    "public_port": 443,
+    "reality_public_key": "reality-key",
+    "server_name": "www.example.com",
+    "short_id": "abcd1234"
+  },
+  "route_find_process": true,
+  "split_tunnel": {
+    "bypass_countries": [
+      "ir"
+    ],
+    "bypass_lan": false,
+    "excluded_packages": [],
+    "rule_set_directory": "/data/user/0/rulesets"
+  },
+  "tunnel_ipv4_address": "172.19.0.1/30",
+  "tunnel_ipv6_address": "fdfe:dcba:9876::1/126"
+}

--- a/testdata/singbox-binding/android-split-lan.golden.json
+++ b/testdata/singbox-binding/android-split-lan.golden.json
@@ -1,0 +1,163 @@
+{
+  "dns": {
+    "final": "dns-1",
+    "rules": [
+      {
+        "action": "evaluate",
+        "disable_cache": true,
+        "disable_optimistic_cache": true,
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "server": "dns-0",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "match_response": true,
+        "response_rcode": "NOERROR"
+      },
+      {
+        "action": "respond",
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "match_response": true,
+        "response_rcode": "NXDOMAIN"
+      },
+      {
+        "disable_cache": true,
+        "disable_optimistic_cache": true,
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "server": "dns-1",
+        "timeout": "3s"
+      },
+      {
+        "action": "evaluate",
+        "server": "dns-0",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NOERROR"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NXDOMAIN"
+      },
+      {
+        "server": "dns-1",
+        "timeout": "3s"
+      }
+    ],
+    "servers": [
+      {
+        "detour": "proxy",
+        "server": "1.1.1.1",
+        "tag": "dns-0",
+        "tls": {
+          "enabled": true,
+          "server_name": "cloudflare-dns.com"
+        },
+        "type": "https"
+      },
+      {
+        "detour": "proxy",
+        "server": "8.8.8.8",
+        "tag": "dns-1",
+        "tls": {
+          "enabled": true,
+          "server_name": "dns.google"
+        },
+        "type": "https"
+      }
+    ],
+    "timeout": "3s"
+  },
+  "experimental": {
+    "clash_api": {}
+  },
+  "inbounds": [
+    {
+      "address": [
+        "172.19.0.1/30",
+        "fdfe:dcba:9876::1/126"
+      ],
+      "auto_route": true,
+      "dns_mode": "hijack",
+      "endpoint_independent_nat": true,
+      "mtu": 1400,
+      "route_exclude_address": [
+        "203.0.113.10/32"
+      ],
+      "stack": "system",
+      "strict_route": true,
+      "tag": "tun-in",
+      "type": "tun"
+    }
+  ],
+  "log": {
+    "level": "warn",
+    "timestamp": true
+  },
+  "outbounds": [
+    {
+      "flow": "xtls-rprx-vision",
+      "network": "tcp",
+      "packet_encoding": "xudp",
+      "server": "203.0.113.10",
+      "server_port": 443,
+      "tag": "proxy",
+      "tls": {
+        "enabled": true,
+        "reality": {
+          "enabled": true,
+          "public_key": "reality-key",
+          "short_id": "abcd1234"
+        },
+        "server_name": "www.example.com",
+        "utls": {
+          "enabled": true,
+          "fingerprint": "chrome"
+        }
+      },
+      "type": "vless",
+      "uuid": "e6b1a1de-9f0f-4c1a-8bb1-1f2b3c4d5e6f"
+    },
+    {
+      "tag": "direct",
+      "type": "direct"
+    },
+    {
+      "tag": "block",
+      "type": "block"
+    }
+  ],
+  "route": {
+    "auto_detect_interface": true,
+    "default_domain_resolver": "dns-0",
+    "final": "proxy",
+    "find_process": true,
+    "rules": [
+      {
+        "action": "hijack-dns",
+        "protocol": "dns"
+      },
+      {
+        "ip_is_private": true,
+        "outbound": "direct"
+      }
+    ]
+  }
+}

--- a/testdata/singbox-binding/android-split-lan.input.json
+++ b/testdata/singbox-binding/android-split-lan.input.json
@@ -1,0 +1,28 @@
+{
+  "log_level": "warn",
+  "mtu": 1400,
+  "probe_domain_suffixes": [
+    "probe.openrung.org",
+    "cp.cloudflare.com"
+  ],
+  "relay": {
+    "client_id": "e6b1a1de-9f0f-4c1a-8bb1-1f2b3c4d5e6f",
+    "exit_mode": "direct",
+    "flow": "xtls-rprx-vision",
+    "protocol": "vless-reality-vision",
+    "public_host": "203.0.113.10",
+    "public_port": 443,
+    "reality_public_key": "reality-key",
+    "server_name": "www.example.com",
+    "short_id": "abcd1234"
+  },
+  "route_find_process": true,
+  "split_tunnel": {
+    "bypass_countries": [],
+    "bypass_lan": true,
+    "excluded_packages": [],
+    "rule_set_directory": "/data/user/0/rulesets"
+  },
+  "tunnel_ipv4_address": "172.19.0.1/30",
+  "tunnel_ipv6_address": "fdfe:dcba:9876::1/126"
+}

--- a/testdata/singbox-binding/android-split-packages.golden.json
+++ b/testdata/singbox-binding/android-split-packages.golden.json
@@ -1,0 +1,163 @@
+{
+  "dns": {
+    "final": "dns-1",
+    "rules": [
+      {
+        "action": "evaluate",
+        "disable_cache": true,
+        "disable_optimistic_cache": true,
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "server": "dns-0",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "match_response": true,
+        "response_rcode": "NOERROR"
+      },
+      {
+        "action": "respond",
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "match_response": true,
+        "response_rcode": "NXDOMAIN"
+      },
+      {
+        "disable_cache": true,
+        "disable_optimistic_cache": true,
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "server": "dns-1",
+        "timeout": "3s"
+      },
+      {
+        "action": "evaluate",
+        "server": "dns-0",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NOERROR"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NXDOMAIN"
+      },
+      {
+        "server": "dns-1",
+        "timeout": "3s"
+      }
+    ],
+    "servers": [
+      {
+        "detour": "proxy",
+        "server": "1.1.1.1",
+        "tag": "dns-0",
+        "tls": {
+          "enabled": true,
+          "server_name": "cloudflare-dns.com"
+        },
+        "type": "https"
+      },
+      {
+        "detour": "proxy",
+        "server": "8.8.8.8",
+        "tag": "dns-1",
+        "tls": {
+          "enabled": true,
+          "server_name": "dns.google"
+        },
+        "type": "https"
+      }
+    ],
+    "timeout": "3s"
+  },
+  "experimental": {
+    "clash_api": {}
+  },
+  "inbounds": [
+    {
+      "address": [
+        "172.19.0.1/30",
+        "fdfe:dcba:9876::1/126"
+      ],
+      "auto_route": true,
+      "dns_mode": "hijack",
+      "endpoint_independent_nat": true,
+      "exclude_package": [
+        "com.tencent.mm",
+        "org.telegram.messenger"
+      ],
+      "mtu": 1400,
+      "route_exclude_address": [
+        "203.0.113.10/32"
+      ],
+      "stack": "system",
+      "strict_route": true,
+      "tag": "tun-in",
+      "type": "tun"
+    }
+  ],
+  "log": {
+    "level": "warn",
+    "timestamp": true
+  },
+  "outbounds": [
+    {
+      "flow": "xtls-rprx-vision",
+      "network": "tcp",
+      "packet_encoding": "xudp",
+      "server": "203.0.113.10",
+      "server_port": 443,
+      "tag": "proxy",
+      "tls": {
+        "enabled": true,
+        "reality": {
+          "enabled": true,
+          "public_key": "reality-key",
+          "short_id": "abcd1234"
+        },
+        "server_name": "www.example.com",
+        "utls": {
+          "enabled": true,
+          "fingerprint": "chrome"
+        }
+      },
+      "type": "vless",
+      "uuid": "e6b1a1de-9f0f-4c1a-8bb1-1f2b3c4d5e6f"
+    },
+    {
+      "tag": "direct",
+      "type": "direct"
+    },
+    {
+      "tag": "block",
+      "type": "block"
+    }
+  ],
+  "route": {
+    "auto_detect_interface": true,
+    "default_domain_resolver": "dns-0",
+    "final": "proxy",
+    "find_process": true,
+    "rules": [
+      {
+        "action": "hijack-dns",
+        "protocol": "dns"
+      }
+    ]
+  }
+}

--- a/testdata/singbox-binding/android-split-packages.input.json
+++ b/testdata/singbox-binding/android-split-packages.input.json
@@ -1,0 +1,31 @@
+{
+  "log_level": "warn",
+  "mtu": 1400,
+  "probe_domain_suffixes": [
+    "probe.openrung.org",
+    "cp.cloudflare.com"
+  ],
+  "relay": {
+    "client_id": "e6b1a1de-9f0f-4c1a-8bb1-1f2b3c4d5e6f",
+    "exit_mode": "direct",
+    "flow": "xtls-rprx-vision",
+    "protocol": "vless-reality-vision",
+    "public_host": "203.0.113.10",
+    "public_port": 443,
+    "reality_public_key": "reality-key",
+    "server_name": "www.example.com",
+    "short_id": "abcd1234"
+  },
+  "route_find_process": true,
+  "split_tunnel": {
+    "bypass_countries": [],
+    "bypass_lan": false,
+    "excluded_packages": [
+      "com.tencent.mm",
+      "org.telegram.messenger"
+    ],
+    "rule_set_directory": ""
+  },
+  "tunnel_ipv4_address": "172.19.0.1/30",
+  "tunnel_ipv6_address": "fdfe:dcba:9876::1/126"
+}

--- a/testdata/singbox-binding/android-tun.golden.json
+++ b/testdata/singbox-binding/android-tun.golden.json
@@ -1,0 +1,159 @@
+{
+  "dns": {
+    "final": "dns-1",
+    "rules": [
+      {
+        "action": "evaluate",
+        "disable_cache": true,
+        "disable_optimistic_cache": true,
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "server": "dns-0",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "match_response": true,
+        "response_rcode": "NOERROR"
+      },
+      {
+        "action": "respond",
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "match_response": true,
+        "response_rcode": "NXDOMAIN"
+      },
+      {
+        "disable_cache": true,
+        "disable_optimistic_cache": true,
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "server": "dns-1",
+        "timeout": "3s"
+      },
+      {
+        "action": "evaluate",
+        "server": "dns-0",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NOERROR"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NXDOMAIN"
+      },
+      {
+        "server": "dns-1",
+        "timeout": "3s"
+      }
+    ],
+    "servers": [
+      {
+        "detour": "proxy",
+        "server": "1.1.1.1",
+        "tag": "dns-0",
+        "tls": {
+          "enabled": true,
+          "server_name": "cloudflare-dns.com"
+        },
+        "type": "https"
+      },
+      {
+        "detour": "proxy",
+        "server": "8.8.8.8",
+        "tag": "dns-1",
+        "tls": {
+          "enabled": true,
+          "server_name": "dns.google"
+        },
+        "type": "https"
+      }
+    ],
+    "timeout": "3s"
+  },
+  "experimental": {
+    "clash_api": {}
+  },
+  "inbounds": [
+    {
+      "address": [
+        "172.19.0.1/30",
+        "fdfe:dcba:9876::1/126"
+      ],
+      "auto_route": true,
+      "dns_mode": "hijack",
+      "endpoint_independent_nat": true,
+      "mtu": 1400,
+      "route_exclude_address": [
+        "203.0.113.10/32"
+      ],
+      "stack": "system",
+      "strict_route": true,
+      "tag": "tun-in",
+      "type": "tun"
+    }
+  ],
+  "log": {
+    "level": "warn",
+    "timestamp": true
+  },
+  "outbounds": [
+    {
+      "flow": "xtls-rprx-vision",
+      "network": "tcp",
+      "packet_encoding": "xudp",
+      "server": "203.0.113.10",
+      "server_port": 443,
+      "tag": "proxy",
+      "tls": {
+        "enabled": true,
+        "reality": {
+          "enabled": true,
+          "public_key": "reality-key",
+          "short_id": "abcd1234"
+        },
+        "server_name": "www.example.com",
+        "utls": {
+          "enabled": true,
+          "fingerprint": "chrome"
+        }
+      },
+      "type": "vless",
+      "uuid": "e6b1a1de-9f0f-4c1a-8bb1-1f2b3c4d5e6f"
+    },
+    {
+      "tag": "direct",
+      "type": "direct"
+    },
+    {
+      "tag": "block",
+      "type": "block"
+    }
+  ],
+  "route": {
+    "auto_detect_interface": true,
+    "default_domain_resolver": "dns-0",
+    "final": "proxy",
+    "find_process": true,
+    "rules": [
+      {
+        "action": "hijack-dns",
+        "protocol": "dns"
+      }
+    ]
+  }
+}

--- a/testdata/singbox-binding/android-tun.input.json
+++ b/testdata/singbox-binding/android-tun.input.json
@@ -1,0 +1,22 @@
+{
+  "log_level": "warn",
+  "mtu": 1400,
+  "probe_domain_suffixes": [
+    "probe.openrung.org",
+    "cp.cloudflare.com"
+  ],
+  "relay": {
+    "client_id": "e6b1a1de-9f0f-4c1a-8bb1-1f2b3c4d5e6f",
+    "exit_mode": "direct",
+    "flow": "xtls-rprx-vision",
+    "protocol": "vless-reality-vision",
+    "public_host": "203.0.113.10",
+    "public_port": 443,
+    "reality_public_key": "reality-key",
+    "server_name": "www.example.com",
+    "short_id": "abcd1234"
+  },
+  "route_find_process": true,
+  "tunnel_ipv4_address": "172.19.0.1/30",
+  "tunnel_ipv6_address": "fdfe:dcba:9876::1/126"
+}

--- a/testdata/singbox-binding/ios-bridge.golden.json
+++ b/testdata/singbox-binding/ios-bridge.golden.json
@@ -1,0 +1,155 @@
+{
+  "dns": {
+    "final": "dns-1",
+    "rules": [
+      {
+        "action": "evaluate",
+        "disable_cache": true,
+        "disable_optimistic_cache": true,
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "server": "dns-0",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "match_response": true,
+        "response_rcode": "NOERROR"
+      },
+      {
+        "action": "respond",
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "match_response": true,
+        "response_rcode": "NXDOMAIN"
+      },
+      {
+        "disable_cache": true,
+        "disable_optimistic_cache": true,
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "server": "dns-1",
+        "timeout": "3s"
+      },
+      {
+        "action": "evaluate",
+        "server": "dns-0",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NOERROR"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NXDOMAIN"
+      },
+      {
+        "server": "dns-1",
+        "timeout": "3s"
+      }
+    ],
+    "servers": [
+      {
+        "detour": "proxy",
+        "server": "1.1.1.1",
+        "tag": "dns-0",
+        "tls": {
+          "enabled": true,
+          "server_name": "cloudflare-dns.com"
+        },
+        "type": "https"
+      },
+      {
+        "detour": "proxy",
+        "server": "8.8.8.8",
+        "tag": "dns-1",
+        "tls": {
+          "enabled": true,
+          "server_name": "dns.google"
+        },
+        "type": "https"
+      }
+    ],
+    "timeout": "3s"
+  },
+  "experimental": {
+    "clash_api": {}
+  },
+  "inbounds": [
+    {
+      "address": [
+        "172.19.0.1/30",
+        "fdfe:dcba:9876::1/126"
+      ],
+      "auto_route": true,
+      "dns_mode": "hijack",
+      "endpoint_independent_nat": true,
+      "mtu": 1400,
+      "stack": "system",
+      "strict_route": true,
+      "tag": "tun-in",
+      "type": "tun"
+    }
+  ],
+  "log": {
+    "level": "warn",
+    "timestamp": true
+  },
+  "outbounds": [
+    {
+      "flow": "xtls-rprx-vision",
+      "network": "tcp",
+      "packet_encoding": "xudp",
+      "server": "127.0.0.1",
+      "server_port": 54321,
+      "tag": "proxy",
+      "tls": {
+        "enabled": true,
+        "reality": {
+          "enabled": true,
+          "public_key": "reality-key",
+          "short_id": "abcd1234"
+        },
+        "server_name": "www.example.com",
+        "utls": {
+          "enabled": true,
+          "fingerprint": "chrome"
+        }
+      },
+      "type": "vless",
+      "uuid": "e6b1a1de-9f0f-4c1a-8bb1-1f2b3c4d5e6f"
+    },
+    {
+      "tag": "direct",
+      "type": "direct"
+    },
+    {
+      "tag": "block",
+      "type": "block"
+    }
+  ],
+  "route": {
+    "auto_detect_interface": true,
+    "default_domain_resolver": "dns-0",
+    "final": "proxy",
+    "rules": [
+      {
+        "action": "hijack-dns",
+        "protocol": "dns"
+      }
+    ]
+  }
+}

--- a/testdata/singbox-binding/ios-bridge.input.json
+++ b/testdata/singbox-binding/ios-bridge.input.json
@@ -1,0 +1,23 @@
+{
+  "bridge_host": "127.0.0.1",
+  "bridge_port": 54321,
+  "log_level": "warn",
+  "mtu": 1400,
+  "probe_domain_suffixes": [
+    "probe.openrung.org",
+    "cp.cloudflare.com"
+  ],
+  "relay": {
+    "client_id": "e6b1a1de-9f0f-4c1a-8bb1-1f2b3c4d5e6f",
+    "exit_mode": "direct",
+    "flow": "xtls-rprx-vision",
+    "protocol": "vless-reality-vision",
+    "public_host": "203.0.113.10",
+    "public_port": 443,
+    "reality_public_key": "reality-key",
+    "server_name": "www.example.com",
+    "short_id": "abcd1234"
+  },
+  "tunnel_ipv4_address": "172.19.0.1/30",
+  "tunnel_ipv6_address": "fdfe:dcba:9876::1/126"
+}

--- a/testdata/singbox-binding/ios-split-cn.golden.json
+++ b/testdata/singbox-binding/ios-split-cn.golden.json
@@ -1,0 +1,222 @@
+{
+  "dns": {
+    "final": "dns-1",
+    "rules": [
+      {
+        "action": "evaluate",
+        "disable_cache": true,
+        "disable_optimistic_cache": true,
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "server": "dns-0",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "match_response": true,
+        "response_rcode": "NOERROR"
+      },
+      {
+        "action": "respond",
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "match_response": true,
+        "response_rcode": "NXDOMAIN"
+      },
+      {
+        "disable_cache": true,
+        "disable_optimistic_cache": true,
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "server": "dns-1",
+        "timeout": "3s"
+      },
+      {
+        "action": "evaluate",
+        "rule_set": [
+          "geosite-cn"
+        ],
+        "server": "dns-direct-cn",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NOERROR",
+        "rule_set": [
+          "geosite-cn"
+        ]
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NXDOMAIN",
+        "rule_set": [
+          "geosite-cn"
+        ]
+      },
+      {
+        "action": "evaluate",
+        "server": "dns-0",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NOERROR"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NXDOMAIN"
+      },
+      {
+        "server": "dns-1",
+        "timeout": "3s"
+      }
+    ],
+    "servers": [
+      {
+        "detour": "proxy",
+        "server": "1.1.1.1",
+        "tag": "dns-0",
+        "tls": {
+          "enabled": true,
+          "server_name": "cloudflare-dns.com"
+        },
+        "type": "https"
+      },
+      {
+        "detour": "proxy",
+        "server": "8.8.8.8",
+        "tag": "dns-1",
+        "tls": {
+          "enabled": true,
+          "server_name": "dns.google"
+        },
+        "type": "https"
+      },
+      {
+        "server": "223.5.5.5",
+        "tag": "dns-direct-cn",
+        "tls": {
+          "enabled": true,
+          "server_name": "dns.alidns.com"
+        },
+        "type": "https"
+      }
+    ],
+    "timeout": "3s"
+  },
+  "experimental": {
+    "clash_api": {}
+  },
+  "inbounds": [
+    {
+      "address": [
+        "172.19.0.1/30",
+        "fdfe:dcba:9876::1/126"
+      ],
+      "auto_route": true,
+      "dns_mode": "hijack",
+      "endpoint_independent_nat": true,
+      "mtu": 1400,
+      "route_exclude_address": [
+        "203.0.113.10/32"
+      ],
+      "stack": "system",
+      "strict_route": true,
+      "tag": "tun-in",
+      "type": "tun"
+    }
+  ],
+  "log": {
+    "level": "warn",
+    "timestamp": true
+  },
+  "outbounds": [
+    {
+      "flow": "xtls-rprx-vision",
+      "network": "tcp",
+      "packet_encoding": "xudp",
+      "server": "203.0.113.10",
+      "server_port": 443,
+      "tag": "proxy",
+      "tls": {
+        "enabled": true,
+        "reality": {
+          "enabled": true,
+          "public_key": "reality-key",
+          "short_id": "abcd1234"
+        },
+        "server_name": "www.example.com",
+        "utls": {
+          "enabled": true,
+          "fingerprint": "chrome"
+        }
+      },
+      "type": "vless",
+      "uuid": "e6b1a1de-9f0f-4c1a-8bb1-1f2b3c4d5e6f"
+    },
+    {
+      "tag": "direct",
+      "type": "direct"
+    },
+    {
+      "tag": "block",
+      "type": "block"
+    }
+  ],
+  "route": {
+    "auto_detect_interface": true,
+    "default_domain_resolver": "dns-0",
+    "final": "proxy",
+    "rule_set": [
+      {
+        "format": "binary",
+        "path": "/var/mobile/rulesets/geosite-cn.srs",
+        "tag": "geosite-cn",
+        "type": "local"
+      },
+      {
+        "format": "binary",
+        "path": "/var/mobile/rulesets/geoip-cn.srs",
+        "tag": "geoip-cn",
+        "type": "local"
+      }
+    ],
+    "rules": [
+      {
+        "action": "hijack-dns",
+        "protocol": "dns"
+      },
+      {
+        "action": "sniff"
+      },
+      {
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "outbound": "proxy"
+      },
+      {
+        "outbound": "direct",
+        "rule_set": [
+          "geosite-cn",
+          "geoip-cn"
+        ]
+      }
+    ]
+  }
+}

--- a/testdata/singbox-binding/ios-split-cn.input.json
+++ b/testdata/singbox-binding/ios-split-cn.input.json
@@ -1,0 +1,29 @@
+{
+  "log_level": "warn",
+  "mtu": 1400,
+  "probe_domain_suffixes": [
+    "probe.openrung.org",
+    "cp.cloudflare.com"
+  ],
+  "relay": {
+    "client_id": "e6b1a1de-9f0f-4c1a-8bb1-1f2b3c4d5e6f",
+    "exit_mode": "direct",
+    "flow": "xtls-rprx-vision",
+    "protocol": "vless-reality-vision",
+    "public_host": "203.0.113.10",
+    "public_port": 443,
+    "reality_public_key": "reality-key",
+    "server_name": "www.example.com",
+    "short_id": "abcd1234"
+  },
+  "split_tunnel": {
+    "bypass_countries": [
+      "cn"
+    ],
+    "bypass_lan": false,
+    "excluded_packages": [],
+    "rule_set_directory": "/var/mobile/rulesets"
+  },
+  "tunnel_ipv4_address": "172.19.0.1/30",
+  "tunnel_ipv6_address": "fdfe:dcba:9876::1/126"
+}

--- a/testdata/singbox-binding/ios-split-empty.golden.json
+++ b/testdata/singbox-binding/ios-split-empty.golden.json
@@ -1,0 +1,158 @@
+{
+  "dns": {
+    "final": "dns-1",
+    "rules": [
+      {
+        "action": "evaluate",
+        "disable_cache": true,
+        "disable_optimistic_cache": true,
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "server": "dns-0",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "match_response": true,
+        "response_rcode": "NOERROR"
+      },
+      {
+        "action": "respond",
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "match_response": true,
+        "response_rcode": "NXDOMAIN"
+      },
+      {
+        "disable_cache": true,
+        "disable_optimistic_cache": true,
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "server": "dns-1",
+        "timeout": "3s"
+      },
+      {
+        "action": "evaluate",
+        "server": "dns-0",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NOERROR"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NXDOMAIN"
+      },
+      {
+        "server": "dns-1",
+        "timeout": "3s"
+      }
+    ],
+    "servers": [
+      {
+        "detour": "proxy",
+        "server": "1.1.1.1",
+        "tag": "dns-0",
+        "tls": {
+          "enabled": true,
+          "server_name": "cloudflare-dns.com"
+        },
+        "type": "https"
+      },
+      {
+        "detour": "proxy",
+        "server": "8.8.8.8",
+        "tag": "dns-1",
+        "tls": {
+          "enabled": true,
+          "server_name": "dns.google"
+        },
+        "type": "https"
+      }
+    ],
+    "timeout": "3s"
+  },
+  "experimental": {
+    "clash_api": {}
+  },
+  "inbounds": [
+    {
+      "address": [
+        "172.19.0.1/30",
+        "fdfe:dcba:9876::1/126"
+      ],
+      "auto_route": true,
+      "dns_mode": "hijack",
+      "endpoint_independent_nat": true,
+      "mtu": 1400,
+      "route_exclude_address": [
+        "203.0.113.10/32"
+      ],
+      "stack": "system",
+      "strict_route": true,
+      "tag": "tun-in",
+      "type": "tun"
+    }
+  ],
+  "log": {
+    "level": "warn",
+    "timestamp": true
+  },
+  "outbounds": [
+    {
+      "flow": "xtls-rprx-vision",
+      "network": "tcp",
+      "packet_encoding": "xudp",
+      "server": "203.0.113.10",
+      "server_port": 443,
+      "tag": "proxy",
+      "tls": {
+        "enabled": true,
+        "reality": {
+          "enabled": true,
+          "public_key": "reality-key",
+          "short_id": "abcd1234"
+        },
+        "server_name": "www.example.com",
+        "utls": {
+          "enabled": true,
+          "fingerprint": "chrome"
+        }
+      },
+      "type": "vless",
+      "uuid": "e6b1a1de-9f0f-4c1a-8bb1-1f2b3c4d5e6f"
+    },
+    {
+      "tag": "direct",
+      "type": "direct"
+    },
+    {
+      "tag": "block",
+      "type": "block"
+    }
+  ],
+  "route": {
+    "auto_detect_interface": true,
+    "default_domain_resolver": "dns-0",
+    "final": "proxy",
+    "rules": [
+      {
+        "action": "hijack-dns",
+        "protocol": "dns"
+      }
+    ]
+  }
+}

--- a/testdata/singbox-binding/ios-split-empty.input.json
+++ b/testdata/singbox-binding/ios-split-empty.input.json
@@ -1,0 +1,27 @@
+{
+  "log_level": "warn",
+  "mtu": 1400,
+  "probe_domain_suffixes": [
+    "probe.openrung.org",
+    "cp.cloudflare.com"
+  ],
+  "relay": {
+    "client_id": "e6b1a1de-9f0f-4c1a-8bb1-1f2b3c4d5e6f",
+    "exit_mode": "direct",
+    "flow": "xtls-rprx-vision",
+    "protocol": "vless-reality-vision",
+    "public_host": "203.0.113.10",
+    "public_port": 443,
+    "reality_public_key": "reality-key",
+    "server_name": "www.example.com",
+    "short_id": "abcd1234"
+  },
+  "split_tunnel": {
+    "bypass_countries": [],
+    "bypass_lan": false,
+    "excluded_packages": [],
+    "rule_set_directory": ""
+  },
+  "tunnel_ipv4_address": "172.19.0.1/30",
+  "tunnel_ipv6_address": "fdfe:dcba:9876::1/126"
+}

--- a/testdata/singbox-binding/ios-split-ir-cn-lan-bridge.golden.json
+++ b/testdata/singbox-binding/ios-split-ir-cn-lan-bridge.golden.json
@@ -1,0 +1,242 @@
+{
+  "dns": {
+    "final": "dns-1",
+    "rules": [
+      {
+        "action": "evaluate",
+        "disable_cache": true,
+        "disable_optimistic_cache": true,
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "server": "dns-0",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "match_response": true,
+        "response_rcode": "NOERROR"
+      },
+      {
+        "action": "respond",
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "match_response": true,
+        "response_rcode": "NXDOMAIN"
+      },
+      {
+        "disable_cache": true,
+        "disable_optimistic_cache": true,
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "server": "dns-1",
+        "timeout": "3s"
+      },
+      {
+        "action": "evaluate",
+        "rule_set": [
+          "geosite-cn"
+        ],
+        "server": "dns-direct-cn",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NOERROR",
+        "rule_set": [
+          "geosite-cn"
+        ]
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NXDOMAIN",
+        "rule_set": [
+          "geosite-cn"
+        ]
+      },
+      {
+        "action": "evaluate",
+        "server": "dns-0",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NOERROR"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NXDOMAIN"
+      },
+      {
+        "server": "dns-1",
+        "timeout": "3s"
+      }
+    ],
+    "servers": [
+      {
+        "detour": "proxy",
+        "server": "1.1.1.1",
+        "tag": "dns-0",
+        "tls": {
+          "enabled": true,
+          "server_name": "cloudflare-dns.com"
+        },
+        "type": "https"
+      },
+      {
+        "detour": "proxy",
+        "server": "8.8.8.8",
+        "tag": "dns-1",
+        "tls": {
+          "enabled": true,
+          "server_name": "dns.google"
+        },
+        "type": "https"
+      },
+      {
+        "server": "223.5.5.5",
+        "tag": "dns-direct-cn",
+        "tls": {
+          "enabled": true,
+          "server_name": "dns.alidns.com"
+        },
+        "type": "https"
+      }
+    ],
+    "timeout": "3s"
+  },
+  "experimental": {
+    "clash_api": {}
+  },
+  "inbounds": [
+    {
+      "address": [
+        "172.19.0.1/30",
+        "fdfe:dcba:9876::1/126"
+      ],
+      "auto_route": true,
+      "dns_mode": "hijack",
+      "endpoint_independent_nat": true,
+      "mtu": 1400,
+      "stack": "system",
+      "strict_route": true,
+      "tag": "tun-in",
+      "type": "tun"
+    }
+  ],
+  "log": {
+    "level": "warn",
+    "timestamp": true
+  },
+  "outbounds": [
+    {
+      "flow": "xtls-rprx-vision",
+      "network": "tcp",
+      "packet_encoding": "xudp",
+      "server": "127.0.0.1",
+      "server_port": 54321,
+      "tag": "proxy",
+      "tls": {
+        "enabled": true,
+        "reality": {
+          "enabled": true,
+          "public_key": "reality-key",
+          "short_id": "abcd1234"
+        },
+        "server_name": "www.example.com",
+        "utls": {
+          "enabled": true,
+          "fingerprint": "chrome"
+        }
+      },
+      "type": "vless",
+      "uuid": "e6b1a1de-9f0f-4c1a-8bb1-1f2b3c4d5e6f"
+    },
+    {
+      "tag": "direct",
+      "type": "direct"
+    },
+    {
+      "tag": "block",
+      "type": "block"
+    }
+  ],
+  "route": {
+    "auto_detect_interface": true,
+    "default_domain_resolver": "dns-0",
+    "final": "proxy",
+    "rule_set": [
+      {
+        "format": "binary",
+        "path": "/var/mobile/rulesets/geosite-ir.srs",
+        "tag": "geosite-ir",
+        "type": "local"
+      },
+      {
+        "format": "binary",
+        "path": "/var/mobile/rulesets/geoip-ir.srs",
+        "tag": "geoip-ir",
+        "type": "local"
+      },
+      {
+        "format": "binary",
+        "path": "/var/mobile/rulesets/geosite-cn.srs",
+        "tag": "geosite-cn",
+        "type": "local"
+      },
+      {
+        "format": "binary",
+        "path": "/var/mobile/rulesets/geoip-cn.srs",
+        "tag": "geoip-cn",
+        "type": "local"
+      }
+    ],
+    "rules": [
+      {
+        "action": "hijack-dns",
+        "protocol": "dns"
+      },
+      {
+        "action": "sniff"
+      },
+      {
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "outbound": "proxy"
+      },
+      {
+        "ip_is_private": true,
+        "outbound": "direct"
+      },
+      {
+        "outbound": "direct",
+        "rule_set": [
+          "geosite-ir",
+          "geoip-ir"
+        ]
+      },
+      {
+        "outbound": "direct",
+        "rule_set": [
+          "geosite-cn",
+          "geoip-cn"
+        ]
+      }
+    ]
+  }
+}

--- a/testdata/singbox-binding/ios-split-ir-cn-lan-bridge.input.json
+++ b/testdata/singbox-binding/ios-split-ir-cn-lan-bridge.input.json
@@ -1,0 +1,32 @@
+{
+  "bridge_host": "127.0.0.1",
+  "bridge_port": 54321,
+  "log_level": "warn",
+  "mtu": 1400,
+  "probe_domain_suffixes": [
+    "probe.openrung.org",
+    "cp.cloudflare.com"
+  ],
+  "relay": {
+    "client_id": "e6b1a1de-9f0f-4c1a-8bb1-1f2b3c4d5e6f",
+    "exit_mode": "direct",
+    "flow": "xtls-rprx-vision",
+    "protocol": "vless-reality-vision",
+    "public_host": "203.0.113.10",
+    "public_port": 443,
+    "reality_public_key": "reality-key",
+    "server_name": "www.example.com",
+    "short_id": "abcd1234"
+  },
+  "split_tunnel": {
+    "bypass_countries": [
+      "ir",
+      "cn"
+    ],
+    "bypass_lan": true,
+    "excluded_packages": [],
+    "rule_set_directory": "/var/mobile/rulesets"
+  },
+  "tunnel_ipv4_address": "172.19.0.1/30",
+  "tunnel_ipv6_address": "fdfe:dcba:9876::1/126"
+}

--- a/testdata/singbox-binding/ios-split-ir-cn-lan.golden.json
+++ b/testdata/singbox-binding/ios-split-ir-cn-lan.golden.json
@@ -1,0 +1,245 @@
+{
+  "dns": {
+    "final": "dns-1",
+    "rules": [
+      {
+        "action": "evaluate",
+        "disable_cache": true,
+        "disable_optimistic_cache": true,
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "server": "dns-0",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "match_response": true,
+        "response_rcode": "NOERROR"
+      },
+      {
+        "action": "respond",
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "match_response": true,
+        "response_rcode": "NXDOMAIN"
+      },
+      {
+        "disable_cache": true,
+        "disable_optimistic_cache": true,
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "server": "dns-1",
+        "timeout": "3s"
+      },
+      {
+        "action": "evaluate",
+        "rule_set": [
+          "geosite-cn"
+        ],
+        "server": "dns-direct-cn",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NOERROR",
+        "rule_set": [
+          "geosite-cn"
+        ]
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NXDOMAIN",
+        "rule_set": [
+          "geosite-cn"
+        ]
+      },
+      {
+        "action": "evaluate",
+        "server": "dns-0",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NOERROR"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NXDOMAIN"
+      },
+      {
+        "server": "dns-1",
+        "timeout": "3s"
+      }
+    ],
+    "servers": [
+      {
+        "detour": "proxy",
+        "server": "1.1.1.1",
+        "tag": "dns-0",
+        "tls": {
+          "enabled": true,
+          "server_name": "cloudflare-dns.com"
+        },
+        "type": "https"
+      },
+      {
+        "detour": "proxy",
+        "server": "8.8.8.8",
+        "tag": "dns-1",
+        "tls": {
+          "enabled": true,
+          "server_name": "dns.google"
+        },
+        "type": "https"
+      },
+      {
+        "server": "223.5.5.5",
+        "tag": "dns-direct-cn",
+        "tls": {
+          "enabled": true,
+          "server_name": "dns.alidns.com"
+        },
+        "type": "https"
+      }
+    ],
+    "timeout": "3s"
+  },
+  "experimental": {
+    "clash_api": {}
+  },
+  "inbounds": [
+    {
+      "address": [
+        "172.19.0.1/30",
+        "fdfe:dcba:9876::1/126"
+      ],
+      "auto_route": true,
+      "dns_mode": "hijack",
+      "endpoint_independent_nat": true,
+      "mtu": 1400,
+      "route_exclude_address": [
+        "203.0.113.10/32"
+      ],
+      "stack": "system",
+      "strict_route": true,
+      "tag": "tun-in",
+      "type": "tun"
+    }
+  ],
+  "log": {
+    "level": "warn",
+    "timestamp": true
+  },
+  "outbounds": [
+    {
+      "flow": "xtls-rprx-vision",
+      "network": "tcp",
+      "packet_encoding": "xudp",
+      "server": "203.0.113.10",
+      "server_port": 443,
+      "tag": "proxy",
+      "tls": {
+        "enabled": true,
+        "reality": {
+          "enabled": true,
+          "public_key": "reality-key",
+          "short_id": "abcd1234"
+        },
+        "server_name": "www.example.com",
+        "utls": {
+          "enabled": true,
+          "fingerprint": "chrome"
+        }
+      },
+      "type": "vless",
+      "uuid": "e6b1a1de-9f0f-4c1a-8bb1-1f2b3c4d5e6f"
+    },
+    {
+      "tag": "direct",
+      "type": "direct"
+    },
+    {
+      "tag": "block",
+      "type": "block"
+    }
+  ],
+  "route": {
+    "auto_detect_interface": true,
+    "default_domain_resolver": "dns-0",
+    "final": "proxy",
+    "rule_set": [
+      {
+        "format": "binary",
+        "path": "/var/mobile/rulesets/geosite-ir.srs",
+        "tag": "geosite-ir",
+        "type": "local"
+      },
+      {
+        "format": "binary",
+        "path": "/var/mobile/rulesets/geoip-ir.srs",
+        "tag": "geoip-ir",
+        "type": "local"
+      },
+      {
+        "format": "binary",
+        "path": "/var/mobile/rulesets/geosite-cn.srs",
+        "tag": "geosite-cn",
+        "type": "local"
+      },
+      {
+        "format": "binary",
+        "path": "/var/mobile/rulesets/geoip-cn.srs",
+        "tag": "geoip-cn",
+        "type": "local"
+      }
+    ],
+    "rules": [
+      {
+        "action": "hijack-dns",
+        "protocol": "dns"
+      },
+      {
+        "action": "sniff"
+      },
+      {
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "outbound": "proxy"
+      },
+      {
+        "ip_is_private": true,
+        "outbound": "direct"
+      },
+      {
+        "outbound": "direct",
+        "rule_set": [
+          "geosite-ir",
+          "geoip-ir"
+        ]
+      },
+      {
+        "outbound": "direct",
+        "rule_set": [
+          "geosite-cn",
+          "geoip-cn"
+        ]
+      }
+    ]
+  }
+}

--- a/testdata/singbox-binding/ios-split-ir-cn-lan.input.json
+++ b/testdata/singbox-binding/ios-split-ir-cn-lan.input.json
@@ -1,0 +1,30 @@
+{
+  "log_level": "warn",
+  "mtu": 1400,
+  "probe_domain_suffixes": [
+    "probe.openrung.org",
+    "cp.cloudflare.com"
+  ],
+  "relay": {
+    "client_id": "e6b1a1de-9f0f-4c1a-8bb1-1f2b3c4d5e6f",
+    "exit_mode": "direct",
+    "flow": "xtls-rprx-vision",
+    "protocol": "vless-reality-vision",
+    "public_host": "203.0.113.10",
+    "public_port": 443,
+    "reality_public_key": "reality-key",
+    "server_name": "www.example.com",
+    "short_id": "abcd1234"
+  },
+  "split_tunnel": {
+    "bypass_countries": [
+      "ir",
+      "cn"
+    ],
+    "bypass_lan": true,
+    "excluded_packages": [],
+    "rule_set_directory": "/var/mobile/rulesets"
+  },
+  "tunnel_ipv4_address": "172.19.0.1/30",
+  "tunnel_ipv6_address": "fdfe:dcba:9876::1/126"
+}

--- a/testdata/singbox-binding/ios-split-ir.golden.json
+++ b/testdata/singbox-binding/ios-split-ir.golden.json
@@ -1,0 +1,189 @@
+{
+  "dns": {
+    "final": "dns-1",
+    "rules": [
+      {
+        "action": "evaluate",
+        "disable_cache": true,
+        "disable_optimistic_cache": true,
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "server": "dns-0",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "match_response": true,
+        "response_rcode": "NOERROR"
+      },
+      {
+        "action": "respond",
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "match_response": true,
+        "response_rcode": "NXDOMAIN"
+      },
+      {
+        "disable_cache": true,
+        "disable_optimistic_cache": true,
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "server": "dns-1",
+        "timeout": "3s"
+      },
+      {
+        "action": "evaluate",
+        "server": "dns-0",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NOERROR"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NXDOMAIN"
+      },
+      {
+        "server": "dns-1",
+        "timeout": "3s"
+      }
+    ],
+    "servers": [
+      {
+        "detour": "proxy",
+        "server": "1.1.1.1",
+        "tag": "dns-0",
+        "tls": {
+          "enabled": true,
+          "server_name": "cloudflare-dns.com"
+        },
+        "type": "https"
+      },
+      {
+        "detour": "proxy",
+        "server": "8.8.8.8",
+        "tag": "dns-1",
+        "tls": {
+          "enabled": true,
+          "server_name": "dns.google"
+        },
+        "type": "https"
+      }
+    ],
+    "timeout": "3s"
+  },
+  "experimental": {
+    "clash_api": {}
+  },
+  "inbounds": [
+    {
+      "address": [
+        "172.19.0.1/30",
+        "fdfe:dcba:9876::1/126"
+      ],
+      "auto_route": true,
+      "dns_mode": "hijack",
+      "endpoint_independent_nat": true,
+      "mtu": 1400,
+      "route_exclude_address": [
+        "203.0.113.10/32"
+      ],
+      "stack": "system",
+      "strict_route": true,
+      "tag": "tun-in",
+      "type": "tun"
+    }
+  ],
+  "log": {
+    "level": "warn",
+    "timestamp": true
+  },
+  "outbounds": [
+    {
+      "flow": "xtls-rprx-vision",
+      "network": "tcp",
+      "packet_encoding": "xudp",
+      "server": "203.0.113.10",
+      "server_port": 443,
+      "tag": "proxy",
+      "tls": {
+        "enabled": true,
+        "reality": {
+          "enabled": true,
+          "public_key": "reality-key",
+          "short_id": "abcd1234"
+        },
+        "server_name": "www.example.com",
+        "utls": {
+          "enabled": true,
+          "fingerprint": "chrome"
+        }
+      },
+      "type": "vless",
+      "uuid": "e6b1a1de-9f0f-4c1a-8bb1-1f2b3c4d5e6f"
+    },
+    {
+      "tag": "direct",
+      "type": "direct"
+    },
+    {
+      "tag": "block",
+      "type": "block"
+    }
+  ],
+  "route": {
+    "auto_detect_interface": true,
+    "default_domain_resolver": "dns-0",
+    "final": "proxy",
+    "rule_set": [
+      {
+        "format": "binary",
+        "path": "/var/mobile/rulesets/geosite-ir.srs",
+        "tag": "geosite-ir",
+        "type": "local"
+      },
+      {
+        "format": "binary",
+        "path": "/var/mobile/rulesets/geoip-ir.srs",
+        "tag": "geoip-ir",
+        "type": "local"
+      }
+    ],
+    "rules": [
+      {
+        "action": "hijack-dns",
+        "protocol": "dns"
+      },
+      {
+        "action": "sniff"
+      },
+      {
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "outbound": "proxy"
+      },
+      {
+        "outbound": "direct",
+        "rule_set": [
+          "geosite-ir",
+          "geoip-ir"
+        ]
+      }
+    ]
+  }
+}

--- a/testdata/singbox-binding/ios-split-ir.input.json
+++ b/testdata/singbox-binding/ios-split-ir.input.json
@@ -1,0 +1,29 @@
+{
+  "log_level": "warn",
+  "mtu": 1400,
+  "probe_domain_suffixes": [
+    "probe.openrung.org",
+    "cp.cloudflare.com"
+  ],
+  "relay": {
+    "client_id": "e6b1a1de-9f0f-4c1a-8bb1-1f2b3c4d5e6f",
+    "exit_mode": "direct",
+    "flow": "xtls-rprx-vision",
+    "protocol": "vless-reality-vision",
+    "public_host": "203.0.113.10",
+    "public_port": 443,
+    "reality_public_key": "reality-key",
+    "server_name": "www.example.com",
+    "short_id": "abcd1234"
+  },
+  "split_tunnel": {
+    "bypass_countries": [
+      "ir"
+    ],
+    "bypass_lan": false,
+    "excluded_packages": [],
+    "rule_set_directory": "/var/mobile/rulesets"
+  },
+  "tunnel_ipv4_address": "172.19.0.1/30",
+  "tunnel_ipv6_address": "fdfe:dcba:9876::1/126"
+}

--- a/testdata/singbox-binding/ios-split-lan.golden.json
+++ b/testdata/singbox-binding/ios-split-lan.golden.json
@@ -1,0 +1,162 @@
+{
+  "dns": {
+    "final": "dns-1",
+    "rules": [
+      {
+        "action": "evaluate",
+        "disable_cache": true,
+        "disable_optimistic_cache": true,
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "server": "dns-0",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "match_response": true,
+        "response_rcode": "NOERROR"
+      },
+      {
+        "action": "respond",
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "match_response": true,
+        "response_rcode": "NXDOMAIN"
+      },
+      {
+        "disable_cache": true,
+        "disable_optimistic_cache": true,
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "server": "dns-1",
+        "timeout": "3s"
+      },
+      {
+        "action": "evaluate",
+        "server": "dns-0",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NOERROR"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NXDOMAIN"
+      },
+      {
+        "server": "dns-1",
+        "timeout": "3s"
+      }
+    ],
+    "servers": [
+      {
+        "detour": "proxy",
+        "server": "1.1.1.1",
+        "tag": "dns-0",
+        "tls": {
+          "enabled": true,
+          "server_name": "cloudflare-dns.com"
+        },
+        "type": "https"
+      },
+      {
+        "detour": "proxy",
+        "server": "8.8.8.8",
+        "tag": "dns-1",
+        "tls": {
+          "enabled": true,
+          "server_name": "dns.google"
+        },
+        "type": "https"
+      }
+    ],
+    "timeout": "3s"
+  },
+  "experimental": {
+    "clash_api": {}
+  },
+  "inbounds": [
+    {
+      "address": [
+        "172.19.0.1/30",
+        "fdfe:dcba:9876::1/126"
+      ],
+      "auto_route": true,
+      "dns_mode": "hijack",
+      "endpoint_independent_nat": true,
+      "mtu": 1400,
+      "route_exclude_address": [
+        "203.0.113.10/32"
+      ],
+      "stack": "system",
+      "strict_route": true,
+      "tag": "tun-in",
+      "type": "tun"
+    }
+  ],
+  "log": {
+    "level": "warn",
+    "timestamp": true
+  },
+  "outbounds": [
+    {
+      "flow": "xtls-rprx-vision",
+      "network": "tcp",
+      "packet_encoding": "xudp",
+      "server": "203.0.113.10",
+      "server_port": 443,
+      "tag": "proxy",
+      "tls": {
+        "enabled": true,
+        "reality": {
+          "enabled": true,
+          "public_key": "reality-key",
+          "short_id": "abcd1234"
+        },
+        "server_name": "www.example.com",
+        "utls": {
+          "enabled": true,
+          "fingerprint": "chrome"
+        }
+      },
+      "type": "vless",
+      "uuid": "e6b1a1de-9f0f-4c1a-8bb1-1f2b3c4d5e6f"
+    },
+    {
+      "tag": "direct",
+      "type": "direct"
+    },
+    {
+      "tag": "block",
+      "type": "block"
+    }
+  ],
+  "route": {
+    "auto_detect_interface": true,
+    "default_domain_resolver": "dns-0",
+    "final": "proxy",
+    "rules": [
+      {
+        "action": "hijack-dns",
+        "protocol": "dns"
+      },
+      {
+        "ip_is_private": true,
+        "outbound": "direct"
+      }
+    ]
+  }
+}

--- a/testdata/singbox-binding/ios-split-lan.input.json
+++ b/testdata/singbox-binding/ios-split-lan.input.json
@@ -1,0 +1,27 @@
+{
+  "log_level": "warn",
+  "mtu": 1400,
+  "probe_domain_suffixes": [
+    "probe.openrung.org",
+    "cp.cloudflare.com"
+  ],
+  "relay": {
+    "client_id": "e6b1a1de-9f0f-4c1a-8bb1-1f2b3c4d5e6f",
+    "exit_mode": "direct",
+    "flow": "xtls-rprx-vision",
+    "protocol": "vless-reality-vision",
+    "public_host": "203.0.113.10",
+    "public_port": 443,
+    "reality_public_key": "reality-key",
+    "server_name": "www.example.com",
+    "short_id": "abcd1234"
+  },
+  "split_tunnel": {
+    "bypass_countries": [],
+    "bypass_lan": true,
+    "excluded_packages": [],
+    "rule_set_directory": "/var/mobile/rulesets"
+  },
+  "tunnel_ipv4_address": "172.19.0.1/30",
+  "tunnel_ipv6_address": "fdfe:dcba:9876::1/126"
+}

--- a/testdata/singbox-binding/ios-tun.golden.json
+++ b/testdata/singbox-binding/ios-tun.golden.json
@@ -1,0 +1,158 @@
+{
+  "dns": {
+    "final": "dns-1",
+    "rules": [
+      {
+        "action": "evaluate",
+        "disable_cache": true,
+        "disable_optimistic_cache": true,
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "server": "dns-0",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "match_response": true,
+        "response_rcode": "NOERROR"
+      },
+      {
+        "action": "respond",
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "match_response": true,
+        "response_rcode": "NXDOMAIN"
+      },
+      {
+        "disable_cache": true,
+        "disable_optimistic_cache": true,
+        "domain_suffix": [
+          "probe.openrung.org",
+          "cp.cloudflare.com"
+        ],
+        "server": "dns-1",
+        "timeout": "3s"
+      },
+      {
+        "action": "evaluate",
+        "server": "dns-0",
+        "timeout": "2s"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NOERROR"
+      },
+      {
+        "action": "respond",
+        "match_response": true,
+        "response_rcode": "NXDOMAIN"
+      },
+      {
+        "server": "dns-1",
+        "timeout": "3s"
+      }
+    ],
+    "servers": [
+      {
+        "detour": "proxy",
+        "server": "1.1.1.1",
+        "tag": "dns-0",
+        "tls": {
+          "enabled": true,
+          "server_name": "cloudflare-dns.com"
+        },
+        "type": "https"
+      },
+      {
+        "detour": "proxy",
+        "server": "8.8.8.8",
+        "tag": "dns-1",
+        "tls": {
+          "enabled": true,
+          "server_name": "dns.google"
+        },
+        "type": "https"
+      }
+    ],
+    "timeout": "3s"
+  },
+  "experimental": {
+    "clash_api": {}
+  },
+  "inbounds": [
+    {
+      "address": [
+        "172.19.0.1/30",
+        "fdfe:dcba:9876::1/126"
+      ],
+      "auto_route": true,
+      "dns_mode": "hijack",
+      "endpoint_independent_nat": true,
+      "mtu": 1400,
+      "route_exclude_address": [
+        "203.0.113.10/32"
+      ],
+      "stack": "system",
+      "strict_route": true,
+      "tag": "tun-in",
+      "type": "tun"
+    }
+  ],
+  "log": {
+    "level": "warn",
+    "timestamp": true
+  },
+  "outbounds": [
+    {
+      "flow": "xtls-rprx-vision",
+      "network": "tcp",
+      "packet_encoding": "xudp",
+      "server": "203.0.113.10",
+      "server_port": 443,
+      "tag": "proxy",
+      "tls": {
+        "enabled": true,
+        "reality": {
+          "enabled": true,
+          "public_key": "reality-key",
+          "short_id": "abcd1234"
+        },
+        "server_name": "www.example.com",
+        "utls": {
+          "enabled": true,
+          "fingerprint": "chrome"
+        }
+      },
+      "type": "vless",
+      "uuid": "e6b1a1de-9f0f-4c1a-8bb1-1f2b3c4d5e6f"
+    },
+    {
+      "tag": "direct",
+      "type": "direct"
+    },
+    {
+      "tag": "block",
+      "type": "block"
+    }
+  ],
+  "route": {
+    "auto_detect_interface": true,
+    "default_domain_resolver": "dns-0",
+    "final": "proxy",
+    "rules": [
+      {
+        "action": "hijack-dns",
+        "protocol": "dns"
+      }
+    ]
+  }
+}

--- a/testdata/singbox-binding/ios-tun.input.json
+++ b/testdata/singbox-binding/ios-tun.input.json
@@ -1,0 +1,21 @@
+{
+  "log_level": "warn",
+  "mtu": 1400,
+  "probe_domain_suffixes": [
+    "probe.openrung.org",
+    "cp.cloudflare.com"
+  ],
+  "relay": {
+    "client_id": "e6b1a1de-9f0f-4c1a-8bb1-1f2b3c4d5e6f",
+    "exit_mode": "direct",
+    "flow": "xtls-rprx-vision",
+    "protocol": "vless-reality-vision",
+    "public_host": "203.0.113.10",
+    "public_port": 443,
+    "reality_public_key": "reality-key",
+    "server_name": "www.example.com",
+    "short_id": "abcd1234"
+  },
+  "tunnel_ipv4_address": "172.19.0.1/30",
+  "tunnel_ipv6_address": "fdfe:dcba:9876::1/126"
+}


### PR DESCRIPTION
Second of the D4 series (mobile adopts the bound leaf policies): the sing-box config builder. The Kotlin and Swift copies of the generator are deleted; both platforms assemble their inputs and hand them to a new punchbridge binding, `OpenRungBuildSingBoxConfig`, which routes them through `connectcore/client.BuildSingBoxConfig` — the D2 superset builder the desktop/CLI clients run.

## What moved where

- **Binding** (`android/punchbridge/singbox_binding.go`): input is one JSON object — a relay on the broker's canonical wire names, TUN addresses, MTU, an optional loopback bridge, log level, the platform's probe suffixes, split-tunnel rules, and `route_find_process` (Android). The binding fixes the mobile constants (TUN inbound, DoH-failover DNS shape, clash_api accounting, bridge-owns-outer-socket) and enforces the mobile input contract connectcore deliberately doesn't: a positive MTU (Go would default 0 to 1500, silently replacing mobile's 1400) and no partial bridge (Go would quietly dial the relay's public endpoint, masking a broken punch/WSS adapter as a direct connection). Relay identity and split-tunnel validation stay connectcore's.
- **Adapters**: `SingBoxConfiguration.kt` / `.swift` keep the constructor surface, the probe-facing constants, and `tunnelDnsAddress` (probe policy, not emission), plus a pure `bindingInputJson()` / `bindingInput(debug:)` assembly. Deleted with no remaining callers: `makeJsonObject`/`makeJSONObject` and every emission helper, Kotlin's `validateRelay`/`relayRouteExcludeAddress`/`DirectResolver`, and Swift's `SplitTunnelDirectResolver`/`SplitTunnelCountry.directResolver` (the resolver table is connectcore's).
- **Probe suffixes are now an explicit input** assembled from each platform's `ProbeTargets`, so the builder's probe-priority DNS/route pins can never silently diverge from the endpoints the platforms actually probe (the binding rejects an empty list rather than falling back to its own copy).

## The platform golden tests against the bound output

`testdata/singbox-binding/` holds one `.input.json` per platform scenario and one frozen `.golden.json` per scenario ([README](testdata/singbox-binding/README.md)):

- `singbox_binding_test.go` is the only writer of the goldens (`UPDATE_SINGBOX_BINDING_GOLDEN=1`) and pins input → config through the real binding entry point (runs in `android-punch-check` CI and at the top of both release build scripts).
- The new assembly suites (`SingBoxConfigurationBindingInputTest`, `SingBoxConfigurationBindingInputTests`) pin platform construction → input for every checked-in scenario, including the debug→"info" log-level mapping and faithful forwarding of a partial bridge.
- The existing structural suites (`SingBoxConfigurationDnsTest`/`SplitTunnelTest`/`PunchTest`, `DnsConfigurationTests`, `SplitTunnelConfigurationTests`, `WssLifecycleAndConfigurationTests`, `StartupProbeChinaBypassTest`) keep their assertions — probe pins first/uncached/terminal, canonical rule order, leak-precedent bridge guards, Iran-contributes-no-resolver, no-plaintext-DNS — now asserted against the frozen bound outputs.

**Parity evidence**: the bound goldens are byte-identical to connectcore's frozen mobile-parity goldens (`connectcore/client/testdata/singbox/mobile-*.golden.json`) except the test relay's identity literals (uuid/public_key/short_id/server_name differ between the repos' test fixtures).

## Resolved divergences

1. **Emitted bytes change; semantics don't.** The bound output is Go's `json.MarshalIndent` (sorted keys, 2-space indent) instead of kotlinx's insertion-order 4-space / `JSONSerialization`'s sorted pretty print. The consumer is sing-box's JSON parser (engine start and the `checkConfig` preflight), so only log appearance changes. The byte-identical-to-connectcore-goldens check above pins that the *content* is exactly the shape both generators produced.
2. **iOS now rejects a partial bridge and an invalid relay at encode time.** The Swift generator silently fell back to the relay's public endpoint on a partial bridge and never validated relay identity fields (only Kotlin did); both now fail via `SingBoxConfigurationError.rejected`, matching Kotlin's old posture and the shared builder. Runtime paths always pass a complete bridge and a selection-filtered relay, so this only surfaces caller bugs.
3. **Error text/type changes**: Kotlin still throws `IllegalArgumentException` from `encodedJsonString()`, but the messages are the binding's; Swift throws the new `SingBoxConfigurationError` instead of (practically-never) `JSONSerialization` errors. Both call sites already caught broad error types.
4. Kotlin's `SplitTunnelRules.DirectResolver`/`directResolver` and Swift's resolver table are gone; the in-country resolver policy (and Iran's documented absence) lives only in `connectcore/client/singbox_split_tunnel.go`, pinned here by the goldens.
5. New Swift test code lives in existing files (`WssTestFixtures.swift`, `SplitTunnelConfigurationTests.swift`): the OpenRungTests target lists files explicitly, and regenerating the Xcode project (xcodegen + pod install) in this PR would add unrelated churn.

## Testing

- `android/punchbridge`: gofmt clean; `GOWORK=off go test -race ./...` ✅ (17 scenario goldens + empty-split identity + 17-case validation table, plus the existing suites)
- Android: AAR rebuilt via `android/build-libbox-release.sh` (new javap symbol checks ✅); `./gradlew :app:testDebugUnitTest` ✅ 236 tests, 0 failures
- iOS: `Libbox.xcframework` rebuilt via `ios/build-libbox-release.sh` (new header symbol checks ✅ on both slices); `xcodebuild -scheme OpenRungTests … test` ✅ 174 tests, 0 failures; `xcodebuild -target PacketTunnel` compiles against the new framework ✅
- `npm run contract:check` ✅ (vendored contract copies untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)